### PR TITLE
Note supported Go versions in quick start, from sylabs 56

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -36,28 +36,32 @@ admin guide
 Install system dependencies
 ===========================
 
-You must first install development libraries to your host. Assuming Ubuntu
-(apply similar to RHEL derivatives):
+You must first install development tools and libraries to your host.
 
-.. code-block:: none
+On Debian-based systems, including Ubuntu:
 
-    $ sudo apt-get update && sudo apt-get install -y \
-        build-essential \
-        libssl-dev \
-        uuid-dev \
-        libgpgme11-dev \
-        squashfs-tools \
-        libseccomp-dev \
-        wget \
-        pkg-config \
-        git \
-        cryptsetup
+.. code::
 
-.. note::
-    Note that ``squashfs-tools`` is only a dependency for commands that build
-    images. The ``build`` command obviously relies on ``squashfs-tools``, but
-    other commands may do so as well if they are ran using container images
-    from Docker Hub for instance.
+   # Ensure repositories are up-to-date
+   sudo apt-get update
+   # Install debian packages for dependencies
+   sudo apt-get install -y \
+      build-essential \
+      libseccomp-dev \
+      pkg-config \
+      squashfs-tools \
+      cryptsetup
+
+On CentOS/RHEL:
+
+.. code::
+   # Install basic tools for compiling
+   sudo yum groupinstall -y 'Development Tools'
+   # Install RPM packages for dependencies
+   sudo yum install -y \
+      libseccomp-devel \
+      squashfs-tools \
+      cryptsetup
 
 There are 3 broad steps to installing {Singularity}:
 
@@ -70,11 +74,14 @@ There are 3 broad steps to installing {Singularity}:
 Install Go
 ==========
 
-{Singularity} v3 and above is written primarily in Go, so you will need Go
-installed to compile it from source.
+{Singularity} is written in Go, and may require a newer version of Go than is
+available in the repositories of your distribution. We recommend installing the
+latest version of Go from the [official binaries](https://golang.org/dl/).
 
-This is one of several ways to `install and configure Go
-<https://golang.org/doc/install>`_.
+{Singularity} aims to maintain support for the two most recent stable versions
+of Go. This corresponds to the Go Release Maintenance Policy and Security
+Policy, ensuring critical bug fixes and security patches are available for all
+supported language versions.
 
 .. note::
 

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -50,18 +50,22 @@ On Debian-based systems, including Ubuntu:
       libseccomp-dev \
       pkg-config \
       squashfs-tools \
-      cryptsetup
+      cryptsetup \
+      curl wget git
 
 On CentOS/RHEL:
 
 .. code::
    # Install basic tools for compiling
    sudo yum groupinstall -y 'Development Tools'
+   # Ensure EPEL repository is available
+   sudo yum install -y epel-release
    # Install RPM packages for dependencies
    sudo yum install -y \
       libseccomp-devel \
       squashfs-tools \
-      cryptsetup
+      cryptsetup \
+      wget git
 
 There are 3 broad steps to installing {Singularity}:
 
@@ -83,6 +87,16 @@ of Go. This corresponds to the Go Release Maintenance Policy and Security
 Policy, ensuring critical bug fixes and security patches are available for all
 supported language versions.
 
+If you are building rpm or debian packages using the packaging supplied
+in the ``dist`` directory, and the operating system distribution of Go
+is below the minimum required by {Singularity}, the packages can make
+use of the native Go to compile a newer version of Go whose source
+tarball is included with the package source.  That capability is
+supplied so packages can be built on systems with no access to the
+internet.  If you are not building a package or don't want to incur the
+overhead of compiling the Go toolchain from source, install a local
+binary copy of Go as follows.
+
 .. note::
 
    If you have previously installed Go from a download, rather than an
@@ -99,7 +113,7 @@ page). Alternatively, follow the commands here:
 
 .. code-block:: none
 
-    $ export VERSION=1.17.2 OS=linux ARCH=amd64 && \  # Replace the values as needed
+    $ export VERSION=1.17.5 OS=linux ARCH=amd64 && \  # Replace the values as needed
       wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \ # Downloads the required Go package
       sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \ # Extracts the archive
       rm go$VERSION.$OS-$ARCH.tar.gz    # Deletes the ``tar`` file


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-userdocs#56
 which fixed
- sylabs/singularity-userdocs#55