### PR TITLE
Reformat RST for consistency, from sylabs 50

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           go-version: 1.17.3
 
+      - name: Update repositories
+        run: |
+          sudo apt update
+
       - name: Install Apptainer dependencies
         run: |
           sudo apt-get install -f -y build-essential libssl-dev uuid-dev squashfs-tools libseccomp-dev cryptsetup-bin libgpgme-dev

--- a/README.md
+++ b/README.md
@@ -85,50 +85,34 @@ common things you need to do when writing or editing RST.
 
 #### 1. Create a section/subsection/subsubsection title
 
-Sections titles are defined by surrounding or underlining them
-with different characters. Each combination of overline/underline and character
-used represents a different level section.
-
-- To create a main section title: A main section title is surrounded (above and
-  below) with `=` characters:
+Section titles are defined by surrounding or underlining them with different
+characters. Each combination of overline/underline and character used represents
+a different level section. We follow the conventions used by the python
+documentation for headers:
 
 ```rst
-================
-New Main Section
-================
+##################
+H1: document title
+##################
+
+*********
+Sample H2
+*********
+
+Sample H3
+=========
+
+Sample H4
+---------
+
+Sample H5
+^^^^^^^^^
+
+Sample H6
+"""""""""
 ```
 
-- To create a sub-section: A sub section title is surrounded (above and below)
-  with `-` characters:
-
-```rst
----------------
-New Sub section
----------------
-```
-
-- To create a sub-sub-section: A sub-sub section title is underlined with ``=``
-  characters:
-
-```rst
-New sub-sub section
-===================
-```
-
-- If you need more levels you can keep going: A sub-sub-sub-section is
-  underlined with `-` characters.
-
-```rst
-New sub-sub-sub section
------------------------
-```
-
-RST doesn't actually set a specific order for the characters you use to
-underline and overline titles, as it will pick up the method used for the first
-title at each level. Following the convention above, though, will make it easy
-to see what level a section is wherever you are working in the documentation.
-
-#### 2. Reference sections
+#### 2. Referencing sections
 
 To reference a section in an RST file you need to first create the reference
 above the title you need to reference, and second to reference it where you need

--- a/appendix.rst
+++ b/appendix.rst
@@ -1,6 +1,7 @@
 
 .. _appendix:
 
+========
 Appendix
 ========
 
@@ -9,7 +10,7 @@ Appendix
 
 .. _singularity-environment-variables:
 
-
+-------------------------------------
 {Singularity}'s environment variables
 -------------------------------------
 
@@ -17,7 +18,7 @@ Appendix
 You can see them listed alphabetically below with their respective functionality.
 
 ``A``
-^^^^^
+=====
 
 #. **SINGULARITY_ADD_CAPS**: To specify a list (comma separated string) of capabilities to be added. Default is an empty string.
 
@@ -30,7 +31,7 @@ You can see them listed alphabetically below with their respective functionality
 #. **SINGULARITY_APPLY_CGROUPS**: Used to apply cgroups from an input file for container processes. (it requires root privileges)
 
 ``B``
-^^^^^
+=====
 
 #. **SINGULARITY_BINDPATH** and **SINGULARITY_BIND**: Comma separated string ``source:<dest>`` list of paths to bind between the host and the container.
 
@@ -39,7 +40,7 @@ You can see them listed alphabetically below with their respective functionality
 #. **SINGULARITY_BUILDER**: To specify the remote builder service URL. Defaults to our remote builder.
 
 ``C``
-^^^^^
+=====
 
 #. **SINGULARITY_CACHEDIR**: Specifies the directory for image downloads to be cached in. See :ref:`sec:cache`.
 
@@ -52,7 +53,7 @@ You can see them listed alphabetically below with their respective functionality
 #. **SINGULARITY_CONTAINLIBS**: Used to specify a string of file names (comma separated string) to bind to the ``/.singularity.d/libs`` directory.
 
 ``D``
-^^^^^
+=====
 
 #. **SINGULARITY_DEFFILE**: Shows the {Singularity} recipe that was used to generate the image.
 
@@ -83,7 +84,7 @@ You can see them listed alphabetically below with their respective functionality
    of capabilities to be dropped. Default is an empty string.
 
 ``E``
-^^^^^
+=====
 
 #. **SINGULARITY_ENVIRONMENT**: Contains all the environment variables that have been exported in your container.
 #. **SINGULARITY_ENCRYPTION_PASSPHRASE**: Used to specify the plaintext passphrase to encrypt the container.
@@ -94,19 +95,19 @@ You can see them listed alphabetically below with their respective functionality
 #. **SINGULARITYENV_PREPEND_PATH**: Used to prepend directories to the beginning of `$PATH`` environment variable. You can see more in detail on how to use this variable in our :ref:`environment and metadata section <environment-and-metadata>`.
 
 ``F``
-^^^^^
+=====
 
 #. **SINGULARITY_FAKEROOT**: Set to false by default, considers running the container in a new user namespace as uid 0 (experimental).
 
 #. **SINGULARITY_FORCE**: Forces to kill the instance.
 
 ``G``
-^^^^^
+=====
 
 #. **SINGULARITY_GROUP**: Used to specify a string of capabilities for the given group.
 
 ``H``
-^^^^^
+=====
 
 #. **SINGULARITY_HELPFILE**: Specifies the runscript helpfile, if it exists.
 
@@ -115,22 +116,22 @@ You can see them listed alphabetically below with their respective functionality
 #. **SINGULARITY_HOSTNAME**: The container's hostname.
 
 ``I``
-^^^^^
+=====
 
 #. **SINGULARITY_IMAGE**: Filename of the container.
 
 ``J``
-^^^^^
+=====
 
 #. **SINGULARITY_JSON**: Specifies the structured json of the def file, every node as each section in the def file.
 
 ``K``
-^^^^^
+=====
 
 #. **SINGULARITY_KEEP_PRIVS**: To let root user keep privileges in the container. Default is set to false.
 
 ``L``
-^^^^^
+=====
 
 #. **SINGULARITY_LABELS**: Specifies the labels associated with the image.
 
@@ -144,7 +145,7 @@ You can see them listed alphabetically below with their respective functionality
    separated by newline characters.
 
 ``N``
-^^^^^
+=====
 
 #. **SINGULARITY_NAME**: Specifies a custom image name.
 
@@ -171,17 +172,17 @@ You can see them listed alphabetically below with their respective functionality
    (experimental, only unprivileged).
 
 ``O``
-^^^^^
+=====
 
 #. **SINGULARITY_OVERLAY** and **SINGULARITY_OVERLAYIMAGE**: To indicate the use of an overlay file system image for persistent data storage or as read-only layer of container.
 
 ``P``
-^^^^^
+=====
 
 #. **SINGULARITY_PWD** and **SINGULARITY_TARGET_PWD**: The initial working directory for payload process inside the container.
 
 ``R``
-^^^^^
+=====
 
 #. **SINGULARITY_REMOTE**: To build an image remotely. (Does not require root) Default is set to false.
 
@@ -190,7 +191,7 @@ You can see them listed alphabetically below with their respective functionality
 #. **SINGULARITY_RUNSCRIPT**: Specifies the runscript of the image.
 
 ``S``
-^^^^^
+=====
 
 #. **SINGULARITY_SANDBOX**: To specify that the format of the image should be a sandbox. Default is set to false.
 
@@ -207,14 +208,14 @@ You can see them listed alphabetically below with their respective functionality
 #. **SINGULARITY_SIGNAL**: Specifies a signal sent to the instance.
 
 ``T``
-^^^^^
+=====
 
 #. **SINGULARITY_TEST**: Specifies the test script for the image.
 
 #. **SINGULARITY_TMPDIR**: Used with the ``build`` command, to consider a temporary location for the build. See :ref:`sec:temporaryfolders`.
 
 ``U``
-^^^^^
+=====
 
 #. **SINGULARITY_UNSHARE_PID**: To specify that the container will run in a new PID namespace. Default is set to false.
 
@@ -233,7 +234,7 @@ You can see them listed alphabetically below with their respective functionality
 #. **SINGULARITY_USERNS** and **SINGULARITY_UNSHARE_USERNS**: To specify that the container will run in a new user namespace, allowing {Singularity} to run completely unprivileged on recent kernels. This may not support every feature of {Singularity}. (Sandbox image only). Default is set to false.
 
 ``W``
-^^^^^
+=====
 
 #. **SINGULARITY_WORKDIR**: The working directory to be used for ``/tmp``, ``/var/tmp`` and ``$HOME`` (if ``-c`` or ``--contain`` was also used)
 
@@ -244,6 +245,7 @@ You can see them listed alphabetically below with their respective functionality
 
 .. _buildmodules:
 
+-------------
 Build Modules
 -------------
 
@@ -251,7 +253,7 @@ Build Modules
 
 
 ``library`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+===========================
 
 .. _sec:build-library-module:
 
@@ -310,7 +312,7 @@ if it is signed by keys matching *all* of the specified fingerprints.
 
 
 ``docker`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+==========================
 
 .. _sec:build-docker-module:
 
@@ -389,7 +391,7 @@ For detailed information about setting your build environment see
 
 
 ``shub`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^^
+========================
 
 Overview
 """"""""
@@ -435,7 +437,7 @@ image and the new image during bootstrap.
 
 
 ``oras`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^^
+========================
 
 Overview
 """"""""
@@ -470,7 +472,7 @@ Also,``tag`` is mandatory that refers to the version of image you want to use.
 
 
 ``localimage`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==============================
 
 .. _sec:build-localimage:
 
@@ -529,7 +531,7 @@ the new image during bootstrap.
 
 
 ``yum`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^
+=======================
 
 .. _sec:build-yum:
 
@@ -603,7 +605,7 @@ on Ubuntu you can install it like so:
 
 
 ``debootstrap`` build agent
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+===========================
 
 .. _sec:build-debootstrap:
 
@@ -674,7 +676,7 @@ On CentOS you can install it from the epel repos like so:
 
 
 ``arch`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^^
+========================
 
 .. _sec:build-arch:
 
@@ -717,7 +719,7 @@ for more info.
 
 
 ``busybox`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+===========================
 
 .. _sec:build-busybox:
 
@@ -756,7 +758,7 @@ disk space!
 
 
 ``zypper`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==========================
 
 .. _sec:build-zypper:
 
@@ -803,7 +805,7 @@ zypper build module is ``zypper`` itself.
 .. _docker-daemon-archive:
 
 ``docker-daemon`` and ``docker-archive`` bootstrap agents
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=========================================================
 
 If you are using docker locally there are two options for creating {Singularity}
 images without the need for a repository. You can either build a SIF from a
@@ -878,7 +880,7 @@ Note that differently from the ``docker://`` bootstrap agent both ``docker-daemo
 .. _scratch-agent:
 
 ``scratch`` bootstrap agent
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+===========================
 
 The scratch bootstrap agent allows you to start from a completely
 empty container. You are then responsible for adding any and all

--- a/appendix.rst
+++ b/appendix.rst
@@ -1,75 +1,100 @@
-
 .. _appendix:
 
-========
-Appendix
-========
+##########
+ Appendix
+##########
 
-
-.. TODO oci & oci-archive along with http & https
+..
+   TODO oci & oci-archive along with http & https
 
 .. _singularity-environment-variables:
 
--------------------------------------
-{Singularity}'s environment variables
--------------------------------------
+***************************************
+ {Singularity}'s environment variables
+***************************************
 
-{Singularity} 3.0 comes with some environment variables you can set or modify depending on your needs.
-You can see them listed alphabetically below with their respective functionality.
+{Singularity} 3.0 comes with some environment variables you can set or
+modify depending on your needs. You can see them listed alphabetically
+below with their respective functionality.
 
 ``A``
 =====
 
-#. **SINGULARITY_ADD_CAPS**: To specify a list (comma separated string) of capabilities to be added. Default is an empty string.
+#. **SINGULARITY_ADD_CAPS**: To specify a list (comma separated string)
+   of capabilities to be added. Default is an empty string.
 
 #. **SINGULARITY_ALL**: List all the users and groups capabilities.
 
-#. **SINGULARITY_ALLOW_SETUID**: To specify that setuid binaries should or not be allowed in the container. (root only) Default is set to false.
+#. **SINGULARITY_ALLOW_SETUID**: To specify that setuid binaries should
+   or not be allowed in the container. (root only) Default is set to
+   false.
 
-#. **SINGULARITY_APP** and **SINGULARITY_APPNAME**: Sets the name of an application to be run inside a container.
+#. **SINGULARITY_APP** and **SINGULARITY_APPNAME**: Sets the name of an
+   application to be run inside a container.
 
-#. **SINGULARITY_APPLY_CGROUPS**: Used to apply cgroups from an input file for container processes. (it requires root privileges)
+#. **SINGULARITY_APPLY_CGROUPS**: Used to apply cgroups from an input
+   file for container processes. (it requires root privileges)
 
 ``B``
 =====
 
-#. **SINGULARITY_BINDPATH** and **SINGULARITY_BIND**: Comma separated string ``source:<dest>`` list of paths to bind between the host and the container.
+#. **SINGULARITY_BINDPATH** and **SINGULARITY_BIND**: Comma separated
+   string ``source:<dest>`` list of paths to bind between the host and
+   the container.
 
-#. **SINGULARITY_BOOT**: Set to false by default, considers if executing ``/sbin/init`` when container boots (root only).
+#. **SINGULARITY_BOOT**: Set to false by default, considers if executing
+   ``/sbin/init`` when container boots (root only).
 
-#. **SINGULARITY_BUILDER**: To specify the remote builder service URL. Defaults to our remote builder.
+#. **SINGULARITY_BUILDER**: To specify the remote builder service URL.
+   Defaults to our remote builder.
 
 ``C``
 =====
 
-#. **SINGULARITY_CACHEDIR**: Specifies the directory for image downloads to be cached in. See :ref:`sec:cache`.
+#. **SINGULARITY_CACHEDIR**: Specifies the directory for image downloads
+   to be cached in. See :ref:`sec:cache`.
 
-#. **SINGULARITY_CLEANENV**: Specifies if the environment should be cleaned or not before running the container. Default is set to false.
+#. **SINGULARITY_CLEANENV**: Specifies if the environment should be
+   cleaned or not before running the container. Default is set to false.
 
-#. **SINGULARITY_CONTAIN**: To use minimal ``/dev`` and empty other directories (e.g. ``/tmp`` and ``$HOME``) instead of sharing filesystems from your host. Default is set to false.
+#. **SINGULARITY_CONTAIN**: To use minimal ``/dev`` and empty other
+   directories (e.g. ``/tmp`` and ``$HOME``) instead of sharing
+   filesystems from your host. Default is set to false.
 
-#. **SINGULARITY_CONTAINALL**: To contain not only file systems, but also PID, IPC, and environment. Default is set to false.
+#. **SINGULARITY_CONTAINALL**: To contain not only file systems, but
+   also PID, IPC, and environment. Default is set to false.
 
-#. **SINGULARITY_CONTAINLIBS**: Used to specify a string of file names (comma separated string) to bind to the ``/.singularity.d/libs`` directory.
+#. **SINGULARITY_CONTAINLIBS**: Used to specify a string of file names
+   (comma separated string) to bind to the ``/.singularity.d/libs``
+   directory.
 
 ``D``
 =====
 
-#. **SINGULARITY_DEFFILE**: Shows the {Singularity} recipe that was used to generate the image.
+#. **SINGULARITY_DEFFILE**: Shows the {Singularity} recipe that was used
+   to generate the image.
 
 #. **SINGULARITY_DESC**: Contains a description of the capabilities.
 
-#. **SINGULARITY_DETACHED**: To submit a build job and print the build ID (no real-time logs and also requires ``--remote``). Default is set to false.
+#. **SINGULARITY_DETACHED**: To submit a build job and print the build
+   ID (no real-time logs and also requires ``--remote``). Default is set
+   to false.
 
-#. **SINGULARITY_DISABLE_CACHE**: To disable all caching of docker/oci, library, oras, etc. downloads and built SIFs. Default is set to false.
+#. **SINGULARITY_DISABLE_CACHE**: To disable all caching of docker/oci,
+   library, oras, etc. downloads and built SIFs. Default is set to
+   false.
 
-#. **SINGULARITY_DNS**: A list of the DNS server addresses separated by commas to be added in ``resolv.conf``.
+#. **SINGULARITY_DNS**: A list of the DNS server addresses separated by
+   commas to be added in ``resolv.conf``.
 
-#. **SINGULARITY_DOCKER_LOGIN**: To specify the interactive prompt for docker authentication.
+#. **SINGULARITY_DOCKER_LOGIN**: To specify the interactive prompt for
+   docker authentication.
 
-#. **SINGULARITY_DOCKER_USERNAME**: To specify a username for docker authentication.
+#. **SINGULARITY_DOCKER_USERNAME**: To specify a username for docker
+   authentication.
 
-#. **SINGULARITY_DOCKER_PASSWORD**: To specify the password for docker authentication.
+#. **SINGULARITY_DOCKER_PASSWORD**: To specify the password for docker
+   authentication.
 
 #. **SINGULARITY_DOWNLOAD_CONCURRENCY**: To specify how many concurrent streams
    when downloading (pulling) an image from cloud library.
@@ -86,32 +111,59 @@ You can see them listed alphabetically below with their respective functionality
 ``E``
 =====
 
-#. **SINGULARITY_ENVIRONMENT**: Contains all the environment variables that have been exported in your container.
-#. **SINGULARITY_ENCRYPTION_PASSPHRASE**: Used to specify the plaintext passphrase to encrypt the container.
-#. **SINGULARITY_ENCRYPTION_PEM_PATH**: Used to specify the path of the file containing public or private key to encrypt the container in PEM format.
-#. **SINGULARITYENV_***: Allows you to transpose variables into the container at runtime. You can see more in detail how to use this variable in our :ref:`environment and metadata section <environment-and-metadata>`.
-#. **SINGULARITYENV_APPEND_PATH**: Used to append directories to the end of the ``$PATH`` environment variable. You can see more in detail on how to use this variable in our :ref:`environment and metadata section <environment-and-metadata>`.
-#. **SINGULARITYENV_PATH**: A specified path to override the ``$PATH`` environment variable within the container. You can see more in detail on how to use this variable in our :ref:`environment and metadata section <environment-and-metadata>`.
-#. **SINGULARITYENV_PREPEND_PATH**: Used to prepend directories to the beginning of `$PATH`` environment variable. You can see more in detail on how to use this variable in our :ref:`environment and metadata section <environment-and-metadata>`.
+#. **SINGULARITY_ENVIRONMENT**: Contains all the environment variables
+   that have been exported in your container.
+
+#. **SINGULARITY_ENCRYPTION_PASSPHRASE**: Used to specify the plaintext
+   passphrase to encrypt the container.
+
+#. **SINGULARITY_ENCRYPTION_PEM_PATH**: Used to specify the path of the
+   file containing public or private key to encrypt the container in PEM
+   format.
+
+#. **SINGULARITYENV_\***: Allows you to transpose variables into the
+   container at runtime. You can see more in detail how to use this
+   variable in our :ref:`environment and metadata section
+   <environment-and-metadata>`.
+
+#. **SINGULARITYENV_APPEND_PATH**: Used to append directories to the end
+   of the ``$PATH`` environment variable. You can see more in detail on
+   how to use this variable in our :ref:`environment and metadata
+   section <environment-and-metadata>`.
+
+#. **SINGULARITYENV_PATH**: A specified path to override the ``$PATH``
+   environment variable within the container. You can see more in detail
+   on how to use this variable in our :ref:`environment and metadata
+   section <environment-and-metadata>`.
+
+#. **SINGULARITYENV_PREPEND_PATH**: Used to prepend directories to the
+   beginning of `$PATH`` environment variable. You can see more in
+   detail on how to use this variable in our :ref:`environment and
+   metadata section <environment-and-metadata>`.
 
 ``F``
 =====
 
-#. **SINGULARITY_FAKEROOT**: Set to false by default, considers running the container in a new user namespace as uid 0 (experimental).
-
+#. **SINGULARITY_FAKEROOT**: Set to false by default, considers running
+   the container in a new user namespace as uid 0 (experimental).
 #. **SINGULARITY_FORCE**: Forces to kill the instance.
 
 ``G``
 =====
 
-#. **SINGULARITY_GROUP**: Used to specify a string of capabilities for the given group.
+#. **SINGULARITY_GROUP**: Used to specify a string of capabilities for
+   the given group.
 
 ``H``
 =====
 
-#. **SINGULARITY_HELPFILE**: Specifies the runscript helpfile, if it exists.
+#. **SINGULARITY_HELPFILE**: Specifies the runscript helpfile, if it
+   exists.
 
-#. **SINGULARITY_HOME** : A home directory specification, it could be a source or destination path. The source path is the home directory outside the container and the destination overrides the home directory within the container.
+#. **SINGULARITY_HOME** : A home directory specification, it could be a
+   source or destination path. The source path is the home directory
+   outside the container and the destination overrides the home
+   directory within the container.
 
 #. **SINGULARITY_HOSTNAME**: The container's hostname.
 
@@ -123,19 +175,22 @@ You can see them listed alphabetically below with their respective functionality
 ``J``
 =====
 
-#. **SINGULARITY_JSON**: Specifies the structured json of the def file, every node as each section in the def file.
+#. **SINGULARITY_JSON**: Specifies the structured json of the def file,
+   every node as each section in the def file.
 
 ``K``
 =====
 
-#. **SINGULARITY_KEEP_PRIVS**: To let root user keep privileges in the container. Default is set to false.
+#. **SINGULARITY_KEEP_PRIVS**: To let root user keep privileges in the
+   container. Default is set to false.
 
 ``L``
 =====
 
-#. **SINGULARITY_LABELS**: Specifies the labels associated with the image.
-
-#. **SINGULARITY_LIBRARY**: Specifies the library to pull from. Default is set to our Cloud Library.
+#. **SINGULARITY_LABELS**: Specifies the labels associated with the
+   image.
+#. **SINGULARITY_LIBRARY**: Specifies the library to pull from. Default
+   is set to our Cloud Library.
 
 ``M``
 ^^^^^
@@ -149,21 +204,33 @@ You can see them listed alphabetically below with their respective functionality
 
 #. **SINGULARITY_NAME**: Specifies a custom image name.
 
-#. **SINGULARITY_NETWORK**: Used to specify a desired network. If more than one parameters is used, addresses should be separated by commas, where each network will bring up a dedicated interface inside the container.
+#. **SINGULARITY_NETWORK**: Used to specify a desired network. If more
+   than one parameters is used, addresses should be separated by commas,
+   where each network will bring up a dedicated interface inside the
+   container.
 
-#. **SINGULARITY_NETWORK_ARGS**: To specify the network arguments to pass to CNI plugins.
+#. **SINGULARITY_NETWORK_ARGS**: To specify the network arguments to
+   pass to CNI plugins.
 
-#. **SINGULARITY_NOCLEANUP**: To not clean up the bundle after a failed build, this can be helpful for debugging. Default is set to false.
+#. **SINGULARITY_NOCLEANUP**: To not clean up the bundle after a failed
+   build, this can be helpful for debugging. Default is set to false.
 
-#. **SINGULARITY_NOHTTPS**: Sets to either false or true to avoid using HTTPS for communicating with the local docker registry. Default is set to false.
+#. **SINGULARITY_NOHTTPS**: Sets to either false or true to avoid using
+   HTTPS for communicating with the local docker registry. Default is
+   set to false.
 
-#. **SINGULARITY_NO_HOME**: Considers not mounting users home directory if home is not the current working directory. Default is set to false.
+#. **SINGULARITY_NO_HOME**: Considers not mounting users home directory
+   if home is not the current working directory. Default is set to
+   false.
 
-#. **SINGULARITY_NO_INIT** and **SINGULARITY_NOSHIMINIT**: Considers not starting the ``shim`` process with ``--pid``.
+#. **SINGULARITY_NO_INIT** and **SINGULARITY_NOSHIMINIT**: Considers not
+   starting the ``shim`` process with ``--pid``.
 
-#. **SINGULARITY_NO_NV**: Flag to disable Nvidia support. Opposite of ``SINGULARITY_NV``.
+#. **SINGULARITY_NO_NV**: Flag to disable Nvidia support. Opposite of
+   ``SINGULARITY_NV``.
 
-#. **SINGULARITY_NO_PRIVS**: To drop all the privileges from root user in the container. Default is set to false.
+#. **SINGULARITY_NO_PRIVS**: To drop all the privileges from root user
+   in the container. Default is set to false.
 
 #. **SINGULARITY_NV**: To enable Nvidia GPU support. Default is
    set to false.
@@ -174,36 +241,46 @@ You can see them listed alphabetically below with their respective functionality
 ``O``
 =====
 
-#. **SINGULARITY_OVERLAY** and **SINGULARITY_OVERLAYIMAGE**: To indicate the use of an overlay file system image for persistent data storage or as read-only layer of container.
+#. **SINGULARITY_OVERLAY** and **SINGULARITY_OVERLAYIMAGE**: To indicate
+   the use of an overlay file system image for persistent data storage
+   or as read-only layer of container.
 
 ``P``
 =====
 
-#. **SINGULARITY_PWD** and **SINGULARITY_TARGET_PWD**: The initial working directory for payload process inside the container.
+#. **SINGULARITY_PWD** and **SINGULARITY_TARGET_PWD**: The initial
+   working directory for payload process inside the container.
 
 ``R``
 =====
 
-#. **SINGULARITY_REMOTE**: To build an image remotely. (Does not require root) Default is set to false.
-
+#. **SINGULARITY_REMOTE**: To build an image remotely. (Does not require
+   root) Default is set to false.
 #. **SINGULARITY_ROOTFS**: To reference the system file location.
-
 #. **SINGULARITY_RUNSCRIPT**: Specifies the runscript of the image.
 
 ``S``
 =====
 
-#. **SINGULARITY_SANDBOX**: To specify that the format of the image should be a sandbox. Default is set to false.
+#. **SINGULARITY_SANDBOX**: To specify that the format of the image
+   should be a sandbox. Default is set to false.
 
-#. **SINGULARITY_SCRATCH** and **SINGULARITY_SCRATCHDIR**: Used to include a scratch directory within the container that is linked to a temporary directory. (use -W to force location)
+#. **SINGULARITY_SCRATCH** and **SINGULARITY_SCRATCHDIR**: Used to
+   include a scratch directory within the container that is linked to a
+   temporary directory. (use -W to force location)
 
-#. **SINGULARITY_SECTION**: To specify a comma separated string of all the sections to be run from the deffile (setup, post, files, environment, test, labels, none)
+#. **SINGULARITY_SECTION**: To specify a comma separated string of all
+   the sections to be run from the deffile (setup, post, files,
+   environment, test, labels, none)
 
-#. **SINGULARITY_SECURITY**: Used to enable security features. (SELinux, Apparmor, Seccomp)
+#. **SINGULARITY_SECURITY**: Used to enable security features. (SELinux,
+   Apparmor, Seccomp)
 
-#. **SINGULARITY_SECRET**: Lists all the private keys instead of the default which display the public ones.
+#. **SINGULARITY_SECRET**: Lists all the private keys instead of the
+   default which display the public ones.
 
-#. **SINGULARITY_SHELL**: The path to the program to be used as an interactive shell.
+#. **SINGULARITY_SHELL**: The path to the program to be used as an
+   interactive shell.
 
 #. **SINGULARITY_SIGNAL**: Specifies a signal sent to the instance.
 
@@ -211,324 +288,341 @@ You can see them listed alphabetically below with their respective functionality
 =====
 
 #. **SINGULARITY_TEST**: Specifies the test script for the image.
-
-#. **SINGULARITY_TMPDIR**: Used with the ``build`` command, to consider a temporary location for the build. See :ref:`sec:temporaryfolders`.
+#. **SINGULARITY_TMPDIR**: Used with the ``build`` command, to consider
+   a temporary location for the build. See :ref:`sec:temporaryfolders`.
 
 ``U``
 =====
 
-#. **SINGULARITY_UNSHARE_PID**: To specify that the container will run in a new PID namespace. Default is set to false.
+#. **SINGULARITY_UNSHARE_PID**: To specify that the container will run
+   in a new PID namespace. Default is set to false.
 
-#. **SINGULARITY_UNSHARE_IPC**: To specify that the container will run in a new IPC namespace. Default is set to false.
+#. **SINGULARITY_UNSHARE_IPC**: To specify that the container will run
+   in a new IPC namespace. Default is set to false.
 
-#. **SINGULARITY_UNSHARE_NET**: To specify that the container will run in a new network namespace (sets up a bridge network interface by default). Default is set to false.
+#. **SINGULARITY_UNSHARE_NET**: To specify that the container will run
+   in a new network namespace (sets up a bridge network interface by
+   default). Default is set to false.
 
-#. **SINGULARITY_UNSHARE_UTS**: To specify that the container will run in a new UTS namespace. Default is set to false.
+#. **SINGULARITY_UNSHARE_UTS**: To specify that the container will run
+   in a new UTS namespace. Default is set to false.
 
-#. **SINGULARITY_UPDATE**: To run the definition over an existing container (skips the header). Default is set to false.
+#. **SINGULARITY_UPDATE**: To run the definition over an existing
+   container (skips the header). Default is set to false.
 
 #. **SINGULARITY_URL**: Specifies the key server ``URL``.
 
-#. **SINGULARITY_USER**: Used to specify a string of capabilities for the given user.
+#. **SINGULARITY_USER**: Used to specify a string of capabilities for
+   the given user.
 
-#. **SINGULARITY_USERNS** and **SINGULARITY_UNSHARE_USERNS**: To specify that the container will run in a new user namespace, allowing {Singularity} to run completely unprivileged on recent kernels. This may not support every feature of {Singularity}. (Sandbox image only). Default is set to false.
+#. **SINGULARITY_USERNS** and **SINGULARITY_UNSHARE_USERNS**: To specify
+   that the container will run in a new user namespace, allowing
+   {Singularity} to run completely unprivileged on recent kernels. This
+   may not support every feature of {Singularity}. (Sandbox image only).
+   Default is set to false.
 
 ``W``
 =====
 
-#. **SINGULARITY_WORKDIR**: The working directory to be used for ``/tmp``, ``/var/tmp`` and ``$HOME`` (if ``-c`` or ``--contain`` was also used)
+#. **SINGULARITY_WORKDIR**: The working directory to be used for
+   ``/tmp``, ``/var/tmp`` and ``$HOME`` (if ``-c`` or ``--contain`` was
+   also used)
 
-#. **SINGULARITY_WRITABLE**: By default, all {Singularity} containers are available as read only, this option makes the file system accessible as read/write. Default set to false.
+#. **SINGULARITY_WRITABLE**: By default, all {Singularity} containers
+   are available as read only, this option makes the file system
+   accessible as read/write. Default set to false.
 
-#. **SINGULARITY_WRITABLE_TMPFS**: Makes the file system accessible as read-write with non-persistent data (with overlay support only). Default is set to false.
-
+#. **SINGULARITY_WRITABLE_TMPFS**: Makes the file system accessible as
+   read-write with non-persistent data (with overlay support only).
+   Default is set to false.
 
 .. _buildmodules:
 
--------------
-Build Modules
--------------
+***************
+ Build Modules
+***************
 
 .. _build-library-module:
-
 
 ``library`` bootstrap agent
 ===========================
 
 .. _sec:build-library-module:
 
-
 Overview
-""""""""
+--------
 
-You can use an existing container on the Container Library as your “base,” and
-then add customization. This allows you to build multiple images from the same
-starting point. For example, you may want to build several containers with the
-same custom python installation, the same custom compiler toolchain, or the same
-base MPI installation. Instead of building these from scratch each time, you
-could create a base container on the Container Library and then build new
-containers from that existing base container adding customizations in ``%post``,
+You can use an existing container on the Container Library as your
+“base,” and then add customization. This allows you to build multiple
+images from the same starting point. For example, you may want to build
+several containers with the same custom python installation, the same
+custom compiler toolchain, or the same base MPI installation. Instead of
+building these from scratch each time, you could create a base container
+on the Container Library and then build new containers from that
+existing base container adding customizations in ``%post``,
 ``%environment``, ``%runscript``, etc.
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: library
+   Bootstrap: library
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    From: <entity>/<collection>/<container>:<tag>
+   From: <entity>/<collection>/<container>:<tag>
 
-The ``From`` keyword is mandatory. It specifies the container to use as a base.
-``entity`` is optional and defaults to ``library``. ``collection`` is
-optional and defaults to ``default``. This is the correct namespace to use for
-some official containers (``alpine`` for example). ``tag`` is also optional and
-will default to ``latest``.
+The ``From`` keyword is mandatory. It specifies the container to use as
+a base. ``entity`` is optional and defaults to ``library``.
+``collection`` is optional and defaults to ``default``. This is the
+correct namespace to use for some official containers (``alpine`` for
+example). ``tag`` is also optional and will default to ``latest``.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Library: http://custom/library
+   Library: http://custom/library
 
 The Library keyword is optional. It will default to
 ``https://library.sylabs.io``.
 
+.. code:: singularity
 
-.. code-block:: singularity
-
-    Fingerprints: 22045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
+   Fingerprints: 22045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
 
 The Fingerprints keyword is optional. It specifies one or more comma
-separated fingerprints corresponding to PGP public keys. If present,
-the bootstrap image will be verified and the build will only proceed
-if it is signed by keys matching *all* of the specified fingerprints.
-
+separated fingerprints corresponding to PGP public keys. If present, the
+bootstrap image will be verified and the build will only proceed if it
+is signed by keys matching *all* of the specified fingerprints.
 
 .. _build-docker-module:
-
 
 ``docker`` bootstrap agent
 ==========================
 
 .. _sec:build-docker-module:
 
-
 Overview
-""""""""
+--------
 
-Docker images are comprised of layers that are assembled at runtime to create an
-image. You can use Docker layers to create a base image, and then add your own
-custom software. For example, you might use Docker’s Ubuntu image layers to
-create an Ubuntu {Singularity} container. You could do the same with CentOS,
-Debian, Arch, Suse, Alpine, BusyBox, etc.
+Docker images are comprised of layers that are assembled at runtime to
+create an image. You can use Docker layers to create a base image, and
+then add your own custom software. For example, you might use Docker’s
+Ubuntu image layers to create an Ubuntu {Singularity} container. You
+could do the same with CentOS, Debian, Arch, Suse, Alpine, BusyBox, etc.
 
-Or maybe you want a container that already has software installed. For instance,
-maybe you want to build a container that uses CUDA and cuDNN to leverage the
-GPU, but you don’t want to install from scratch. You can start with one of the
-``nvidia/cuda`` containers and install your software on top of that.
+Or maybe you want a container that already has software installed. For
+instance, maybe you want to build a container that uses CUDA and cuDNN
+to leverage the GPU, but you don’t want to install from scratch. You can
+start with one of the ``nvidia/cuda`` containers and install your
+software on top of that.
 
-Or perhaps you have already invested in Docker and created your own Docker
-containers. If so, you can seamlessly convert them to {Singularity} with the
-``docker`` bootstrap module.
-
+Or perhaps you have already invested in Docker and created your own
+Docker containers. If so, you can seamlessly convert them to
+{Singularity} with the ``docker`` bootstrap module.
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: docker
+   Bootstrap: docker
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    From: <registry>/<namespace>/<container>:<tag>@<digest>
+   From: <registry>/<namespace>/<container>:<tag>@<digest>
 
-The ``From`` keyword is mandatory. It specifies the container to use as a base.
-``registry`` is optional and defaults to ``index.docker.io``. ``namespace`` is
-optional and defaults to ``library``. This is the correct namespace to use for
-some official containers (ubuntu for example). ``tag`` is also optional and will
-default to ``latest``
+The ``From`` keyword is mandatory. It specifies the container to use as
+a base. ``registry`` is optional and defaults to ``index.docker.io``.
+``namespace`` is optional and defaults to ``library``. This is the
+correct namespace to use for some official containers (ubuntu for
+example). ``tag`` is also optional and will default to ``latest``
 
-See :ref:`{Singularity} and Docker <singularity-and-docker>` for more detailed
-info on using Docker registries.
+See :ref:`{Singularity} and Docker <singularity-and-docker>` for more
+detailed info on using Docker registries.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Registry: http://custom_registry
+   Registry: http://custom_registry
 
-The Registry keyword is optional. It will default to ``index.docker.io``.
+The Registry keyword is optional. It will default to
+``index.docker.io``.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Namespace: namespace
+   Namespace: namespace
 
 The Namespace keyword is optional. It will default to ``library``.
 
 Notes
-"""""
+-----
 
-Docker containers are stored as a collection of tarballs called layers. When
-building from a Docker container the layers must be downloaded and then
-assembled in the proper order to produce a viable file system. Then the file
-system must be converted to Singularity Image File (sif) format.
+Docker containers are stored as a collection of tarballs called layers.
+When building from a Docker container the layers must be downloaded and
+then assembled in the proper order to produce a viable file system. Then
+the file system must be converted to Singularity Image File (sif)
+format.
 
-Building from Docker Hub is not considered reproducible because if any of the
-layers of the image are changed, the container will change. If reproducibility
-is important to your workflow, consider hosting a base container on the
-Container Library and building from it instead.
+Building from Docker Hub is not considered reproducible because if any
+of the layers of the image are changed, the container will change. If
+reproducibility is important to your workflow, consider hosting a base
+container on the Container Library and building from it instead.
 
 For detailed information about setting your build environment see
 :ref:`Build Customization <build-environment>`.
 
 .. _build-shub:
 
-
 ``shub`` bootstrap agent
 ========================
 
 Overview
-""""""""
+--------
 
-You can use an existing container on Singularity Hub as your “base,” and then
-add customization. This allows you to build multiple images from the same
-starting point. For example, you may want to build several containers with the
-same custom python installation, the same custom compiler toolchain, or the same
-base MPI installation. Instead of building these from scratch each time, you
-could create a base container on Singularity Hub and then build new containers
-from that existing base container adding customizations in ``%post`` ,
-``%environment``, ``%runscript``, etc.
+You can use an existing container on Singularity Hub as your “base,” and
+then add customization. This allows you to build multiple images from
+the same starting point. For example, you may want to build several
+containers with the same custom python installation, the same custom
+compiler toolchain, or the same base MPI installation. Instead of
+building these from scratch each time, you could create a base container
+on Singularity Hub and then build new containers from that existing base
+container adding customizations in ``%post`` , ``%environment``,
+``%runscript``, etc.
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: shub
+   Bootstrap: shub
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    From: shub://<registry>/<username>/<container-name>:<tag>@digest
+   From: shub://<registry>/<username>/<container-name>:<tag>@digest
 
-The ``From`` keyword is mandatory. It specifies the container to use as a base.
-``registry is optional and defaults to ``singularity-hub.org``. ``tag`` and
-``digest`` are also optional. ``tag`` defaults to ``latest`` and ``digest`` can
-be left blank if you want the latest build.
+The ``From`` keyword is mandatory. It specifies the container to use as
+a base. ``registry is optional and defaults to ``singularity-hub.org``.
+``tag`` and ``digest`` are also optional. ``tag`` defaults to ``latest``
+and ``digest`` can be left blank if you want the latest build.
 
 Notes
-"""""
+-----
 
-When bootstrapping from a Singularity Hub image, all previous definition files
-that led to the creation of the current image will be stored in a directory
-within the container called ``/.singularity.d/bootstrap_history``. {Singularity}
-will also alert you if environment variables have been changed between the base
-image and the new image during bootstrap.
+When bootstrapping from a Singularity Hub image, all previous definition
+files that led to the creation of the current image will be stored in a
+directory within the container called
+``/.singularity.d/bootstrap_history``. {Singularity} will also alert you
+if environment variables have been changed between the base image and
+the new image during bootstrap.
 
 .. _build-oras:
-
 
 ``oras`` bootstrap agent
 ========================
 
 Overview
-""""""""
+--------
 
-Using, this module, a container from supporting OCI Registries - Eg: ACR (Azure Container
-Registry), local container registries, etc can be used as your “base” image and later
-customized. This allows you to build multiple images from the same starting point. For
-example, you may want to build several containers with the same custom python installation,
-the same custom compiler toolchain, or the same base MPI installation. Instead of
-building these from scratch each time, you could make use of ``oras`` to pull an
-appropriate base container and then build new containers by adding customizations in
-``%post`` , ``%environment``, ``%runscript``, etc.
+Using, this module, a container from supporting OCI Registries - Eg: ACR
+(Azure Container Registry), local container registries, etc can be used
+as your “base” image and later customized. This allows you to build
+multiple images from the same starting point. For example, you may want
+to build several containers with the same custom python installation,
+the same custom compiler toolchain, or the same base MPI installation.
+Instead of building these from scratch each time, you could make use of
+``oras`` to pull an appropriate base container and then build new
+containers by adding customizations in ``%post`` , ``%environment``,
+``%runscript``, etc.
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: oras
+   Bootstrap: oras
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    From: oras://registry/namespace/image:tag
+   From: oras://registry/namespace/image:tag
 
-The ``From`` keyword is mandatory. It specifies the container to use as a base.
-Also,``tag`` is mandatory that refers to the version of image you want to use.
+The ``From`` keyword is mandatory. It specifies the container to use as
+a base. Also,``tag`` is mandatory that refers to the version of image
+you want to use.
 
 .. _build-localimage:
-
 
 ``localimage`` bootstrap agent
 ==============================
 
 .. _sec:build-localimage:
 
-This module allows you to build a container from an existing {Singularity}
-container on your host system. The name is somewhat misleading because your
-container can be in either image or directory format.
+This module allows you to build a container from an existing
+{Singularity} container on your host system. The name is somewhat
+misleading because your container can be in either image or directory
+format.
 
 Overview
-""""""""
+--------
 
 You can use an existing container image as your “base”, and then add
-customization. This allows you to build multiple images from the same starting
-point. For example, you may want to build several containers with the same
-custom python installation, the same custom compiler toolchain, or the same base
-MPI installation. Instead of building these from scratch each time, you could
-start with the appropriate local base container and then customize the new
-container in ``%post``, ``%environment``, ``%runscript``, etc.
+customization. This allows you to build multiple images from the same
+starting point. For example, you may want to build several containers
+with the same custom python installation, the same custom compiler
+toolchain, or the same base MPI installation. Instead of building these
+from scratch each time, you could start with the appropriate local base
+container and then customize the new container in ``%post``,
+``%environment``, ``%runscript``, etc.
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: localimage
+   Bootstrap: localimage
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    From: /path/to/container/file/or/directory
+   From: /path/to/container/file/or/directory
 
-The ``From`` keyword is mandatory. It specifies the local container to use as a
-base.
+The ``From`` keyword is mandatory. It specifies the local container to
+use as a base.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Fingerprints: 22045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
+   Fingerprints: 22045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
 
 The Fingerprints keyword is optional. It specifies one or more comma
-separated fingerprints corresponding to PGP public keys. If present,
-and the ``From:`` keyword points to a SIF format image, it will be
-verified and the build will only proceed if it is signed by keys
-matching *all* of the specified fingerprints.
+separated fingerprints corresponding to PGP public keys. If present, and
+the ``From:`` keyword points to a SIF format image, it will be verified
+and the build will only proceed if it is signed by keys matching *all*
+of the specified fingerprints.
 
 Notes
-"""""
+-----
 
-When building from a local container, all previous definition files that led to
-the creation of the current container will be stored in a directory within the
-container called ``/.singularity.d/bootstrap_history``. {Singularity} will also
-alert you if environment variables have been changed between the base image and
+When building from a local container, all previous definition files that
+led to the creation of the current container will be stored in a
+directory within the container called
+``/.singularity.d/bootstrap_history``. {Singularity} will also alert you
+if environment variables have been changed between the base image and
 the new image during bootstrap.
 
 .. _build-yum:
-
 
 ``yum`` bootstrap agent
 =======================
@@ -539,141 +633,139 @@ This module allows you to build a Red Hat/CentOS/Scientific Linux style
 container from a mirror URI.
 
 Overview
-""""""""
+--------
 
-Use the ``yum`` module to specify a base for a CentOS-like container. You must
-also specify the URI for the mirror you would like to use.
+Use the ``yum`` module to specify a base for a CentOS-like container.
+You must also specify the URI for the mirror you would like to use.
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: yum
+   Bootstrap: yum
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    OSVersion: 7
+   OSVersion: 7
 
-The OSVersion keyword is optional. It specifies the OS version you would like to
-use. It is only required if you have specified a %{OSVERSION} variable in the
-``MirrorURL`` keyword.
+The OSVersion keyword is optional. It specifies the OS version you would
+like to use. It is only required if you have specified a %{OSVERSION}
+variable in the ``MirrorURL`` keyword.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+   MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
 
-The MirrorURL keyword is mandatory. It specifies the URI to use as a mirror to
-download the OS. If you define the ``OSVersion`` keyword, then you can use it in
-the URI as in the example above.
+The MirrorURL keyword is mandatory. It specifies the URI to use as a
+mirror to download the OS. If you define the ``OSVersion`` keyword, then
+you can use it in the URI as in the example above.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Include: yum
+   Include: yum
 
-The Include keyword is optional. It allows you to install additional packages
-into the core operating system. It is a best practice to supply only the bare
-essentials such that the ``%post`` section has what it needs to properly
-complete the build. One common package you may want to install when using the
-``yum`` build module is YUM itself.
+The Include keyword is optional. It allows you to install additional
+packages into the core operating system. It is a best practice to supply
+only the bare essentials such that the ``%post`` section has what it
+needs to properly complete the build. One common package you may want to
+install when using the ``yum`` build module is YUM itself.
 
 Notes
-"""""
+-----
 
-There is a major limitation with using YUM to bootstrap a container. The RPM
-database that exists within the container will be created using the RPM library
-and Berkeley DB implementation that exists on the host system. If the RPM
-implementation inside the container is not compatible with the RPM database that
-was used to create the container, RPM and YUM commands inside the container may
-fail. This issue can be easily demonstrated by bootstrapping an older RHEL
-compatible image by a newer one (e.g. bootstrap a Centos 5 or 6 container from a
-Centos 7 host).
+There is a major limitation with using YUM to bootstrap a container. The
+RPM database that exists within the container will be created using the
+RPM library and Berkeley DB implementation that exists on the host
+system. If the RPM implementation inside the container is not compatible
+with the RPM database that was used to create the container, RPM and YUM
+commands inside the container may fail. This issue can be easily
+demonstrated by bootstrapping an older RHEL compatible image by a newer
+one (e.g. bootstrap a Centos 5 or 6 container from a Centos 7 host).
 
 In order to use the ``yum`` build module, you must have ``yum``
-installed on your system. It may seem counter-intuitive to install YUM on a
-system that uses a different package manager, but you can do so. For instance,
-on Ubuntu you can install it like so:
+installed on your system. It may seem counter-intuitive to install YUM
+on a system that uses a different package manager, but you can do so.
+For instance, on Ubuntu you can install it like so:
 
-.. code-block::
+.. code::
 
-    $ sudo apt-get update && sudo apt-get install yum
+   $ sudo apt-get update && sudo apt-get install yum
 
 .. _build-debootstrap:
-
 
 ``debootstrap`` build agent
 ===========================
 
 .. _sec:build-debootstrap:
 
-This module allows you to build a Debian/Ubuntu style container from a mirror
-URI.
+This module allows you to build a Debian/Ubuntu style container from a
+mirror URI.
 
 Overview
-""""""""
+--------
 
-Use the ``debootstrap`` module to specify a base for a Debian-like container.
-You must also specify the OS version and a URI for the mirror you would like to
-use.
+Use the ``debootstrap`` module to specify a base for a Debian-like
+container. You must also specify the OS version and a URI for the mirror
+you would like to use.
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: debootstrap
+   Bootstrap: debootstrap
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    OSVersion: xenial
+   OSVersion: xenial
 
-The OSVersion keyword is mandatory. It specifies the OS version you would like
-to use. For Ubuntu you can use code words like ``trusty`` (14.04), ``xenial``
-(16.04), and ``yakkety`` (17.04). For Debian you can use values like ``stable``,
-``oldstable``, ``testing``, and ``unstable`` or code words like ``wheezy`` (7),
-``jesse`` (8), and ``stretch`` (9).
+The OSVersion keyword is mandatory. It specifies the OS version you
+would like to use. For Ubuntu you can use code words like ``trusty``
+(14.04), ``xenial`` (16.04), and ``yakkety`` (17.04). For Debian you can
+use values like ``stable``, ``oldstable``, ``testing``, and ``unstable``
+or code words like ``wheezy`` (7), ``jesse`` (8), and ``stretch`` (9).
 
- .. code-block:: singularity
+   .. code:: singularity
 
-     MirrorURL:  http://us.archive.ubuntu.com/ubuntu/
+      MirrorURL:  http://us.archive.ubuntu.com/ubuntu/
 
-The MirrorURL keyword is mandatory. It specifies a URI to use as a mirror when
-downloading the OS.
+The MirrorURL keyword is mandatory. It specifies a URI to use as a
+mirror when downloading the OS.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Include: somepackage
+   Include: somepackage
 
-The Include keyword is optional. It allows you to install additional packages
-into the core operating system. It is a best practice to supply only the bare
-essentials such that the ``%post`` section has what it needs to properly
-complete the build.
+The Include keyword is optional. It allows you to install additional
+packages into the core operating system. It is a best practice to supply
+only the bare essentials such that the ``%post`` section has what it
+needs to properly complete the build.
 
 Notes
-"""""
+-----
 
-In order to use the ``debootstrap`` build module, you must have ``debootstrap``
-installed on your system. On Ubuntu you can install it like so:
+In order to use the ``debootstrap`` build module, you must have
+``debootstrap`` installed on your system. On Ubuntu you can install it
+like so:
 
-.. code-block::
+.. code::
 
-    $ sudo apt-get update && sudo apt-get install debootstrap
+   $ sudo apt-get update && sudo apt-get install debootstrap
 
 On CentOS you can install it from the epel repos like so:
 
-.. code-block::
+.. code::
 
-    $ sudo yum update && sudo yum install epel-release && sudo yum install debootstrap.noarch
-
+   $ sudo yum update && sudo yum install epel-release && sudo yum install debootstrap.noarch
 
 .. _build-arch:
-
 
 ``arch`` bootstrap agent
 ========================
@@ -683,40 +775,39 @@ On CentOS you can install it from the epel repos like so:
 This module allows you to build a Arch Linux based container.
 
 Overview
-""""""""
+--------
 
-Use the ``arch`` module to specify a base for an Arch Linux based container.
-Arch Linux uses the aptly named ``pacman`` package manager (all puns intended).
-
+Use the ``arch`` module to specify a base for an Arch Linux based
+container. Arch Linux uses the aptly named ``pacman`` package manager
+(all puns intended).
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: arch
+   Bootstrap: arch
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-The Arch Linux bootstrap module does not name any additional keywords at this
-time. By defining the ``arch`` module, you have essentially given all of the
-information necessary for that particular bootstrap module to build a core
-operating system.
+The Arch Linux bootstrap module does not name any additional keywords at
+this time. By defining the ``arch`` module, you have essentially given
+all of the information necessary for that particular bootstrap module to
+build a core operating system.
 
 Notes
-"""""
+-----
 
-Arch Linux is, by design, a very stripped down, light-weight OS. You may need to
-perform a significant amount of configuration to get a usable OS. Please refer
-to this
-`README.md <https://github.com/singularityware/singularity/blob/master/examples/arch/README.md>`_
-and the
-`Arch Linux example <https://github.com/singularityware/singularity/blob/master/examples/arch/Singularity>`_
+Arch Linux is, by design, a very stripped down, light-weight OS. You may
+need to perform a significant amount of configuration to get a usable
+OS. Please refer to this `README.md
+<https://github.com/singularityware/singularity/blob/master/examples/arch/README.md>`_
+and the `Arch Linux example
+<https://github.com/singularityware/singularity/blob/master/examples/arch/Singularity>`_
 for more info.
 
 .. _build-busybox:
-
 
 ``busybox`` bootstrap agent
 ===========================
@@ -726,211 +817,209 @@ for more info.
 This module allows you to build a container based on BusyBox.
 
 Overview
-""""""""
+--------
 
-Use the ``busybox`` module to specify a BusyBox base for container. You must
-also specify a URI for the mirror you would like to use.
+Use the ``busybox`` module to specify a BusyBox base for container. You
+must also specify a URI for the mirror you would like to use.
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: busybox
+   Bootstrap: busybox
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    MirrorURL: https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64
+   MirrorURL: https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64
 
-The MirrorURL keyword is mandatory. It specifies a URI to use as a mirror when
-downloading the OS.
+The MirrorURL keyword is mandatory. It specifies a URI to use as a
+mirror when downloading the OS.
 
 Notes
-"""""
+-----
 
-You can build a fully functional BusyBox container that only takes up ~600kB of
-disk space!
+You can build a fully functional BusyBox container that only takes up
+~600kB of disk space!
 
 .. _build-zypper:
-
 
 ``zypper`` bootstrap agent
 ==========================
 
 .. _sec:build-zypper:
 
-This module allows you to build a Suse style container from a mirror URI.
+This module allows you to build a Suse style container from a mirror
+URI.
 
 .. note::
-   ``zypper`` version 1.11.20 or greater is required on the host system, as
-   {Singularity} requires the ``--releasever`` flag.
+
+   ``zypper`` version 1.11.20 or greater is required on the host system,
+   as {Singularity} requires the ``--releasever`` flag.
 
 Overview
-""""""""
+--------
 
-Use the ``zypper`` module to specify a base for a Suse-like container. You must
-also specify a URI for the mirror you would like to use.
+Use the ``zypper`` module to specify a base for a Suse-like container.
+You must also specify a URI for the mirror you would like to use.
 
 Keywords
-""""""""
+--------
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: zypper
+   Bootstrap: zypper
 
-The Bootstrap keyword is always mandatory. It describes the bootstrap module to
-use.
+The Bootstrap keyword is always mandatory. It describes the bootstrap
+module to use.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    OSVersion: 42.2
+   OSVersion: 42.2
 
-The OSVersion keyword is optional. It specifies the OS version you would like to
-use. It is only required if you have specified a %{OSVERSION} variable in the
-``MirrorURL`` keyword.
+The OSVersion keyword is optional. It specifies the OS version you would
+like to use. It is only required if you have specified a %{OSVERSION}
+variable in the ``MirrorURL`` keyword.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Include: somepackage
+   Include: somepackage
 
-The Include keyword is optional. It allows you to install additional packages
-into the core operating system. It is a best practice to supply only the bare
-essentials such that the ``%post`` section has what it needs to properly
-complete the build. One common package you may want to install when using the
-zypper build module is ``zypper`` itself.
+The Include keyword is optional. It allows you to install additional
+packages into the core operating system. It is a best practice to supply
+only the bare essentials such that the ``%post`` section has what it
+needs to properly complete the build. One common package you may want to
+install when using the zypper build module is ``zypper`` itself.
 
 .. _docker-daemon-archive:
 
 ``docker-daemon`` and ``docker-archive`` bootstrap agents
 =========================================================
 
-If you are using docker locally there are two options for creating {Singularity}
-images without the need for a repository. You can either build a SIF from a
-``docker-save`` tar file or you can convert any docker image present in
-docker's daemon internal storage.
-
+If you are using docker locally there are two options for creating
+{Singularity} images without the need for a repository. You can either
+build a SIF from a ``docker-save`` tar file or you can convert any
+docker image present in docker's daemon internal storage.
 
 Overview
-""""""""
+--------
 
-``docker-daemon`` allows you to build a SIF from any docker image currently
-residing in docker's daemon internal storage:
+``docker-daemon`` allows you to build a SIF from any docker image
+currently residing in docker's daemon internal storage:
 
-.. code-block:: console
+.. code:: console
 
-    $ docker images alpine
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    alpine              latest              965ea09ff2eb        7 weeks ago         5.55MB
+   $ docker images alpine
+   REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+   alpine              latest              965ea09ff2eb        7 weeks ago         5.55MB
 
-    $ singularity run docker-daemon:alpine:latest
-    INFO:    Converting OCI blobs to SIF format
-    INFO:    Starting build...
-    Getting image source signatures
-    Copying blob 77cae8ab23bf done
-    Copying config 759e71f0d3 done
-    Writing manifest to image destination
-    Storing signatures
-    2019/12/11 14:53:24  info unpack layer: sha256:eb7c47c7f0fd0054242f35366d166e6b041dfb0b89e5f93a82ad3a3206222502
-    INFO:    Creating SIF file...
-    Singularity>
+   $ singularity run docker-daemon:alpine:latest
+   INFO:    Converting OCI blobs to SIF format
+   INFO:    Starting build...
+   Getting image source signatures
+   Copying blob 77cae8ab23bf done
+   Copying config 759e71f0d3 done
+   Writing manifest to image destination
+   Storing signatures
+   2019/12/11 14:53:24  info unpack layer: sha256:eb7c47c7f0fd0054242f35366d166e6b041dfb0b89e5f93a82ad3a3206222502
+   INFO:    Creating SIF file...
+   Singularity>
 
-while ``docker-archive`` permits you to do the same thing starting from a docker
-image stored in a ``docker-save`` formatted tar file:
+while ``docker-archive`` permits you to do the same thing starting from
+a docker image stored in a ``docker-save`` formatted tar file:
 
-.. code-block:: console
+.. code:: console
 
-    $ docker save -o alpine.tar alpine:latest
+   $ docker save -o alpine.tar alpine:latest
 
-    $ singularity run docker-archive:$(pwd)/alpine.tar
-    INFO:    Converting OCI blobs to SIF format
-    INFO:    Starting build...
-    Getting image source signatures
-    Copying blob 77cae8ab23bf done
-    Copying config 759e71f0d3 done
-    Writing manifest to image destination
-    Storing signatures
-    2019/12/11 15:25:09  info unpack layer: sha256:eb7c47c7f0fd0054242f35366d166e6b041dfb0b89e5f93a82ad3a3206222502
-    INFO:    Creating SIF file...
-    Singularity>
+   $ singularity run docker-archive:$(pwd)/alpine.tar
+   INFO:    Converting OCI blobs to SIF format
+   INFO:    Starting build...
+   Getting image source signatures
+   Copying blob 77cae8ab23bf done
+   Copying config 759e71f0d3 done
+   Writing manifest to image destination
+   Storing signatures
+   2019/12/11 15:25:09  info unpack layer: sha256:eb7c47c7f0fd0054242f35366d166e6b041dfb0b89e5f93a82ad3a3206222502
+   INFO:    Creating SIF file...
+   Singularity>
 
 Keywords
-""""""""
+--------
 
-The ``docker-daemon`` bootstrap agent can be used in a {Singularity} definition file
-as follows:
+The ``docker-daemon`` bootstrap agent can be used in a {Singularity}
+definition file as follows:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    From: docker-daemon:<image>:<tag>
+   From: docker-daemon:<image>:<tag>
 
-where both ``<image>`` and ``<tag>`` are mandatory fields that must be written explicitly.
-The ``docker-archive`` bootstrap agent requires instead the path to the tar file
-containing the image:
+where both ``<image>`` and ``<tag>`` are mandatory fields that must be
+written explicitly. The ``docker-archive`` bootstrap agent requires
+instead the path to the tar file containing the image:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    From: docker-archive:<path-to-tar-file>
+   From: docker-archive:<path-to-tar-file>
 
-Note that differently from the ``docker://`` bootstrap agent both ``docker-daemon`` and
-``docker-archive`` don't require a double slash ``//`` after the colon in the agent name.
+Note that differently from the ``docker://`` bootstrap agent both
+``docker-daemon`` and ``docker-archive`` don't require a double slash
+``//`` after the colon in the agent name.
 
 .. _scratch-agent:
 
 ``scratch`` bootstrap agent
 ===========================
 
-The scratch bootstrap agent allows you to start from a completely
-empty container. You are then responsible for adding any and all
-executables, libraries etc. that are required. Starting with a scratch
-container can be useful when you are aiming to minimize container size,
-and have a simple application / static binaries.
+The scratch bootstrap agent allows you to start from a completely empty
+container. You are then responsible for adding any and all executables,
+libraries etc. that are required. Starting with a scratch container can
+be useful when you are aiming to minimize container size, and have a
+simple application / static binaries.
 
 Overview
-""""""""
+--------
 
 A minimal container providing a shell can be created by copying the
 ``busybox`` static binary into an empty scratch container:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: scratch
+   Bootstrap: scratch
 
-    %setup
-        # Runs on host - fetch static busybox binary
-        curl -o /tmp/busybox https://www.busybox.net/downloads/binaries/1.31.0-i686-uclibc/busybox
-        # It needs to be executable
-        chmod +x /tmp/busybox
+   %setup
+       # Runs on host - fetch static busybox binary
+       curl -o /tmp/busybox https://www.busybox.net/downloads/binaries/1.31.0-i686-uclibc/busybox
+       # It needs to be executable
+       chmod +x /tmp/busybox
 
-    %files
-        # Copy from host into empty container
-        /tmp/busybox /bin/sh
+   %files
+       # Copy from host into empty container
+       /tmp/busybox /bin/sh
 
-    %runscript
-       /bin/sh
-
+   %runscript
+      /bin/sh
 
 The resulting container provides a shell, and is 696KiB in size:
 
-.. code-block::
+.. code::
 
-    $ ls -lah scratch.sif
-    -rwxr-xr-x. 1 dave dave 696K May 28 13:29 scratch.sif
+   $ ls -lah scratch.sif
+   -rwxr-xr-x. 1 dave dave 696K May 28 13:29 scratch.sif
 
-    $ singularity run scratch.sif
-    WARNING: passwd file doesn't exist in container, not updating
-    WARNING: group file doesn't exist in container, not updating
-    Singularity> echo "Hello from a 696KiB container"
-    Hello from a 696KiB container
-
+   $ singularity run scratch.sif
+   WARNING: passwd file doesn't exist in container, not updating
+   WARNING: group file doesn't exist in container, not updating
+   Singularity> echo "Hello from a 696KiB container"
+   Hello from a 696KiB container
 
 Keywords
 
+.. code:: singularity
 
-.. code-block:: singularity
-
-    Bootstrap: scratch
+   Bootstrap: scratch
 
 There are no additional keywords for the scratch bootstrap agent.

--- a/appendix.rst
+++ b/appendix.rst
@@ -595,7 +595,7 @@ installed on your system. It may seem counter-intuitive to install YUM on a
 system that uses a different package manager, but you can do so. For instance,
 on Ubuntu you can install it like so:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo apt-get update && sudo apt-get install yum
 
@@ -659,13 +659,13 @@ Notes
 In order to use the ``debootstrap`` build module, you must have ``debootstrap``
 installed on your system. On Ubuntu you can install it like so:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo apt-get update && sudo apt-get install debootstrap
 
 On CentOS you can install it from the epel repos like so:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo yum update && sudo yum install epel-release && sudo yum install debootstrap.noarch
 

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -100,7 +100,7 @@ Here’s an example of using the ``--bind`` option and binding ``/data`` on the
 host to ``/mnt`` in the container (``/mnt`` does not need to already exist in
 the container):
 
-.. code-block:: none
+.. code-block::
 
     $ ls /data
     bar  foo
@@ -110,7 +110,7 @@ the container):
 
 You can bind multiple directories in a single command with this syntax:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity shell --bind /opt,/data:/mnt my_container.sif
 
@@ -120,7 +120,7 @@ on the host to ``/mnt`` in the container.
 Using the environment variable instead of the command line argument, this would
 be:
 
-.. code-block:: none
+.. code-block::
 
     $ export SINGULARITY_BIND="/opt,/data:/mnt"
 
@@ -147,7 +147,7 @@ will infer ``type=bind`` if it is not provided.
 
 To mount ``data`` on the host to ``/mnt`` inside the container:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity exec \
         --mount type=bind,src=/data,dst=/mnt \
@@ -156,7 +156,7 @@ To mount ``data`` on the host to ``/mnt`` inside the container:
 
 To mount the same directory read-only in the container, add the ``ro`` option:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity exec \
         --mount type=bind,source=/data,dest=/mnt,ro \
@@ -166,7 +166,7 @@ To mount the same directory read-only in the container, add the ``ro`` option:
 You can bind multiple directories in a single command with multiple
 ``--mount`` flags:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity shell --mount type=bind,src=/opt,dst=/opt \
                         --mount type=bind,src=/data,dst=/data \
@@ -180,7 +180,7 @@ wrapping each field in double quotes if necessary
 characters. ``--mount`` allows bind mounting paths that are not
 possible with the ``--bind`` flag. For example:
 
-.. code-block:: none
+.. code-block::
 
     # Mount a path containing ':' (not possible with --bind)
     $ singularity run \
@@ -227,7 +227,7 @@ Using ``--no-home`` and ``--containall`` flags
 When shelling into your container image, {Singularity} allows you to mount your current working directory (``CWD``)
 without mounting your host ``$HOME`` directory with the ``--no-home`` flag.
 
-.. code-block:: none
+.. code-block::
 
       $ singularity shell --no-home my_container.sif
 
@@ -244,7 +244,7 @@ without mounting your host ``$HOME`` directory with the ``--no-home`` flag.
     You cannot use ``-B``` (or ``--bind``) to bind your ``$HOME`` directory because it creates an empty mount. So if you have files located in
     the image at ``/home/user``, the ``--containall`` flag will hide them all.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity shell --containall my_container.sif
 
@@ -259,7 +259,7 @@ Kernel. Unprivileged (non-root) users can mount filesystems that have
 FUSE drivers. For example, the ``fuse-sshfs`` package allows you to
 mount a remote computer's filesystem to your local host, over ssh:
 
-.. code-block:: none
+.. code-block::
 
     $ mount.fuse sshfs#ythel:/home/dave other_host/
 
@@ -291,7 +291,7 @@ FUSE mount definitions
 
 A fusemount definition for {Singularity} consists of 3 parts:
 
-.. code-block:: none
+.. code-block::
 
     --fusemount <type>:<fuse command> <container mountpoint>
 
@@ -324,7 +324,7 @@ FUSE mount with a host executable
 To use a FUSE ``sshfs`` mount in a container, where the ``fuse-sshfs`` package has
 been installed on my host, I run with the ``host`` mount type:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run --fusemount "host:sshfs server:/ /server" docker://ubuntu
     Singularity> cat /etc/hostname
@@ -339,7 +339,7 @@ If the FUSE driver / command that you want to use for the mount has
 been added to your container, you can use the ``container`` mount
 type:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run --fusemount "container:sshfs server:/ /server" sshfs.sif
     Singularity> cat /etc/hostname
@@ -368,14 +368,14 @@ time.
 To mount a directory from an image file, use the ``-B/--bind`` option
 and specify the bind in the format:
 
-.. code-block:: none
+.. code-block::
 
     -B <image-file>:<dest>:image-src=<source>
 
 Alternatively use the ``--mount`` option, and specify the bind in the
 format:
 
-.. code-block:: none
+.. code-block::
 
     --mount type=bind,src=<image-file>,dst=<dest>,image-src=<source>
 

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -1,44 +1,42 @@
-
 .. _bind-paths-and-mounts:
 
-
-=====================
-Bind Paths and Mounts
-=====================
+#######################
+ Bind Paths and Mounts
+#######################
 
 .. _sec:bindpaths:
 
 Unless `disabled by the system administrator
 <\{admindocs\}/configfiles.html#bind-mount-management>`_,
-{Singularity} allows you to map directories on your host system to directories
-within your container using bind mounts. This allows you to read and write data
-on the host system with ease.
+{Singularity} allows you to map directories on your host system to
+directories within your container using bind mounts. This allows you to
+read and write data on the host system with ease.
 
+**********
+ Overview
+**********
 
---------
-Overview
---------
+When {Singularity} ‘swaps’ the host operating system for the one inside
+your container, the host file systems becomes inaccessible. However, you
+may want to read and write files on the host system from within the
+container. To enable this functionality, {Singularity} will bind
+directories back into the container via two primary methods:
+system-defined bind paths and user-defined bind paths.
 
-When {Singularity} ‘swaps’ the host operating system for the one
-inside your container, the host file systems becomes
-inaccessible. However, you may want to read and write files on the
-host system from within the container. To enable this functionality,
-{Singularity} will bind directories back into the container via two
-primary methods: system-defined bind paths and user-defined bind
-paths.
+***************************
+ System-defined bind paths
+***************************
 
--------------------------
-System-defined bind paths
--------------------------
-
-The system administrator has the ability to define what bind paths will be
-included automatically inside each container. Some bind paths are automatically
-derived (e.g. a user’s home directory) and some are statically defined (e.g.
-bind paths in the {Singularity} configuration file). In the default
-configuration, the system default bind points are ``$HOME`` , ``/sys:/sys`` ,
-``/proc:/proc``, ``/tmp:/tmp``, ``/var/tmp:/var/tmp``, ``/etc/resolv.conf:/etc/resolv.conf``,
-``/etc/passwd:/etc/passwd``, and ``$PWD``. Where the first path before ``:``
-is the path from the host and the second path is the path in the container.
+The system administrator has the ability to define what bind paths will
+be included automatically inside each container. Some bind paths are
+automatically derived (e.g. a user’s home directory) and some are
+statically defined (e.g. bind paths in the {Singularity} configuration
+file). In the default configuration, the system default bind points are
+``$HOME`` , ``/sys:/sys`` , ``/proc:/proc``, ``/tmp:/tmp``,
+``/var/tmp:/var/tmp``, ``/etc/resolv.conf:/etc/resolv.conf``,
+``/etc/passwd:/etc/passwd``, and ``$PWD``. Where the first path before
+``:`` is the path from the host and the second path is the path in the
+container.
 
 Disabling System Binds
 ======================
@@ -55,82 +53,80 @@ running, you can disable the ``hostfs`` binds:
 
 .. code:: console
 
-    $ singularity run --no-mount hostfs mycontainer.sif
+   $ singularity run --no-mount hostfs mycontainer.sif
 
-
-Multiple mounts can be disabled by specifying them separated by
-commas:
+Multiple mounts can be disabled by specifying them separated by commas:
 
 .. code:: console
 
-    $ singularity run --no-mount tmp,sys,dev mycontainer.sif
+   $ singularity run --no-mount tmp,sys,dev mycontainer.sif
 
 .. _user-defined-bind-paths:
 
------------------------
-User-defined bind paths
------------------------
+*************************
+ User-defined bind paths
+*************************
 
 Unless the system administrator has `disabled user control of binds
 <\{admindocs\}/configfiles.html#bind-mount-management>`_,
 you will be able to request your own bind paths within your container.
 
 The {Singularity} action commands (``run``, ``exec``, ``shell``, and
-``instance start``) will accept the ``--bind/-B`` command-line option to specify
-bind paths, and will also honor the ``$SINGULARITY_BIND`` (or
-``$SINGULARITY_BINDPATH``) environment variable. The argument for this option is
-a comma-delimited string of bind path specifications in the format
-``src[:dest[:opts]]``, where ``src`` and ``dest`` are paths outside and inside
-of the container respectively. If ``dest`` is not given, it is set equal to
-``src``. Mount options (``opts``) may be specified as ``ro`` (read-only) or
-``rw`` (read/write, which is the default). The ``--bind/-B`` option can be
-specified multiple times, or a comma-delimited string of bind path
-specifications can be used.
+``instance start``) will accept the ``--bind/-B`` command-line option to
+specify bind paths, and will also honor the ``$SINGULARITY_BIND`` (or
+``$SINGULARITY_BINDPATH``) environment variable. The argument for this
+option is a comma-delimited string of bind path specifications in the
+format ``src[:dest[:opts]]``, where ``src`` and ``dest`` are paths
+outside and inside of the container respectively. If ``dest`` is not
+given, it is set equal to ``src``. Mount options (``opts``) may be
+specified as ``ro`` (read-only) or ``rw`` (read/write, which is the
+default). The ``--bind/-B`` option can be specified multiple times, or a
+comma-delimited string of bind path specifications can be used.
 
-{Singularity} 3.9 adds an additional ``--mount`` flag, which provides
-a longer-form method of specifying binds in ``--mount
+{Singularity} 3.9 adds an additional ``--mount`` flag, which provides a
+longer-form method of specifying binds in ``--mount
 type=bind,src=<source>,dst=<destination>[,<option>]...`` format. This is
-compatible with the ``--mount`` syntax for binds in Docker and other
-OCI runtimes.
+compatible with the ``--mount`` syntax for binds in Docker and other OCI
+runtimes.
 
 ``--bind`` Examples
 ===================
 
-Here’s an example of using the ``--bind`` option and binding ``/data`` on the
-host to ``/mnt`` in the container (``/mnt`` does not need to already exist in
-the container):
+Here’s an example of using the ``--bind`` option and binding ``/data``
+on the host to ``/mnt`` in the container (``/mnt`` does not need to
+already exist in the container):
 
-.. code-block::
+.. code::
 
-    $ ls /data
-    bar  foo
+   $ ls /data
+   bar  foo
 
-    $ singularity exec --bind /data:/mnt my_container.sif ls /mnt
-    bar  foo
+   $ singularity exec --bind /data:/mnt my_container.sif ls /mnt
+   bar  foo
 
 You can bind multiple directories in a single command with this syntax:
 
-.. code-block::
+.. code::
 
-    $ singularity shell --bind /opt,/data:/mnt my_container.sif
+   $ singularity shell --bind /opt,/data:/mnt my_container.sif
 
-This will bind ``/opt`` on the host to ``/opt`` in the container and ``/data``
-on the host to ``/mnt`` in the container.
+This will bind ``/opt`` on the host to ``/opt`` in the container and
+``/data`` on the host to ``/mnt`` in the container.
 
-Using the environment variable instead of the command line argument, this would
-be:
+Using the environment variable instead of the command line argument,
+this would be:
 
-.. code-block::
+.. code::
 
-    $ export SINGULARITY_BIND="/opt,/data:/mnt"
+   $ export SINGULARITY_BIND="/opt,/data:/mnt"
 
-    $ singularity shell my_container.sif
+   $ singularity shell my_container.sif
 
-Using the environment variable ``$SINGULARITY_BIND``, you can bind paths even
-when you are running your container as an executable file with a runscript. If
-you bind many directories into your {Singularity} containers and they don’t
-change, you could even benefit by setting this variable in your ``.bashrc``
-file.
+Using the environment variable ``$SINGULARITY_BIND``, you can bind paths
+even when you are running your container as an executable file with a
+runscript. If you bind many directories into your {Singularity}
+containers and they don’t change, you could even benefit by setting this
+variable in your ``.bashrc`` file.
 
 ``--mount`` Examples
 ====================
@@ -139,119 +135,121 @@ The ``--mount`` flag takes a mount specification in the format
 ``type=bind,src=<source>,dst=<dest>``. Additional options can be
 specified, comma delimited.
 
-{Singularity} only supports the ``bind`` type for ``--mount``, and
-will infer ``type=bind`` if it is not provided.
+{Singularity} only supports the ``bind`` type for ``--mount``, and will
+infer ``type=bind`` if it is not provided.
 
 ``src`` or ``source`` can be used interchangeably. ``dst``,
 ``destination``, or ``target`` are also equivalent.
 
 To mount ``data`` on the host to ``/mnt`` inside the container:
 
-.. code-block::
+.. code::
 
-    $ singularity exec \
-        --mount type=bind,src=/data,dst=/mnt \
-	my_container.sif ls /mnt
-    bar  foo
+   $ singularity exec \
+       --mount type=bind,src=/data,dst=/mnt \
+       my_container.sif ls /mnt
+   bar  foo
 
-To mount the same directory read-only in the container, add the ``ro`` option:
+To mount the same directory read-only in the container, add the ``ro``
+option:
 
-.. code-block::
+.. code::
 
-    $ singularity exec \
-        --mount type=bind,source=/data,dest=/mnt,ro \
-	my_container.sif touch /mnt/test
-    touch: cannot touch '/mnt/test': Permission denied
+   $ singularity exec \
+       --mount type=bind,source=/data,dest=/mnt,ro \
+       my_container.sif touch /mnt/test
+   touch: cannot touch '/mnt/test': Permission denied
 
 You can bind multiple directories in a single command with multiple
 ``--mount`` flags:
 
-.. code-block::
+.. code::
 
-    $ singularity shell --mount type=bind,src=/opt,dst=/opt \
-                        --mount type=bind,src=/data,dst=/data \
-                        my_container.sif
+   $ singularity shell --mount type=bind,src=/opt,dst=/opt \
+                       --mount type=bind,src=/data,dst=/data \
+                       my_container.sif
 
-This will bind ``/opt`` on the host to ``/opt`` in the container and ``/data``
-on the host to ``/mnt`` in the container.
+This will bind ``/opt`` on the host to ``/opt`` in the container and
+``/data`` on the host to ``/mnt`` in the container.
 
 The mount string can be quoted and escaped according to CSV rules,
-wrapping each field in double quotes if necessary
-characters. ``--mount`` allows bind mounting paths that are not
-possible with the ``--bind`` flag. For example:
+wrapping each field in double quotes if necessary characters.
+``--mount`` allows bind mounting paths that are not possible with the
+``--bind`` flag. For example:
 
-.. code-block::
+.. code::
 
-    # Mount a path containing ':' (not possible with --bind)
-    $ singularity run \
-        --mount type=bind,src=/my:path,dst=/mnt \
-	mycontainer.sif
+   # Mount a path containing ':' (not possible with --bind)
+   $ singularity run \
+       --mount type=bind,src=/my:path,dst=/mnt \
+       mycontainer.sif
 
-    # Mount a path containing a ','
-    $ singularity run \
-        --mount type=bind,"src=/comma,dir",dst=/mnt \
-	mycontainer.sif
+   # Mount a path containing a ','
+   $ singularity run \
+       --mount type=bind,"src=/comma,dir",dst=/mnt \
+       mycontainer.sif
 
 Mount specifications are also read from then environment variable
 ``$SINGULARITY_MOUNT``. Multiple bind mounts set via this environment
 variable should be separated by newlines (``\n``).
 
-
 Using ``--bind`` or ``-mount`` with the ``--writable`` flag
 ===========================================================
 
-To mount a bind path inside the container, a *bind point* must be defined
-within the container. The bind point is a directory within the container that
-{Singularity} can use as a destination to bind a directory on the host system.
+To mount a bind path inside the container, a *bind point* must be
+defined within the container. The bind point is a directory within the
+container that {Singularity} can use as a destination to bind a
+directory on the host system.
 
-Starting in version 3.0, {Singularity} will do its best to bind mount requested
-paths into a container regardless of whether the appropriate bind point exists
-within the container.  {Singularity} can often carry out this operation even in
-the absence of the "overlay fs" feature.
+Starting in version 3.0, {Singularity} will do its best to bind mount
+requested paths into a container regardless of whether the appropriate
+bind point exists within the container. {Singularity} can often carry
+out this operation even in the absence of the "overlay fs" feature.
 
-However, binding paths to non-existent points within the container can result in
-unexpected behavior when used in conjunction with the ``--writable`` flag, and is
-therefore disallowed. If you need to specify bind paths in combination with the
-``--writable`` flag, please ensure that the appropriate bind points exist within
-the container. If they do not already exist, it will be necessary to modify the
-container and create them.
-
+However, binding paths to non-existent points within the container can
+result in unexpected behavior when used in conjunction with the
+``--writable`` flag, and is therefore disallowed. If you need to specify
+bind paths in combination with the ``--writable`` flag, please ensure
+that the appropriate bind points exist within the container. If they do
+not already exist, it will be necessary to modify the container and
+create them.
 
 Using ``--no-home`` and ``--containall`` flags
 ==============================================
 
-^^^^^^^^^^^^^
 ``--no-home``
-^^^^^^^^^^^^^
+-------------
 
-When shelling into your container image, {Singularity} allows you to mount your current working directory (``CWD``)
-without mounting your host ``$HOME`` directory with the ``--no-home`` flag.
+When shelling into your container image, {Singularity} allows you to
+mount your current working directory (``CWD``) without mounting your
+host ``$HOME`` directory with the ``--no-home`` flag.
 
-.. code-block::
+.. code::
 
-      $ singularity shell --no-home my_container.sif
+   $ singularity shell --no-home my_container.sif
 
 .. note::
 
-    Beware that if it is the case that your ``CWD`` is your ``$HOME`` directory, it will still mount your ``$HOME`` directory.
+   Beware that if it is the case that your ``CWD`` is your ``$HOME``
+   directory, it will still mount your ``$HOME`` directory.
 
-
-^^^^^^^^^^^^^^^^
 ``--containall``
-^^^^^^^^^^^^^^^^
+----------------
 
-    Using the ``--containall`` (or ``-C`` for short) flag, ``$HOME`` is not  mounted and a dummy bind mount is created at the ``$HOME`` point.
-    You cannot use ``-B``` (or ``--bind``) to bind your ``$HOME`` directory because it creates an empty mount. So if you have files located in
-    the image at ``/home/user``, the ``--containall`` flag will hide them all.
+   Using the ``--containall`` (or ``-C`` for short) flag, ``$HOME`` is
+   not mounted and a dummy bind mount is created at the ``$HOME`` point.
+   You cannot use ``-B``` (or ``--bind``) to bind your ``$HOME``
+   directory because it creates an empty mount. So if you have files
+   located in the image at ``/home/user``, the ``--containall`` flag
+   will hide them all.
 
-.. code-block::
+.. code::
 
-    $ singularity shell --containall my_container.sif
+   $ singularity shell --containall my_container.sif
 
-
------------
-FUSE mounts
------------
+*************
+ FUSE mounts
+*************
 
 Filesystem in Userspace (FUSE) is an interface to allow filesystems to
 be mounted using code that runs in userspace, rather than in the Linux
@@ -259,13 +257,12 @@ Kernel. Unprivileged (non-root) users can mount filesystems that have
 FUSE drivers. For example, the ``fuse-sshfs`` package allows you to
 mount a remote computer's filesystem to your local host, over ssh:
 
-.. code-block::
+.. code::
 
-    $ mount.fuse sshfs#ythel:/home/dave other_host/
+   $ mount.fuse sshfs#ythel:/home/dave other_host/
 
-    # Now mounted to my local machine:
-    $ ythel:/home/dave on /home/dave/other_host type fuse.sshfs (rw,nosuid,nodev,relatime,user_id=1000,group_id=1000)
-
+   # Now mounted to my local machine:
+   $ ythel:/home/dave on /home/dave/other_host type fuse.sshfs (rw,nosuid,nodev,relatime,user_id=1000,group_id=1000)
 
 {Singularity} 3.6 introduces the ``--fusemount`` option, which allows
 you directly expose FUSE filesystems inside a container. The FUSE
@@ -278,78 +275,78 @@ that provides FUSE commands such as ``sshfs`` based on FUSE 2 then you
 can install FUSE 3 versions of the commands you need inside your
 container.
 
-
 .. note::
 
    ``--fusemount`` functionality was present in a hidden preview state
    from {Singularity} 3.4. The behavior has changed for the final
    supported version introduced in {Singularity} 3.6.
 
-
 FUSE mount definitions
 ======================
 
 A fusemount definition for {Singularity} consists of 3 parts:
 
-.. code-block::
+.. code::
 
-    --fusemount <type>:<fuse command> <container mountpoint>
+   --fusemount <type>:<fuse command> <container mountpoint>
 
+-  **type** specifies how and where the FUSE mount will be run. The
+   options are:
 
-- **type** specifies how and where the FUSE mount will be run. The options are:
+   -  ``container`` - use a FUSE command on the host, to mount a
+      filesystem into the container, with the fuse process attached.
 
-  - ``container`` - use a FUSE command on the host, to mount a
-    filesystem into the container, with the fuse process attached.
-  - ``host`` - use a FUSE command inside the container, to mount a
-    filesystem into the container, with the fuse process attached.
-  - ``container-daemon`` - use a FUSE command on the host, to mount a
-    filesystem into the container, with the fuse process detached.
-  - ``host-daemon`` - use a FUSE command inside the container, to
-    mount a filesystem into the container, with the fuse process
-    detached.
+   -  ``host`` - use a FUSE command inside the container, to mount a
+      filesystem into the container, with the fuse process attached.
 
-- **fuse command** specifies the name of the executable that
-  implements the FUSE mount, and any arguments. E.g. ``sshfs
-  server:over-there/`` for mounting a remote filesystem over SSH,
-  where the remote source is ``over-there/`` in my home directory on
-  the machine called ``server``.
+   -  ``container-daemon`` - use a FUSE command on the host, to mount a
+      filesystem into the container, with the fuse process detached.
 
-- **container mountpoint** is an *absolute path* at which the FUSE
-  filesystem will be mounted in the container.
+   -  ``host-daemon`` - use a FUSE command inside the container, to
+      mount a filesystem into the container, with the fuse process
+      detached.
 
+-  **fuse command** specifies the name of the executable that implements
+   the FUSE mount, and any arguments. E.g. ``sshfs server:over-there/``
+   for mounting a remote filesystem over SSH, where the remote source is
+   ``over-there/`` in my home directory on the machine called
+   ``server``.
+
+-  **container mountpoint** is an *absolute path* at which the FUSE
+   filesystem will be mounted in the container.
 
 FUSE mount with a host executable
 =================================
 
-To use a FUSE ``sshfs`` mount in a container, where the ``fuse-sshfs`` package has
-been installed on my host, I run with the ``host`` mount type:
+To use a FUSE ``sshfs`` mount in a container, where the ``fuse-sshfs``
+package has been installed on my host, I run with the ``host`` mount
+type:
 
-.. code-block::
+.. code::
 
-    $ singularity run --fusemount "host:sshfs server:/ /server" docker://ubuntu
-    Singularity> cat /etc/hostname
-    localhost.localdomain
-    Singularity> cat /server/etc/hostname
-    server
+   $ singularity run --fusemount "host:sshfs server:/ /server" docker://ubuntu
+   Singularity> cat /etc/hostname
+   localhost.localdomain
+   Singularity> cat /server/etc/hostname
+   server
 
 FUSE mount with a container executable
 ======================================
 
-If the FUSE driver / command that you want to use for the mount has
-been added to your container, you can use the ``container`` mount
-type:
+If the FUSE driver / command that you want to use for the mount has been
+added to your container, you can use the ``container`` mount type:
 
-.. code-block::
+.. code::
 
-    $ singularity run --fusemount "container:sshfs server:/ /server" sshfs.sif
-    Singularity> cat /etc/hostname
-    localhost.localdomain
-    Singularity> cat /server/etc/hostname
-    server
+   $ singularity run --fusemount "container:sshfs server:/ /server" sshfs.sif
+   Singularity> cat /etc/hostname
+   localhost.localdomain
+   Singularity> cat /server/etc/hostname
+   server
 
-------------
-Image Mounts
-------------
+**************
+ Image Mounts
+**************
 
 In {Singularity} 3.6 and above you can mount a directory contained in an
 image file into a container. This may be useful if you want to
@@ -360,24 +357,23 @@ You can mount from image files in ext3 format, squashfs format, or SIF
 format.
 
 The ext3 image file format allows you to mount it into the container
-read/write and make changes, while the other formats are
-read-only. Note that you can only use a read/write image in a single
-container. You cannot mount it to multiple container runs at the same
-time.
+read/write and make changes, while the other formats are read-only. Note
+that you can only use a read/write image in a single container. You
+cannot mount it to multiple container runs at the same time.
 
 To mount a directory from an image file, use the ``-B/--bind`` option
 and specify the bind in the format:
 
-.. code-block::
+.. code::
 
-    -B <image-file>:<dest>:image-src=<source>
+   -B <image-file>:<dest>:image-src=<source>
 
 Alternatively use the ``--mount`` option, and specify the bind in the
 format:
 
-.. code-block::
+.. code::
 
-    --mount type=bind,src=<image-file>,dst=<dest>,image-src=<source>
+   --mount type=bind,src=<image-file>,dst=<dest>,image-src=<source>
 
 This will bind the ``<source>`` path inside ``<image-file>`` to
 ``<dest>`` in the container.
@@ -385,98 +381,95 @@ This will bind the ``<source>`` path inside ``<image-file>`` to
 If you do not add ``:image-src=<source>`` to your bind specification,
 then the ``<image-file>`` itself will be bound to ``<dest>`` instead.
 
-
 Ext3 Image Files
 ================
 
-If you have a directory called ``inputs/`` that holds data files you wish
-to distribute in an image file that allows read/write:
+If you have a directory called ``inputs/`` that holds data files you
+wish to distribute in an image file that allows read/write:
 
-.. code-block:: sh
+.. code:: sh
 
-    # Create an image file 'inputs.img' of size 100MB and put the
-    # files inputs/ into it's root directory
-    $ mkfs.ext3 -d inputs/ inputs.img 100M
-    mke2fs 1.45.6 (20-Mar-2020)
-    Creating regular file inputs.img
-    Creating filesystem with 102400 1k blocks and 25688 inodes
-    Filesystem UUID: e23c29c9-7a49-4b82-89bf-2faf36b5a781
-    Superblock backups stored on blocks:
-   	8193, 24577, 40961, 57345, 73729
+   # Create an image file 'inputs.img' of size 100MB and put the
+   # files inputs/ into it's root directory
+   $ mkfs.ext3 -d inputs/ inputs.img 100M
+   mke2fs 1.45.6 (20-Mar-2020)
+   Creating regular file inputs.img
+   Creating filesystem with 102400 1k blocks and 25688 inodes
+   Filesystem UUID: e23c29c9-7a49-4b82-89bf-2faf36b5a781
+   Superblock backups stored on blocks:
+       8193, 24577, 40961, 57345, 73729
 
-    Allocating group tables: done
-    Writing inode tables: done
-    Creating journal (4096 blocks): done
-    Copying files into the device: done
-    Writing superblocks and filesystem accounting information: done
+   Allocating group tables: done
+   Writing inode tables: done
+   Creating journal (4096 blocks): done
+   Copying files into the device: done
+   Writing superblocks and filesystem accounting information: done
 
-    # Run {Singularity}, mounting my input data to '/input-data' in
-    # the container.
-    $ singularity run -B inputs.img:/input-data:image-src=/ mycontainer.sif
-    Singularity> ls /input-data
-    1           3           5           7           9
-    2           4           6           8           lost+found
+   # Run {Singularity}, mounting my input data to '/input-data' in
+   # the container.
+   $ singularity run -B inputs.img:/input-data:image-src=/ mycontainer.sif
+   Singularity> ls /input-data
+   1           3           5           7           9
+   2           4           6           8           lost+found
 
-    # Or with --mount instead of -B
-    $ singularity run \
-        --mount type=bind,src=inputs.img,dst=/input-data,image-src=/ \
-	mycontainer.sif
-
+   # Or with --mount instead of -B
+   $ singularity run \
+       --mount type=bind,src=inputs.img,dst=/input-data,image-src=/ \
+       mycontainer.sif
 
 SquashFS Image Files
 ====================
 
-If you have a directory called ``inputs/`` that holds data files you wish
-to distribute in an image file that is read-only, and compressed, then
-the squashfs format is appropriate:
+If you have a directory called ``inputs/`` that holds data files you
+wish to distribute in an image file that is read-only, and compressed,
+then the squashfs format is appropriate:
 
-.. code-block:: sh
+.. code:: sh
 
-    # Create an image file 'inputs.squashfs' and put the files from
-    # inputs/ into it's root directory
-    $ mksquashfs inputs/ inputs.squashfs
-    Parallel mksquashfs: Using 16 processors
-    Creating 4.0 filesystem on inputs.squashfs, block size 131072.
-    ...
+   # Create an image file 'inputs.squashfs' and put the files from
+   # inputs/ into it's root directory
+   $ mksquashfs inputs/ inputs.squashfs
+   Parallel mksquashfs: Using 16 processors
+   Creating 4.0 filesystem on inputs.squashfs, block size 131072.
+   ...
 
-    # Run {Singularity}, mounting my input data to '/input-data' in
-    # the container.
-    $ singularity run -B inputs.squashfs:/input-data:image-src=/ mycontainer.sif
-    Singularity> ls /input-data/
-    1  2  3  4  5  6  7  8  9
+   # Run {Singularity}, mounting my input data to '/input-data' in
+   # the container.
+   $ singularity run -B inputs.squashfs:/input-data:image-src=/ mycontainer.sif
+   Singularity> ls /input-data/
+   1  2  3  4  5  6  7  8  9
 
-    # Or with --mount instead of -B
-    $ singularity run \
-        --mount type=bind,src=src-inputs.squashfs,dst=/input-data,image-src=/ \
-	mycontainer.sif
+   # Or with --mount instead of -B
+   $ singularity run \
+       --mount type=bind,src=src-inputs.squashfs,dst=/input-data,image-src=/ \
+       mycontainer.sif
 
 SIF Image Files
 ===============
 
 Advanced users may wish to create a standalone SIF image, which contains
 an ``ext3`` or ``squashfs`` data partition holding files, by using the
-``singularity sif`` commands similarly to the :ref:`persistent
-overlays instructions<overlay-sif>`:
+``singularity sif`` commands similarly to the :ref:`persistent overlays
+instructions <overlay-sif>`:
 
-.. code-block:: console
+.. code:: console
 
-    # Create a new empty SIF file
-    $ singularity sif new inputs.sif
+   # Create a new empty SIF file
+   $ singularity sif new inputs.sif
 
-    # Add the squashfs data image from above to the SIF
-    $ singularity sif add --datatype 4 --partarch 2 --partfs 1 --parttype 3 inputs.sif inputs.squashfs
+   # Add the squashfs data image from above to the SIF
+   $ singularity sif add --datatype 4 --partarch 2 --partfs 1 --parttype 3 inputs.sif inputs.squashfs
 
-    # Run {Singularity}, binding data from the SIF file
-    $ singularity run -B inputs.sif:/input-data:image-src=/ mycontainer.sif
-    Singularity> ls /input-data
-    1  2  3  4  5  6  7  8  9
+   # Run {Singularity}, binding data from the SIF file
+   $ singularity run -B inputs.sif:/input-data:image-src=/ mycontainer.sif
+   Singularity> ls /input-data
+   1  2  3  4  5  6  7  8  9
 
-    # Or with --mount instead of -B
-    $ singularity run \
-        --mount type=bind,src=inputs.sif,dst=/input-data,image-src=/ \
-	mycontainer.sif
+   # Or with --mount instead of -B
+   $ singularity run \
+       --mount type=bind,src=inputs.sif,dst=/input-data,image-src=/ \
+       mycontainer.sif
 
-If your bind source is a SIF then {Singularity} will bind from the
-first data partition in the SIF, or you may specify an alternative
-descriptor by ID with the additional option ``id=n``, where n is the
-descriptor ID.
+If your bind source is a SIF then {Singularity} will bind from the first
+data partition in the SIF, or you may specify an alternative descriptor
+by ID with the additional option ``id=n``, where n is the descriptor ID.

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -7,7 +7,7 @@
 .. _sec:bindpaths:
 
 Unless `disabled by the system administrator
-<\{admindocs\}/configfiles.html#bind-mount-management>`_,
+<{admindocs}/configfiles.html#bind-mount-management>`_,
 {Singularity} allows you to map directories on your host system to
 directories within your container using bind mounts. This allows you to
 read and write data on the host system with ease.
@@ -68,7 +68,7 @@ Multiple mounts can be disabled by specifying them separated by commas:
 *************************
 
 Unless the system administrator has `disabled user control of binds
-<\{admindocs\}/configfiles.html#bind-mount-management>`_,
+<{admindocs}/configfiles.html#bind-mount-management>`_,
 you will be able to request your own bind paths within your container.
 
 The {Singularity} action commands (``run``, ``exec``, ``shell``, and

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -60,7 +60,7 @@ You can use the build command to download a container from the Container
 Library.
 
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build lolcow.sif library://lolcow
 
@@ -77,7 +77,7 @@ Downloading an existing container from Docker Hub
 You can use ``build`` to download layers from Docker Hub and assemble them into
 {Singularity} containers.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build lolcow.sif docker://sylabsio/lolcow
 
@@ -92,7 +92,7 @@ sandbox) you can do so with the ``--sandbox`` option. It’s possible to create 
 sandbox without root privileges, but to ensure proper file permissions it is
 recommended to do so as root.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build --sandbox lolcow/ library://lolcow
 
@@ -101,7 +101,7 @@ changes within the container, use the ``--writable`` flag when you invoke your
 container.  It’s a good idea to do this as root to ensure you have permission to
 access the files and directories that you want to change.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity shell --writable lolcow/
 
@@ -114,7 +114,7 @@ build a new container. This allows you convert containers from one format to
 another. For example if you had a sandbox container called ``development/`` and
 you wanted to convert it to SIF container called ``production.sif`` you could:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build production.sif development/
 
@@ -152,7 +152,7 @@ and you want to use it to build a SIF container.
 
 You can do so with the following command.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build lolcow.sif lolcow.def
 

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -1,246 +1,249 @@
 .. _build-a-container:
 
-
-=================
-Build a Container
-=================
+###################
+ Build a Container
+###################
 
 .. _sec:build_a_container:
 
-``build`` is the “Swiss army knife” of container creation. You can use it to
-download and assemble existing containers from external resources like the
-`Container Library <https://cloud.sylabs.io/library>`_ and
-`Docker Hub <https://hub.docker.com/>`_. You can use it to convert containers
-between the formats supported by {Singularity}. And you can use it in conjunction
-with a :ref:`{Singularity} definition <definition-files>` file to create a
-container from scratch and customized it to fit your needs.
+``build`` is the “Swiss army knife” of container creation. You can use
+it to download and assemble existing containers from external resources
+like the `Container Library <https://cloud.sylabs.io/library>`_ and
+`Docker Hub <https://hub.docker.com/>`_. You can use it to convert
+containers between the formats supported by {Singularity}. And you can
+use it in conjunction with a :ref:`{Singularity} definition
+<definition-files>` file to create a container from scratch and
+customized it to fit your needs.
 
---------
-Overview
---------
+**********
+ Overview
+**********
 
+The ``build`` command accepts a target as input and produces a container
+as output.
 
-The ``build`` command accepts a target as input and produces a container as
-output.
-
-The target defines the method that ``build`` uses to create the container. It
-can be one of the following:
-
+The target defines the method that ``build`` uses to create the
+container. It can be one of the following:
 
 -  URI beginning with **library://** to build from the Container Library
-
 -  URI beginning with **docker://** to build from Docker Hub
-
 -  URI beginning with **shub://** to build from Singularity Hub
-
 -  path to a **existing container** on your local machine
-
 -  path to a **directory** to build from a sandbox
-
 -  path to a :ref:`{Singularity} definition file <definition-files>`
 
-``build`` can produce containers in two different formats that can be specified
-as follows.
+``build`` can produce containers in two different formats that can be
+specified as follows.
 
--  compressed read-only **Singularity Image File (SIF)** format suitable for
-   production (default)
+-  compressed read-only **Singularity Image File (SIF)** format suitable
+   for production (default)
+-  writable **(ch)root directory** called a sandbox for interactive
+   development ( ``--sandbox`` option)
 
--  writable **(ch)root directory** called a sandbox for interactive development
-   ( ``--sandbox`` option)
+Because ``build`` can accept an existing container as a target and
+create a container in either supported format you can convert existing
+containers from one format to another.
 
-Because ``build`` can accept an existing container as a target and create a
-container in either supported format you can convert existing containers from
-one format to another.
-
-------------------------------------------------------------
-Downloading an existing container from the Container Library
-------------------------------------------------------------
+**************************************************************
+ Downloading an existing container from the Container Library
+**************************************************************
 
 You can use the build command to download a container from the Container
 Library.
 
+.. code::
 
-.. code-block::
-
-    $ sudo singularity build lolcow.sif library://lolcow
+   $ sudo singularity build lolcow.sif library://lolcow
 
 The first argument (``lolcow.sif``) specifies a path and name for your
-container. The second argument (``library://lolcow``) gives
-the Container Library URI from which to download. By default the container will
-be converted to a compressed, read-only SIF. If you want your container in a
-writable format use the ``--sandbox`` option.
+container. The second argument (``library://lolcow``) gives the
+Container Library URI from which to download. By default the container
+will be converted to a compressed, read-only SIF. If you want your
+container in a writable format use the ``--sandbox`` option.
 
--------------------------------------------------
-Downloading an existing container from Docker Hub
--------------------------------------------------
+***************************************************
+ Downloading an existing container from Docker Hub
+***************************************************
 
-You can use ``build`` to download layers from Docker Hub and assemble them into
-{Singularity} containers.
+You can use ``build`` to download layers from Docker Hub and assemble
+them into {Singularity} containers.
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build lolcow.sif docker://sylabsio/lolcow
+   $ sudo singularity build lolcow.sif docker://sylabsio/lolcow
 
 .. _create_a_writable_container:
 
--------------------------------------------
-Creating writable ``--sandbox`` directories
--------------------------------------------
+*********************************************
+ Creating writable ``--sandbox`` directories
+*********************************************
 
-If you wanted to create a container within a writable directory (called a
-sandbox) you can do so with the ``--sandbox`` option. It’s possible to create a
-sandbox without root privileges, but to ensure proper file permissions it is
-recommended to do so as root.
+If you wanted to create a container within a writable directory (called
+a sandbox) you can do so with the ``--sandbox`` option. It’s possible to
+create a sandbox without root privileges, but to ensure proper file
+permissions it is recommended to do so as root.
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build --sandbox lolcow/ library://lolcow
+   $ sudo singularity build --sandbox lolcow/ library://lolcow
 
-The resulting directory operates just like a container in a SIF file. To make
-changes within the container, use the ``--writable`` flag when you invoke your
-container.  It’s a good idea to do this as root to ensure you have permission to
-access the files and directories that you want to change.
+The resulting directory operates just like a container in a SIF file. To
+make changes within the container, use the ``--writable`` flag when you
+invoke your container. It’s a good idea to do this as root to ensure you
+have permission to access the files and directories that you want to
+change.
 
-.. code-block::
+.. code::
 
-    $ sudo singularity shell --writable lolcow/
+   $ sudo singularity shell --writable lolcow/
 
-------------------------------------------------
-Converting containers from one format to another
-------------------------------------------------
+**************************************************
+ Converting containers from one format to another
+**************************************************
 
-If you already have a container saved locally, you can use it as a target to
-build a new container. This allows you convert containers from one format to
-another. For example if you had a sandbox container called ``development/`` and
-you wanted to convert it to SIF container called ``production.sif`` you could:
+If you already have a container saved locally, you can use it as a
+target to build a new container. This allows you convert containers from
+one format to another. For example if you had a sandbox container called
+``development/`` and you wanted to convert it to SIF container called
+``production.sif`` you could:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build production.sif development/
+   $ sudo singularity build production.sif development/
 
-Use care when converting a sandbox directory to the default SIF format. If
-changes were made to the writable container before conversion, there is no
-record of those changes in the {Singularity} definition file rendering your
-container non-reproducible. It is a best practice to build your immutable
-production containers directly from a {Singularity} definition file instead.
+Use care when converting a sandbox directory to the default SIF format.
+If changes were made to the writable container before conversion, there
+is no record of those changes in the {Singularity} definition file
+rendering your container non-reproducible. It is a best practice to
+build your immutable production containers directly from a {Singularity}
+definition file instead.
 
--------------------------------------------------------
-Building containers from {Singularity} definition files
--------------------------------------------------------
+*********************************************************
+ Building containers from {Singularity} definition files
+*********************************************************
 
-Of course, {Singularity} definition files can be used as the target when building
-a container. For detailed information on writing {Singularity} definition files,
-please see the :doc:`Container Definition docs <definition_files>`. Let’s say
-you already have the following container definition file called ``lolcow.def``,
-and you want to use it to build a SIF container.
+Of course, {Singularity} definition files can be used as the target when
+building a container. For detailed information on writing {Singularity}
+definition files, please see the :doc:`Container Definition docs
+<definition_files>`. Let’s say you already have the following container
+definition file called ``lolcow.def``, and you want to use it to build a
+SIF container.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: docker
-    From: ubuntu:16.04
+   Bootstrap: docker
+   From: ubuntu:16.04
 
-    %post
-        apt-get -y update
-        apt-get -y install cowsay lolcat
+   %post
+       apt-get -y update
+       apt-get -y install cowsay lolcat
 
-    %environment
-        export LC_ALL=C
-        export PATH=/usr/games:$PATH
+   %environment
+       export LC_ALL=C
+       export PATH=/usr/games:$PATH
 
-    %runscript
-        date | cowsay | lolcat
+   %runscript
+       date | cowsay | lolcat
 
 You can do so with the following command.
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build lolcow.sif lolcow.def
+   $ sudo singularity build lolcow.sif lolcow.def
 
-The command requires ``sudo`` just as installing software on your local machine
-requires root privileges.
-
+The command requires ``sudo`` just as installing software on your local
+machine requires root privileges.
 
 .. note::
-    Beware that it is possible to build an image on a host and have the image not work on a different host. This could be because of
-    the default compressor supported by the host. For example, when building an image on a host in which the default compressor
-    is ``xz`` and then trying to run that image on a CentOS 6 node, where the only compressor available is ``gzip``.
 
------------------------------
-Building encrypted containers
------------------------------
-Beginning in {Singularity} 3.4.0 it is possible to build and run encrypted
-containers.  The containers are decrypted at runtime entirely in kernel space,
-meaning that no intermediate decrypted data is ever present on disk or in
-memory.  See :ref:`encrypted containers <encryption>` for more details.
+   Beware that it is possible to build an image on a host and have the
+   image not work on a different host. This could be because of the
+   default compressor supported by the host. For example, when building
+   an image on a host in which the default compressor is ``xz`` and then
+   trying to run that image on a CentOS 6 node, where the only
+   compressor available is ``gzip``.
 
--------------
-Build options
--------------
+*******************************
+ Building encrypted containers
+*******************************
+
+Beginning in {Singularity} 3.4.0 it is possible to build and run
+encrypted containers. The containers are decrypted at runtime entirely
+in kernel space, meaning that no intermediate decrypted data is ever
+present on disk or in memory. See :ref:`encrypted containers
+<encryption>` for more details.
+
+***************
+ Build options
+***************
 
 ``--builder``
 =============
 
 {Singularity} 3.0 introduces the option to perform a remote build. The
-``--builder`` option allows you to specify a URL to a different build service.
-For instance, you may need to specify a URL to build to an on premises
-installation of the remote builder.  This option must be used in conjunction
-with ``--remote``.
+``--builder`` option allows you to specify a URL to a different build
+service. For instance, you may need to specify a URL to build to an on
+premises installation of the remote builder. This option must be used in
+conjunction with ``--remote``.
 
 ``--detached``
 ==============
 
-When used in combination with the ``--remote`` option, the ``--detached`` option
-will detach the build from your terminal and allow it to build in the background
-without echoing any output to your terminal.
+When used in combination with the ``--remote`` option, the
+``--detached`` option will detach the build from your terminal and allow
+it to build in the background without echoing any output to your
+terminal.
 
 ``--encrypt``
-==============
+=============
 
 Specifies that {Singularity} should use a secret saved in either the
-``SINGULARITY_ENCRYPTION_PASSPHRASE`` or ``SINGULARITY_ENCRYPTION_PEM_PATH``
-environment variable to build an encrypted container.  See :ref:`encrypted
-containers <encryption>` for more details.
+``SINGULARITY_ENCRYPTION_PASSPHRASE`` or
+``SINGULARITY_ENCRYPTION_PEM_PATH`` environment variable to build an
+encrypted container. See :ref:`encrypted containers <encryption>` for
+more details.
 
 ``--fakeroot``
 ==============
 
-Gives users a way to build containers completely unprivileged.  See :ref:`the
-fakeroot feature <fakeroot>` for details.
+Gives users a way to build containers completely unprivileged. See
+:ref:`the fakeroot feature <fakeroot>` for details.
 
 ``--force``
 ===========
 
-The ``--force`` option will delete and overwrite an existing {Singularity} image
-without presenting the normal interactive prompt.
+The ``--force`` option will delete and overwrite an existing
+{Singularity} image without presenting the normal interactive prompt.
 
 ``--json``
 ==========
 
-The ``--json`` option will force {Singularity} to interpret a given definition
-file as a json.
+The ``--json`` option will force {Singularity} to interpret a given
+definition file as a json.
 
 ``--library``
 =============
 
-This command allows you to set a different library.  (The default library is
-"https://library.sylabs.io")
+This command allows you to set a different library. (The default library
+is "https://library.sylabs.io")
 
 ``--notest``
 ============
 
-If you don’t want to run the ``%test`` section during the container build, you
-can skip it with the ``--notest`` option. For instance, maybe you are building a
-container intended to run in a production environment with GPUs. But perhaps
-your local build resource does not have GPUs. You want to include a ``%test``
-section that runs a short validation but you don’t want your build to exit with
-an error because it cannot find a GPU on your system.
+If you don’t want to run the ``%test`` section during the container
+build, you can skip it with the ``--notest`` option. For instance, maybe
+you are building a container intended to run in a production environment
+with GPUs. But perhaps your local build resource does not have GPUs. You
+want to include a ``%test`` section that runs a short validation but you
+don’t want your build to exit with an error because it cannot find a GPU
+on your system.
 
 ``--passphrase``
 ================
 
-This flag allows you to pass a plaintext passphrase to encrypt the container
-file system at build time. See :ref:`encrypted containers <encryption>` for more
-details.
+This flag allows you to pass a plaintext passphrase to encrypt the
+container file system at build time. See :ref:`encrypted containers
+<encryption>` for more details.
 
 ``--pem-path``
 ==============
@@ -252,9 +255,9 @@ container file system at build time. See :ref:`encrypted containers
 ``--remote``
 ============
 
-{Singularity} 3.0 introduces the ability to build a container on an external
-resource running a remote builder.  (The default remote builder is located at
-"https://cloud.sylabs.io/builder".)
+{Singularity} 3.0 introduces the ability to build a container on an
+external resource running a remote builder. (The default remote builder
+is located at "https://cloud.sylabs.io/builder".)
 
 ``--sandbox``
 =============
@@ -264,37 +267,39 @@ Build a sandbox (chroot directory) instead of the default SIF format.
 ``--section``
 =============
 
-Instead of running the entire definition file, only run a specific section or
-sections.  This option accepts a comma delimited string of definition file
-sections.  Acceptable arguments include ``all``, ``none`` or any combination of
-the following: ``setup``, ``post``, ``files``, ``environment``, ``test``,
-``labels``.
+Instead of running the entire definition file, only run a specific
+section or sections. This option accepts a comma delimited string of
+definition file sections. Acceptable arguments include ``all``, ``none``
+or any combination of the following: ``setup``, ``post``, ``files``,
+``environment``, ``test``, ``labels``.
 
-Under normal build conditions, the {Singularity} definition file is saved into
-a container’s meta-data so that there is a record showing how the container was
-built. Using the ``--section`` option may render this meta-data useless, so use
-care if you value reproducibility.
+Under normal build conditions, the {Singularity} definition file is
+saved into a container’s meta-data so that there is a record showing how
+the container was built. Using the ``--section`` option may render this
+meta-data useless, so use care if you value reproducibility.
 
 ``--update``
 ============
 
-You can build into the same sandbox container multiple times (though the results
-may be unpredictable and it is generally better to delete your container and
-start from scratch).
+You can build into the same sandbox container multiple times (though the
+results may be unpredictable and it is generally better to delete your
+container and start from scratch).
 
-By default if you build into an existing sandbox container, the  ``build``
-command will prompt you to decide whether or not to overwrite the container.
-Instead of this behavior you can use the ``--update`` option to build _into_ an
-existing container. This will cause {Singularity} to skip the header and build
-any sections that are in the definition file into the existing container.
+By default if you build into an existing sandbox container, the
+``build`` command will prompt you to decide whether or not to overwrite
+the container. Instead of this behavior you can use the ``--update``
+option to build _into_ an existing container. This will cause
+{Singularity} to skip the header and build any sections that are in the
+definition file into the existing container.
 
 The ``--update`` option is only valid when used with sandbox containers.
 
 ``--nv``
 ========
 
-This flag allows you to mount the Nvidia CUDA libraries of your host into your build
-environment. Libraries are mounted during the execution of ``post`` and ``test`` sections.
+This flag allows you to mount the Nvidia CUDA libraries of your host
+into your build environment. Libraries are mounted during the execution
+of ``post`` and ``test`` sections.
 
 .. note::
 
@@ -305,8 +310,9 @@ environment. Libraries are mounted during the execution of ``post`` and ``test``
 ``--rocm``
 ==========
 
-This flag allows you to mount the AMD Rocm libraries of your host into your build
-environment. Libraries are mounted during the execution of ``post`` and ``test`` sections.
+This flag allows you to mount the AMD Rocm libraries of your host into
+your build environment. Libraries are mounted during the execution of
+``post`` and ``test`` sections.
 
 .. note::
 
@@ -317,10 +323,11 @@ environment. Libraries are mounted during the execution of ``post`` and ``test``
 ``--bind``
 ==========
 
-This flag allows you to mount a directory, a file or an image during build, it works
-the same way as ``--bind`` for ``shell``, ``exec`` and ``run`` and can be specified
-multiple times, see :ref:`user defined bind paths <user-defined-bind-paths>`.
-Bind mount occurs during the execution of ``post`` and ``test`` sections.
+This flag allows you to mount a directory, a file or an image during
+build, it works the same way as ``--bind`` for ``shell``, ``exec`` and
+``run`` and can be specified multiple times, see :ref:`user defined bind
+paths <user-defined-bind-paths>`. Bind mount occurs during the execution
+of ``post`` and ``test`` sections.
 
 .. note::
 
@@ -349,20 +356,22 @@ tmpfs overlay filesystem in place. This allows the tests to create
 files, which will be discarded at the end of the build. Other portions
 of the build do not use this temporary filesystem.
 
------------------
-More Build topics
------------------
+*******************
+ More Build topics
+*******************
 
--  If you want to **customize the cache location** (where Docker layers are
-   downloaded on your system), specify Docker credentials, or any custom tweaks
-   to your build environment, see :ref:`build environment <build-environment>`.
+-  If you want to **customize the cache location** (where Docker layers
+   are downloaded on your system), specify Docker credentials, or any
+   custom tweaks to your build environment, see :ref:`build environment
+   <build-environment>`.
 
--  If you want to make internally **modular containers**, check out the getting
-   started guide `here <https://sci-f.github.io/tutorials>`_
+-  If you want to make internally **modular containers**, check out the
+   getting started guide `here <https://sci-f.github.io/tutorials>`_
 
--  If you want to **build your containers** on the Remote Builder, (because you
-   don’t have root access on a Linux machine or want to host your container on
-   the cloud) check out `this site <https://cloud.sylabs.io/builder>`_
+-  If you want to **build your containers** on the Remote Builder,
+   (because you don’t have root access on a Linux machine or want to
+   host your container on the cloud) check out `this site
+   <https://cloud.sylabs.io/builder>`_
 
--  If you want to **build a container with an encrypted file system** look
-   :ref:`here <encryption>`.
+-  If you want to **build a container with an encrypted file system**
+   look :ref:`here <encryption>`.

--- a/build_env.rst
+++ b/build_env.rst
@@ -1,56 +1,58 @@
 .. _build-environment:
 
-=================
-Build Environment
-=================
+###################
+ Build Environment
+###################
 
 .. _sec:buildenv:
 
---------
-Overview
---------
+**********
+ Overview
+**********
 
-You may wish to customize your build
-environment by doing things such as specifying a custom cache directory for images or
-sending your Docker Credentials to the registry endpoint. Here we will discuss these and other topics
-related to the build environment.
+You may wish to customize your build environment by doing things such as
+specifying a custom cache directory for images or sending your Docker
+Credentials to the registry endpoint. Here we will discuss these and
+other topics related to the build environment.
 
 .. _sec:cache:
 
--------------
-Cache Folders
--------------
+***************
+ Cache Folders
+***************
 
 {Singularity} will cache SIF container images generated from remote
 sources, and any OCI/docker layers used to create them. The cache is
-created at ``$HOME/.singularity/cache`` by default. The location of
-the cache can be changed by setting the ``SINGULARITY_CACHEDIR``
-environment variable.
+created at ``$HOME/.singularity/cache`` by default. The location of the
+cache can be changed by setting the ``SINGULARITY_CACHEDIR`` environment
+variable.
 
-When you run builds as root, using ``sudo``, images will be cached
-in root’s home at ``/root`` and not your user’s home. Use the
-``-E`` option to sudo to pass through the ``SINGULARITY_CACHEDIR``
-environment variable, if you set it.
+When you run builds as root, using ``sudo``, images will be cached in
+root’s home at ``/root`` and not your user’s home. Use the ``-E`` option
+to sudo to pass through the ``SINGULARITY_CACHEDIR`` environment
+variable, if you set it.
 
-.. code-block::
+.. code::
 
-    $ export SINGULARITY_CACHEDIR=/tmp/user/temporary-cache
+   $ export SINGULARITY_CACHEDIR=/tmp/user/temporary-cache
 
-    # Running a build under your user account
-    $ singularity build --fakeroot myimage.sif mydef.def
+   # Running a build under your user account
+   $ singularity build --fakeroot myimage.sif mydef.def
 
-    # Running a build with sudo, must use -E to pass env var
-    $ sudo -E singularity build myimage.sif mydef.def
+   # Running a build with sudo, must use -E to pass env var
+   $ sudo -E singularity build myimage.sif mydef.def
 
-If you change the value of ``SINGULARITY_CACHEDIR`` be sure to choose
-a location that is:
+If you change the value of ``SINGULARITY_CACHEDIR`` be sure to choose a
+location that is:
 
- - Unique to you. Permissions are set on the cache so that private
-   images cached for one user are not exposed to another. This means
-   that ``SINGULARITY_CACHEDIR`` cannot be shared.
- - Located on a filesystem with sufficient space for the number and size of
-   container images anticipated.
- - Located on a filesystem that supports atomic rename, if possible.
+   -  Unique to you. Permissions are set on the cache so that private
+      images cached for one user are not exposed to another. This means
+      that ``SINGULARITY_CACHEDIR`` cannot be shared.
+
+   -  Located on a filesystem with sufficient space for the number and
+      size of container images anticipated.
+
+   -  Located on a filesystem that supports atomic rename, if possible.
 
 .. warning::
 
@@ -63,119 +65,116 @@ a location that is:
    {Singularity} instance independently fetching the container from the
    remote source, into a temporary location.
 
-
 Inside the cache location you will find separate directories for the
 different kinds of data that are cached:
 
-.. code-block::
+.. code::
 
-    $HOME/.singularity/cache/blob
-    $HOME/.singularity/cache/library
-    $HOME/.singularity/cache/net
-    $HOME/.singularity/cache/oci-tmp
-    $HOME/.singularity/cache/shub
+   $HOME/.singularity/cache/blob
+   $HOME/.singularity/cache/library
+   $HOME/.singularity/cache/net
+   $HOME/.singularity/cache/oci-tmp
+   $HOME/.singularity/cache/shub
 
-You can safely delete these directories, or content within
-them. {Singularity} will re-create any directories and data that are
-needed in future runs.
+You can safely delete these directories, or content within them.
+{Singularity} will re-create any directories and data that are needed in
+future runs.
 
 You should not add any additional files, or modify files in the cache,
 as this may cause checksum / integrity errors when you run or build
 containers. If you experience problems use ``singularity cache clean``
 to reset the cache to a clean, empty state.
-    
+
 BoltDB Corruption Errors
 ========================
 
-The library that {Singularity} uses to retrieve and cache Docker/OCI layers
-keeps track of them using a single file database. If your home directory is on a
-network filesystem which experiences interruptions, or you run out of storage,
-it is possible for this database to become inconsistent.
+The library that {Singularity} uses to retrieve and cache Docker/OCI
+layers keeps track of them using a single file database. If your home
+directory is on a network filesystem which experiences interruptions, or
+you run out of storage, it is possible for this database to become
+inconsistent.
 
-If you observe error messages when trying to run {Singularity} that mention
-`github.com/etcd-io/bbolt` then you should remove the database file:
+If you observe error messages when trying to run {Singularity} that
+mention `github.com/etcd-io/bbolt` then you should remove the database
+file:
 
 .. code::
 
-    rm ~/.local/share/containers/cache/blob-info-cache-v1.boltdb
+   rm ~/.local/share/containers/cache/blob-info-cache-v1.boltdb
 
---------------
-Cache commands
---------------
+****************
+ Cache commands
+****************
 
 The ``cache`` command for {Singularity} allows you to view and clean up
 your cache, without manually inspecting the cache directories.
 
 .. note::
 
-   If you have built images as root, directly or via ``sudo``, the
-   cache location for those builds is ``/root/.singularity``. You
-   will need to use ``sudo`` when running ``cache clean`` or ``cache
-   list`` to manage these cache entries.
-
-   
+   If you have built images as root, directly or via ``sudo``, the cache
+   location for those builds is ``/root/.singularity``. You will need to
+   use ``sudo`` when running ``cache clean`` or ``cache list`` to manage
+   these cache entries.
 
 Listing Cache
 =============
 
 To view a summary of cache usage, use ``singularity cache list``:
 
-.. code-block::
+.. code::
 
-    $ singularity cache list
-    There are 4 container file(s) using 59.45 MB and 23 oci blob file(s) using 379.10 MB of space
-    Total space used: 438.55 MB
+   $ singularity cache list
+   There are 4 container file(s) using 59.45 MB and 23 oci blob file(s) using 379.10 MB of space
+   Total space used: 438.55 MB
 
 To view detailed information, use ``singularity cache list -v``:
 
-.. code-block::
+.. code::
 
-    $ singularity cache list -v
-    NAME                     DATE CREATED           SIZE             TYPE
-    0ed5a98249068fe0592edb   2020-05-27 12:57:22    192.21 MB        blob
-    1d9cd1b99a7eca56d8f2be   2020-05-28 15:19:07    0.35 kB          blob
-    219c332183ec3800bdfda4   2020-05-28 12:22:13    0.35 kB          blob
-    2adae3950d4d0f11875568   2020-05-27 12:57:16    51.83 MB         blob
-    376057ac6fa17f65688c56   2020-05-27 12:57:12    50.39 MB         blob
-    496548a8c952b37bdf149a   2020-05-27 12:57:14    10.00 MB         blob
-    5a63a0a859d859478f3046   2020-05-27 12:57:13    7.81 MB          blob
-    5efaeecfa72afde779c946   2020-05-27 12:57:25    0.23 kB          blob
-    6154df8ff9882934dc5bf2   2020-05-27 08:37:22    0.85 kB          blob
-    70d0b3967cd8abe96c9719   2020-05-27 12:57:24    26.61 MB         blob
-    8f5af4048c33630473b396   2020-05-28 15:19:07    0.57 kB          blob
-    95c3f3755f37380edb2f8f   2020-05-28 14:07:20    2.48 kB          blob
-    96878229af8adf91bcbf11   2020-05-28 14:07:20    0.81 kB          blob
-    af88fdb253aac46693de78   2020-05-28 12:22:13    0.58 kB          blob
-    bb94ffe723890b4d62d742   2020-05-27 12:57:23    6.15 MB          blob
-    c080bf936f6a1fdd2045e3   2020-05-27 12:57:25    1.61 kB          blob
-    cbdbe7a5bc2a134ca8ec91   2020-05-28 12:22:13    2.81 MB          blob
-    d51af753c3d3a984351448   2020-05-27 08:37:21    28.56 MB         blob
-    d9cbbca60e5f0fc028b13c   2020-05-28 15:19:06    760.85 kB        blob
-    db8816f445487e48e1d614   2020-05-27 12:57:25    1.93 MB          blob
-    fc878cd0a91c7bece56f66   2020-05-27 08:37:22    32.30 kB         blob
-    fee5db0ff82f7aa5ace634   2020-05-27 08:37:22    0.16 kB          blob
-    ff110406d51ca9ea722112   2020-05-27 12:57:25    7.78 kB          blob
-    sha256.02ee8bf9dc335c2   2020-05-29 13:45:14    28.11 MB         library
-    sha256.5111f59250ac94f   2020-05-28 13:14:39    782.34 kB        library
-    747d2dbbaaee995098c979   2020-05-28 14:07:22    27.77 MB         oci-tmp
-    9a839e63dad54c3a6d1834   2020-05-28 12:22:13    2.78 MB          oci-tmp
+   $ singularity cache list -v
+   NAME                     DATE CREATED           SIZE             TYPE
+   0ed5a98249068fe0592edb   2020-05-27 12:57:22    192.21 MB        blob
+   1d9cd1b99a7eca56d8f2be   2020-05-28 15:19:07    0.35 kB          blob
+   219c332183ec3800bdfda4   2020-05-28 12:22:13    0.35 kB          blob
+   2adae3950d4d0f11875568   2020-05-27 12:57:16    51.83 MB         blob
+   376057ac6fa17f65688c56   2020-05-27 12:57:12    50.39 MB         blob
+   496548a8c952b37bdf149a   2020-05-27 12:57:14    10.00 MB         blob
+   5a63a0a859d859478f3046   2020-05-27 12:57:13    7.81 MB          blob
+   5efaeecfa72afde779c946   2020-05-27 12:57:25    0.23 kB          blob
+   6154df8ff9882934dc5bf2   2020-05-27 08:37:22    0.85 kB          blob
+   70d0b3967cd8abe96c9719   2020-05-27 12:57:24    26.61 MB         blob
+   8f5af4048c33630473b396   2020-05-28 15:19:07    0.57 kB          blob
+   95c3f3755f37380edb2f8f   2020-05-28 14:07:20    2.48 kB          blob
+   96878229af8adf91bcbf11   2020-05-28 14:07:20    0.81 kB          blob
+   af88fdb253aac46693de78   2020-05-28 12:22:13    0.58 kB          blob
+   bb94ffe723890b4d62d742   2020-05-27 12:57:23    6.15 MB          blob
+   c080bf936f6a1fdd2045e3   2020-05-27 12:57:25    1.61 kB          blob
+   cbdbe7a5bc2a134ca8ec91   2020-05-28 12:22:13    2.81 MB          blob
+   d51af753c3d3a984351448   2020-05-27 08:37:21    28.56 MB         blob
+   d9cbbca60e5f0fc028b13c   2020-05-28 15:19:06    760.85 kB        blob
+   db8816f445487e48e1d614   2020-05-27 12:57:25    1.93 MB          blob
+   fc878cd0a91c7bece56f66   2020-05-27 08:37:22    32.30 kB         blob
+   fee5db0ff82f7aa5ace634   2020-05-27 08:37:22    0.16 kB          blob
+   ff110406d51ca9ea722112   2020-05-27 12:57:25    7.78 kB          blob
+   sha256.02ee8bf9dc335c2   2020-05-29 13:45:14    28.11 MB         library
+   sha256.5111f59250ac94f   2020-05-28 13:14:39    782.34 kB        library
+   747d2dbbaaee995098c979   2020-05-28 14:07:22    27.77 MB         oci-tmp
+   9a839e63dad54c3a6d1834   2020-05-28 12:22:13    2.78 MB          oci-tmp
 
-    There are 4 container file(s) using 59.45 MB and 23 oci blob file(s) using 379.10 MB of space
-    Total space used: 438.55 MB
+   There are 4 container file(s) using 59.45 MB and 23 oci blob file(s) using 379.10 MB of space
+   Total space used: 438.55 MB
 
 All cache entries are named using a content hash, so that identical
-layers or images that are pulled from different URIs do not consume
-more space than needed.
-    
+layers or images that are pulled from different URIs do not consume more
+space than needed.
+
 Entries marked ``blob`` are OCI/docker layers and manifests, that are
-used to create SIF format images in the ``oci-tmp`` cache. Other
-caches are named for the source of the image e.g. ``library`` and
-``oras``.
+used to create SIF format images in the ``oci-tmp`` cache. Other caches
+are named for the source of the image e.g. ``library`` and ``oras``.
 
-You can limit the cache list to a specific cache type with the
-``-type`` / ``-t`` option.
+You can limit the cache list to a specific cache type with the ``-type``
+/ ``-t`` option.
 
-    
 Cleaning the Cache
 ==================
 
@@ -185,57 +184,55 @@ cache clean``.
 By default ``singularity cache clean`` will remove all cache entries,
 after asking you to confirm:
 
-.. code-block::
+.. code::
 
-    $ singularity cache clean
-    This will delete everything in your cache (containers from all sources and OCI blobs). 
-    Hint: You can see exactly what would be deleted by canceling and using the --dry-run option.
-    Do you want to continue? [N/y] n
+   $ singularity cache clean
+   This will delete everything in your cache (containers from all sources and OCI blobs).
+   Hint: You can see exactly what would be deleted by canceling and using the --dry-run option.
+   Do you want to continue? [N/y] n
 
 Use the ``--dry-run`` / ``-n`` option to see the files that would be
-deleted, or the ``--force`` / ``-f`` option to clean without asking
-for confirmation.
+deleted, or the ``--force`` / ``-f`` option to clean without asking for
+confirmation.
 
-If you want to leave your most recent cached images in place, but
-remove images that were cached longer ago, you can use the ``--days``
-/ ``-d`` option. E.g. to clean cache entries older than 30 days:
+If you want to leave your most recent cached images in place, but remove
+images that were cached longer ago, you can use the ``--days`` / ``-d``
+option. E.g. to clean cache entries older than 30 days:
 
-.. code-block::
+.. code::
 
-    $ singularity cache clean --days 30
+   $ singularity cache clean --days 30
 
-To remove only a specific kind of cache entry, e.g. only library
-images, use the ``type`` / ``-T`` option:
+To remove only a specific kind of cache entry, e.g. only library images,
+use the ``type`` / ``-T`` option:
 
-.. code-block::
+.. code::
 
-    $ singularity cache clean --type library
-
+   $ singularity cache clean --type library
 
 .. _sec:temporaryfolders:
 
------------------
-Temporary Folders
------------------
+*******************
+ Temporary Folders
+*******************
 
 When building a container, or pulling/running a {Singularity} container
 from a Docker/OCI source, a temporary working space is required. The
 container is constructed in this temporary space before being packaged
 into a {Singularity} SIF image. Temporary space is also used when
-running containers in unprivileged mode, and performing some
-operations on filesystems that do not fully support ``--fakeroot``.
+running containers in unprivileged mode, and performing some operations
+on filesystems that do not fully support ``--fakeroot``.
 
-The location for temporary directories defaults to
-``/tmp``. {Singularity} will also respect the environment variable
-``TMPDIR``, and both of these locations can be overridden by setting
-the environment variable ``SINGULARITY_TMPDIR``.
+The location for temporary directories defaults to ``/tmp``.
+{Singularity} will also respect the environment variable ``TMPDIR``, and
+both of these locations can be overridden by setting the environment
+variable ``SINGULARITY_TMPDIR``.
 
-The temporary directory used during a build must be on a filesystem
-that has enough space to hold the entire container image,
-uncompressed, including any temporary files that are created and later
-removed during the build. You may need to set ``SINGULARITY_TMPDIR``
-when building a large container on a system which has a small ``/tmp``
-filesystem.
+The temporary directory used during a build must be on a filesystem that
+has enough space to hold the entire container image, uncompressed,
+including any temporary files that are created and later removed during
+the build. You may need to set ``SINGULARITY_TMPDIR`` when building a
+large container on a system which has a small ``/tmp`` filesystem.
 
 Remember to use ``-E`` option to pass the value of
 ``SINGULARITY_TMPDIR`` to root's environment when executing the
@@ -243,37 +240,39 @@ Remember to use ``-E`` option to pass the value of
 
 .. warning::
 
-   Many modern Linux distributions use an in-memory ``tmpfs``
-   filesystem for ``/tmp`` when installed on a computer with a
-   sufficient amount of RAM. This may limit the size of container you
-   can build, as temporary directories under ``/tmp`` share RAM with
-   runniing programs etc. A ``tmpfs`` also uses default mount options
-   that can interfere with some container builds.
+   Many modern Linux distributions use an in-memory ``tmpfs`` filesystem
+   for ``/tmp`` when installed on a computer with a sufficient amount of
+   RAM. This may limit the size of container you can build, as temporary
+   directories under ``/tmp`` share RAM with runniing programs etc. A
+   ``tmpfs`` also uses default mount options that can interfere with
+   some container builds.
 
    Set ``SINGULARITY_TMPDIR`` to a disk location, or disable the
-   ``tmpfs`` ``/tmp`` mount on your system if you experience
-   problems.
+   ``tmpfs`` ``/tmp`` mount on your system if you experience problems.
 
- 
---------------------
-Encrypted Containers
---------------------
+**********************
+ Encrypted Containers
+**********************
 
-Beginning in {Singularity} 3.4.0 it is possible to build and run encrypted
-containers.  The containers are decrypted at runtime entirely in kernel space, 
-meaning that no intermediate decrypted data is ever present on disk or in 
-memory.  See :ref:`encrypted containers <encryption>` for more details.
+Beginning in {Singularity} 3.4.0 it is possible to build and run
+encrypted containers. The containers are decrypted at runtime entirely
+in kernel space, meaning that no intermediate decrypted data is ever
+present on disk or in memory. See :ref:`encrypted containers
+<encryption>` for more details.
 
----------------------
-Environment Variables
----------------------
+***********************
+ Environment Variables
+***********************
 
-#. If a flag is represented by both a CLI option and an environment variable, and both are set, the CLI option will always take precedence. This is true for all environment variables except for ``SINGULARITY_BIND`` and ``SINGULARITY_BINDPATH`` which is combined with the ``--bind`` option, argument pair if both are present.
+#. If a flag is represented by both a CLI option and an environment
+   variable, and both are set, the CLI option will always take
+   precedence. This is true for all environment variables except for
+   ``SINGULARITY_BIND`` and ``SINGULARITY_BINDPATH`` which is combined
+   with the ``--bind`` option, argument pair if both are present.
 
 #. Environment variables overwrite default values in the CLI code
 
 #. Any defaults in the CLI code are applied.
-
 
 Defaults
 ========
@@ -284,7 +283,8 @@ environment variables at runtime.
 Docker
 ------
 
-**SINGULARITY_DOCKER_LOGIN** Used for the interactive login for Docker Hub.
+**SINGULARITY_DOCKER_LOGIN** Used for the interactive login for Docker
+Hub.
 
 **SINGULARITY_DOCKER_USERNAME** Your Docker username.
 
@@ -295,24 +295,31 @@ hard coded default (“/bin/bash”). This is the fallback command used in
 the case that the docker image does not have a CMD or ENTRYPOINT.
 **TAG** Is the default tag, ``latest``.
 
-**SINGULARITY_NOHTTPS** This is relevant if you want to use a
-registry that doesn’t have https, and it speaks for itself. If you
-export the variable ``SINGULARITY_NOHTTPS`` you can force the software to not use https when
-interacting with a Docker registry. This use case is typically for use
-of a local registry.
+**SINGULARITY_NOHTTPS** This is relevant if you want to use a registry
+that doesn’t have https, and it speaks for itself. If you export the
+variable ``SINGULARITY_NOHTTPS`` you can force the software to not use
+https when interacting with a Docker registry. This use case is
+typically for use of a local registry.
 
 Library
 -------
 
-**SINGULARITY_BUILDER** Used to specify the remote builder service URL. The default value is our remote builder.
+**SINGULARITY_BUILDER** Used to specify the remote builder service URL.
+The default value is our remote builder.
 
-**SINGULARITY_LIBRARY** Used to specify the library to pull from. Default is set to our Cloud Library.
+**SINGULARITY_LIBRARY** Used to specify the library to pull from.
+Default is set to our Cloud Library.
 
-**SINGULARITY_REMOTE** Used to build an image remotely (This does not require root). The default is set to false.
+**SINGULARITY_REMOTE** Used to build an image remotely (This does not
+require root). The default is set to false.
 
 Encryption
 ----------
 
-**SINGULARITY_ENCRYPTION_PASSPHRASE** Used to pass a plaintext passphrase to encrypt a container file system (with the ``--encrypt`` flag). The default is empty.
+**SINGULARITY_ENCRYPTION_PASSPHRASE** Used to pass a plaintext
+passphrase to encrypt a container file system (with the ``--encrypt``
+flag). The default is empty.
 
-**SINGULARITY_ENCRYPTION_PEM_PATH** Used to specify the location of a public key to use for container encryption (with the ``--encrypt`` flag). The default is empty.
+**SINGULARITY_ENCRYPTION_PEM_PATH** Used to specify the location of a
+public key to use for container encryption (with the ``--encrypt``
+flag). The default is empty.

--- a/build_env.rst
+++ b/build_env.rst
@@ -32,7 +32,7 @@ in root’s home at ``/root`` and not your user’s home. Use the
 ``-E`` option to sudo to pass through the ``SINGULARITY_CACHEDIR``
 environment variable, if you set it.
 
-.. code-block:: none
+.. code-block::
 
     $ export SINGULARITY_CACHEDIR=/tmp/user/temporary-cache
 
@@ -67,7 +67,7 @@ a location that is:
 Inside the cache location you will find separate directories for the
 different kinds of data that are cached:
 
-.. code-block:: none
+.. code-block::
 
     $HOME/.singularity/cache/blob
     $HOME/.singularity/cache/library
@@ -120,7 +120,7 @@ Listing Cache
 
 To view a summary of cache usage, use ``singularity cache list``:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity cache list
     There are 4 container file(s) using 59.45 MB and 23 oci blob file(s) using 379.10 MB of space
@@ -128,7 +128,7 @@ To view a summary of cache usage, use ``singularity cache list``:
 
 To view detailed information, use ``singularity cache list -v``:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity cache list -v
     NAME                     DATE CREATED           SIZE             TYPE
@@ -185,7 +185,7 @@ cache clean``.
 By default ``singularity cache clean`` will remove all cache entries,
 after asking you to confirm:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity cache clean
     This will delete everything in your cache (containers from all sources and OCI blobs). 
@@ -200,14 +200,14 @@ If you want to leave your most recent cached images in place, but
 remove images that were cached longer ago, you can use the ``--days``
 / ``-d`` option. E.g. to clean cache entries older than 30 days:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity cache clean --days 30
 
 To remove only a specific kind of cache entry, e.g. only library
 images, use the ``type`` / ``-T`` option:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity cache clean --type library
 

--- a/cgroups.rst
+++ b/cgroups.rst
@@ -41,7 +41,7 @@ For example, assuming your system is configured correctly for unprivileged
 cgroup creation via systemd, you can limit the number of CPUs a container run is
 allowed to use:
 
-.. code-block:: none
+.. code-block::
 
     $ systemd-run --user --scope -p AllowedCPUs=1,2 -- singularity run mycontainer.sif
 
@@ -93,7 +93,7 @@ Examples
 To apply resource limits to a container, use the ``--apply-cgroups`` flag, which
 takes a path to a TOML file specifying the cgroups configuration to be applied:
 
-.. code-block:: none
+.. code-block::
 
   $ sudo singularity shell --apply-cgroups /path/to/cgroups.toml my_container.sif
 
@@ -108,14 +108,14 @@ To limit the amount of memory that your container uses to 500MB (524288000
 bytes), set a ``limit`` value inside the ``[memory]`` section of your cgroups
 TOML file:
 
-.. code-block:: none
+.. code-block::
 
   [memory]
       limit = 524288000
 
 Start your container, applying the toml file, e.g.:
 
-.. code-block:: none
+.. code-block::
 
   $ sudo singularity run --apply-cgroups path/to/cgroups.toml library://alpine
 
@@ -124,7 +124,7 @@ This example assumes that there is only one running container. If you are
 running multiple containers you will find multiple cgroups trees under the
 ``singularity`` directory.
 
-.. code-block:: none
+.. code-block::
 
   # cgroups v1
   $ cat /sys/fs/cgroup/memory/singularity/*/memory.limit_in_bytes
@@ -147,7 +147,7 @@ This corresponds to a ratio versus other cgroups with cpu shares. Usually the
 default value is ``1024``. That means if you want to allow to use 50% of a
 single CPU, you will set ``512`` as value.
 
-.. code-block:: none
+.. code-block::
 
   [cpu]
       shares = 512
@@ -166,7 +166,7 @@ processes can't use more than the amount of CPU time set for the cgroup.
 per period. The default is 100ms (100000us). So if you want to limit amount of
 CPU time to 20ms during period of 100ms:
 
-.. code-block:: none
+.. code-block::
 
   [cpu]
       period = 100000
@@ -177,7 +177,7 @@ CPU time to 20ms during period of 100ms:
 You can also restrict access to specific CPUs (cores) and associated memory
 nodes by using ``cpus/mems`` fields:
 
-.. code-block:: none
+.. code-block::
 
   [cpu]
       cpus = "0-1"
@@ -196,7 +196,7 @@ Limiting IO
 To control block device I/O, applying limits to competing container, use the
 ``[blockIO]`` section of the TOML file:
 
-.. code-block:: none
+.. code-block::
 
   [blockIO]
       weight = 1000
@@ -216,7 +216,7 @@ specific device major/minor numbers. For example, to override
 ``weight/leafWeight`` for ``/dev/loop0`` and ``/dev/loop1`` block devices, set
 limits for device major 7, minor 0 and 1:
 
-.. code-block:: none
+.. code-block::
 
   [blockIO]
       [[blockIO.weightDevice]]
@@ -234,7 +234,7 @@ You can also limit the IO read/write rate to a specific absolute value, e.g.
 16MB per second for the ``/dev/loop0`` block device. The ``rate`` is specified
 in bytes per second.
 
-.. code-block:: none
+.. code-block::
 
   [blockIO]
       [[blockIO.throttleReadBpsDevice]]
@@ -256,7 +256,7 @@ and minor numbers to create rules for specific devices or classes of device.
 In this example, a container is configured to only be able to read from or write
 to ``/dev/null``:
 
-.. code-block:: none
+.. code-block::
 
     [[devices]]
         access = "rwm"

--- a/cgroups.rst
+++ b/cgroups.rst
@@ -1,272 +1,282 @@
 .. _cgroups:
 
-=========================================
-Limiting Container Resources with Cgroups
-=========================================
+###########################################
+ Limiting Container Resources with Cgroups
+###########################################
 
-The cgroups (control groups) functionality of the Linux kernel allows you to
-limit and meter the resources used by a process, or group of processes. Using
-cgroups you can limit memory and CPU usage. You can also rate limit block IO,
-network IO, and control access to device nodes.
+The cgroups (control groups) functionality of the Linux kernel allows
+you to limit and meter the resources used by a process, or group of
+processes. Using cgroups you can limit memory and CPU usage. You can
+also rate limit block IO, network IO, and control access to device
+nodes.
 
-There are two versions of cgroups in common use. Cgroups v1 sets resource limits
-for a process within separate hierarchies per resource class. Cgroups v2, the
-default in newer Linux distributions, implements a unified hierarchy,
-simplifying the structure of resource limits on processes.
+There are two versions of cgroups in common use. Cgroups v1 sets
+resource limits for a process within separate hierarchies per resource
+class. Cgroups v2, the default in newer Linux distributions, implements
+a unified hierarchy, simplifying the structure of resource limits on
+processes.
 
-* v1 documentation: https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
-* v2 documentation: https://www.kernel.org/doc/Documentation/cgroup-v2.txt
+-  v1 documentation:
+   https://www.kernel.org/doc/Documentation/cgroup-v1/cgroups.txt
+-  v2 documentation:
+   https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 
--------------------------------------
-Running {Singularity} Inside a Cgroup
--------------------------------------
+***************************************
+ Running {Singularity} Inside a Cgroup
+***************************************
 
-Because {Singularity} starts a container as a simple process, rather than using
-a daemon, you can limit resource usage by running the ``singularity`` command
-inside an existing cgroup. This is convenient where, for example, a job
-scheduler uses cgroups to control job limits. By running ``singularity`` inside
-your batch script, your container will respect the limits set by the scheduler
-on the job's cgroup.
+Because {Singularity} starts a container as a simple process, rather
+than using a daemon, you can limit resource usage by running the
+``singularity`` command inside an existing cgroup. This is convenient
+where, for example, a job scheduler uses cgroups to control job limits.
+By running ``singularity`` inside your batch script, your container will
+respect the limits set by the scheduler on the job's cgroup.
 
 systemd-run
 ===========
 
-As well as schedulers you can use tools such as ``systemd-run`` to create a
-cgroup, and run {Singularity} inside of it. This is convenient on modern cgroups
-v2 systems, where the creation of cgroups can be delegated to users through
-systemd. Without this delegation ``root`` privileges are required to create a
-cgroup.
+As well as schedulers you can use tools such as ``systemd-run`` to
+create a cgroup, and run {Singularity} inside of it. This is convenient
+on modern cgroups v2 systems, where the creation of cgroups can be
+delegated to users through systemd. Without this delegation ``root``
+privileges are required to create a cgroup.
 
-For example, assuming your system is configured correctly for unprivileged
-cgroup creation via systemd, you can limit the number of CPUs a container run is
-allowed to use:
+For example, assuming your system is configured correctly for
+unprivileged cgroup creation via systemd, you can limit the number of
+CPUs a container run is allowed to use:
 
-.. code-block::
+.. code::
 
-    $ systemd-run --user --scope -p AllowedCPUs=1,2 -- singularity run mycontainer.sif
+   $ systemd-run --user --scope -p AllowedCPUs=1,2 -- singularity run mycontainer.sif
 
-* ``--user`` instructs systemd that we want to run as our own user account.
+-  ``--user`` instructs systemd that we want to run as our own user
+   account.
 
-* ``--scope`` will run our command in an interactive scope that inherits from our
-  environment. By default the command would run as a service, in the background.
+-  ``--scope`` will run our command in an interactive scope that
+   inherits from our environment. By default the command would run as a
+   service, in the background.
 
-* ``-p AllowedCPUs=1,2`` sets a property on our scope, so that in this case
-  systemd will then setup a cgroup limiting our command to using CPU 1 and 2 only.
+-  ``-p AllowedCPUs=1,2`` sets a property on our scope, so that in this
+   case systemd will then setup a cgroup limiting our command to using
+   CPU 1 and 2 only.
 
-* The double hyphen ``--`` separates options for ``systemd-run`` from the actual
-  command we wish to execute. This is important so that ``systemd-run`` doesn't
-  capture any flags we might need to pass to ``singularity``.
+-  The double hyphen ``--`` separates options for ``systemd-run`` from
+   the actual command we wish to execute. This is important so that
+   ``systemd-run`` doesn't capture any flags we might need to pass to
+   ``singularity``.
 
-You can read more about how systemd can control resources uses at the link
-below, which details the properties you can set using ``systemd-run``.
+You can read more about how systemd can control resources uses at the
+link below, which details the properties you can set using
+``systemd-run``.
 
 https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
 
-------------------------------------
-Using Singularity to Create a Cgroup
-------------------------------------
+**************************************
+ Using Singularity to Create a Cgroup
+**************************************
 
-{Singularity} 3.9 and above can directly apply resource limitations to systems
-configured for both cgroups v1 and the v2 unified hierarchy. Resource limits are
-specified using a TOML file that represents the `resources` section of the OCI
-runtime-spec:
+{Singularity} 3.9 and above can directly apply resource limitations to
+systems configured for both cgroups v1 and the v2 unified hierarchy.
+Resource limits are specified using a TOML file that represents the
+`resources` section of the OCI runtime-spec:
 https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#control-groups
 
-On a cgroups v1 system the resources configuration is applied directly. On a
-cgroups v2 system the configuration is translated and applied to the unified
-hierarchy.
+On a cgroups v1 system the resources configuration is applied directly.
+On a cgroups v2 system the configuration is translated and applied to
+the unified hierarchy.
 
-Under cgroups v1, access restrictions for device nodes are managed directly.
-Under cgroups v2, the restrictions are applied by attaching eBPF programs that
-implement the requested access controls.
+Under cgroups v1, access restrictions for device nodes are managed
+directly. Under cgroups v2, the restrictions are applied by attaching
+eBPF programs that implement the requested access controls.
 
 .. note::
 
    {Singularity} does not currently support applying native cgroups v2
-   ``unified`` resource limit specifications. Use the cgroups v1 limits, which
-   will be translated to v2 format when applied on a cgroups v2 system.
-
+   ``unified`` resource limit specifications. Use the cgroups v1 limits,
+   which will be translated to v2 format when applied on a cgroups v2
+   system.
 
 Examples
 ========
 
-To apply resource limits to a container, use the ``--apply-cgroups`` flag, which
-takes a path to a TOML file specifying the cgroups configuration to be applied:
+To apply resource limits to a container, use the ``--apply-cgroups``
+flag, which takes a path to a TOML file specifying the cgroups
+configuration to be applied:
 
-.. code-block::
+.. code::
 
-  $ sudo singularity shell --apply-cgroups /path/to/cgroups.toml my_container.sif
+   $ sudo singularity shell --apply-cgroups /path/to/cgroups.toml my_container.sif
 
 .. note::
 
-  The ``--apply-cgroups`` option can only be used with root privileges.
+   The ``--apply-cgroups`` option can only be used with root privileges.
 
 Limiting Memory
 ---------------
 
-To limit the amount of memory that your container uses to 500MB (524288000
-bytes), set a ``limit`` value inside the ``[memory]`` section of your cgroups
-TOML file:
+To limit the amount of memory that your container uses to 500MB
+(524288000 bytes), set a ``limit`` value inside the ``[memory]`` section
+of your cgroups TOML file:
 
-.. code-block::
+.. code::
 
-  [memory]
-      limit = 524288000
+   [memory]
+       limit = 524288000
 
 Start your container, applying the toml file, e.g.:
 
-.. code-block::
+.. code::
 
-  $ sudo singularity run --apply-cgroups path/to/cgroups.toml library://alpine
+   $ sudo singularity run --apply-cgroups path/to/cgroups.toml library://alpine
 
-After that, you can verify that the container is only using 500MB of memory.
-This example assumes that there is only one running container. If you are
-running multiple containers you will find multiple cgroups trees under the
-``singularity`` directory.
+After that, you can verify that the container is only using 500MB of
+memory. This example assumes that there is only one running container.
+If you are running multiple containers you will find multiple cgroups
+trees under the ``singularity`` directory.
 
-.. code-block::
+.. code::
 
-  # cgroups v1
-  $ cat /sys/fs/cgroup/memory/singularity/*/memory.limit_in_bytes
-    524288000
+   # cgroups v1
+   $ cat /sys/fs/cgroup/memory/singularity/*/memory.limit_in_bytes
+     524288000
 
-  # cgroups v2 - note translation of memory.limit_in_bytes -> memory.max
-  $ cat /sys/fs/cgroup/singularity/*/memory.max
-  524288000
-
+   # cgroups v2 - note translation of memory.limit_in_bytes -> memory.max
+   $ cat /sys/fs/cgroup/singularity/*/memory.max
+   524288000
 
 Limiting CPU
 ------------
 
-CPU usage can be limited using different strategies, with limits specified in
-the ``[cpu]`` section of the TOML file.
+CPU usage can be limited using different strategies, with limits
+specified in the ``[cpu]`` section of the TOML file.
 
 **shares**
 
-This corresponds to a ratio versus other cgroups with cpu shares. Usually the
-default value is ``1024``. That means if you want to allow to use 50% of a
-single CPU, you will set ``512`` as value.
+This corresponds to a ratio versus other cgroups with cpu shares.
+Usually the default value is ``1024``. That means if you want to allow
+to use 50% of a single CPU, you will set ``512`` as value.
 
-.. code-block::
+.. code::
 
-  [cpu]
-      shares = 512
+   [cpu]
+       shares = 512
 
-A cgroup can get more than its share of CPU if there are enough idle CPU cycles
-available in the system, due to the work conserving nature of the scheduler, so
-a contained process can consume all CPU cycles even with a ratio of 50%. The
-ratio is only applied when two or more processes conflicts with their needs of
-CPU cycles.
+A cgroup can get more than its share of CPU if there are enough idle CPU
+cycles available in the system, due to the work conserving nature of the
+scheduler, so a contained process can consume all CPU cycles even with a
+ratio of 50%. The ratio is only applied when two or more processes
+conflicts with their needs of CPU cycles.
 
 **quota/period**
 
-You can enforce hard limits on the CPU cycles a cgroup can consume, so contained
-processes can't use more than the amount of CPU time set for the cgroup.
-``quota`` allows you to configure the amount of CPU time that a cgroup can use
-per period. The default is 100ms (100000us). So if you want to limit amount of
-CPU time to 20ms during period of 100ms:
+You can enforce hard limits on the CPU cycles a cgroup can consume, so
+contained processes can't use more than the amount of CPU time set for
+the cgroup. ``quota`` allows you to configure the amount of CPU time
+that a cgroup can use per period. The default is 100ms (100000us). So if
+you want to limit amount of CPU time to 20ms during period of 100ms:
 
-.. code-block::
+.. code::
 
-  [cpu]
-      period = 100000
-      quota = 20000
+   [cpu]
+       period = 100000
+       quota = 20000
 
 **cpus/mems**
 
-You can also restrict access to specific CPUs (cores) and associated memory
-nodes by using ``cpus/mems`` fields:
+You can also restrict access to specific CPUs (cores) and associated
+memory nodes by using ``cpus/mems`` fields:
 
-.. code-block::
+.. code::
 
-  [cpu]
-      cpus = "0-1"
-      mems = "0-1"
+   [cpu]
+       cpus = "0-1"
+       mems = "0-1"
 
 Where the container has limited access to CPU 0 and CPU 1.
 
 .. note::
 
-  It's important to set identical values for both ``cpus`` and ``mems``.
-
+   It's important to set identical values for both ``cpus`` and
+   ``mems``.
 
 Limiting IO
 -----------
 
-To control block device I/O, applying limits to competing container, use the
-``[blockIO]`` section of the TOML file:
+To control block device I/O, applying limits to competing container, use
+the ``[blockIO]`` section of the TOML file:
 
-.. code-block::
+.. code::
 
-  [blockIO]
-      weight = 1000
-      leafWeight = 1000
+   [blockIO]
+       weight = 1000
+       leafWeight = 1000
 
 ``weight`` and ``leafWeight`` accept values between ``10`` and ``1000``.
 
-``weight`` is the default weight of the group on all the devices until and
-unless overridden by a per device rule.
+``weight`` is the default weight of the group on all the devices until
+and unless overridden by a per device rule.
 
-``leafWeight`` relates to weight for the purpose of deciding how heavily to
-weigh tasks in the given cgroup while competing with the cgroup's child cgroups.
+``leafWeight`` relates to weight for the purpose of deciding how heavily
+to weigh tasks in the given cgroup while competing with the cgroup's
+child cgroups.
 
+To apply limits to specific block devices, you must set configuration
+for specific device major/minor numbers. For example, to override
+``weight/leafWeight`` for ``/dev/loop0`` and ``/dev/loop1`` block
+devices, set limits for device major 7, minor 0 and 1:
 
-To apply limits to specific block devices, you must set configuration for
-specific device major/minor numbers. For example, to override
-``weight/leafWeight`` for ``/dev/loop0`` and ``/dev/loop1`` block devices, set
-limits for device major 7, minor 0 and 1:
+.. code::
 
-.. code-block::
+   [blockIO]
+       [[blockIO.weightDevice]]
+           major = 7
+           minor = 0
+           weight = 100
+           leafWeight = 50
+       [[blockIO.weightDevice]]
+           major = 7
+           minor = 1
+           weight = 100
+           leafWeight = 50
 
-  [blockIO]
-      [[blockIO.weightDevice]]
-          major = 7
-          minor = 0
-          weight = 100
-          leafWeight = 50
-      [[blockIO.weightDevice]]
-          major = 7
-          minor = 1
-          weight = 100
-          leafWeight = 50
+You can also limit the IO read/write rate to a specific absolute value,
+e.g. 16MB per second for the ``/dev/loop0`` block device. The ``rate``
+is specified in bytes per second.
 
-You can also limit the IO read/write rate to a specific absolute value, e.g.
-16MB per second for the ``/dev/loop0`` block device. The ``rate`` is specified
-in bytes per second.
+.. code::
 
-.. code-block::
-
-  [blockIO]
-      [[blockIO.throttleReadBpsDevice]]
-          major = 7
-          minor = 0
-          rate = 16777216
-      [[blockIO.throttleWriteBpsDevice]]
-          major = 7
-          minor = 0
-          rate = 16777216
+   [blockIO]
+       [[blockIO.throttleReadBpsDevice]]
+           major = 7
+           minor = 0
+           rate = 16777216
+       [[blockIO.throttleWriteBpsDevice]]
+           major = 7
+           minor = 0
+           rate = 16777216
 
 Limiting Device Access
 ----------------------
 
-You can limit read (``r``), write (``w``), or creation (``c``) of devices by a
-container. Like applying I/O limits to devices, you must use device node major
-and minor numbers to create rules for specific devices or classes of device.
+You can limit read (``r``), write (``w``), or creation (``c``) of
+devices by a container. Like applying I/O limits to devices, you must
+use device node major and minor numbers to create rules for specific
+devices or classes of device.
 
-In this example, a container is configured to only be able to read from or write
-to ``/dev/null``:
+In this example, a container is configured to only be able to read from
+or write to ``/dev/null``:
 
-.. code-block::
+.. code::
 
-    [[devices]]
-        access = "rwm"
-        allow = false
-    [[devices]]
-        access = "rw"
-        allow = true
-        major = 1
-        minor = 3
-        type = "c"
+   [[devices]]
+       access = "rwm"
+       allow = false
+   [[devices]]
+       access = "rw"
+       allow = true
+       major = 1
+       minor = 3
+       type = "c"
 
 Other limits
 ------------
@@ -278,5 +288,5 @@ translated to v2 format when applied on a cgroups v1 system.
 
 See
 https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#control-groups
-for information about the available limits. Note that {Singularity} uses TOML
-format for the confiuration file, rather than JSON.
+for information about the available limits. Note that {Singularity} uses
+TOML format for the confiuration file, rather than JSON.

--- a/cli.rst
+++ b/cli.rst
@@ -1,8 +1,8 @@
 .. _cli:
 
-======================
-Command Line Interface
-======================
+########################
+ Command Line Interface
+########################
 
 Below are links to the automatically generated CLI docs
 

--- a/cloud_library.rst
+++ b/cloud_library.rst
@@ -60,7 +60,7 @@ The ``singularity push`` command will push a container to the
 container library with the given URL. Here's an example of a typical
 push command:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity push my-container.sif library://your-name/project-dir/my-container:latest
 
@@ -75,7 +75,7 @@ Let's assume you have your container (v1.0.1), and you want to push
 that container without deleting your ``:latest`` container, then you
 can add a version tag to that container, like so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity push my-container.sif library://your-name/project-dir/my-container:1.0.1
 
@@ -113,7 +113,7 @@ The ``singularity pull`` command will download a container from the `Library <ht
 
 Here's a typical pull command:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull file-out.sif library://alpine:latest
 
@@ -126,7 +126,7 @@ Here's a typical pull command:
 
 To pull a container with a specific tag, just add the tag to the library URL:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull file-out.sif library://alpine:3.8
 
@@ -137,7 +137,7 @@ Pulling your own container
 
 Pulling your own container is just like pulling from Github, Docker, etc...
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull out-file.sif library://your-name/project-dir/my-container:latest
 
@@ -270,7 +270,7 @@ The remote builder service can build your container in the cloud removing the re
 
 Here's a typical remote build command:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity build --remote file-out.sif docker://ubuntu:18.04
 
@@ -290,7 +290,7 @@ This is our definition file. Let's call it ``ubuntu.def``:
 
 Now, to build the container, use the ``--remote`` flag, and without ``sudo``:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity build --remote ubuntu.sif ubuntu.def
 
@@ -299,7 +299,7 @@ Now, to build the container, use the ``--remote`` flag, and without ``sudo``:
 
 After building, you can test your container like so:
 
-.. code-block:: none
+.. code-block::
 
     $ ./ubuntu.sif
     hello world from ubuntu container!

--- a/cloud_library.rst
+++ b/cloud_library.rst
@@ -1,309 +1,326 @@
 .. _cloud_library:
 
-Cloud Library
-=============
+###############
+ Cloud Library
+###############
 
---------
-Overview
---------
+**********
+ Overview
+**********
 
 The Sylabs Cloud Library is the place to :ref:`push <push>` your
 containers to the cloud so other users can :ref:`pull <pull>`,
 :ref:`verify <signNverify>`, and use them.
 
-The Sylabs Cloud also provides a :ref:`Remote Builder
-<remote_builder>`, allowing you to build containers on a secure remote
-service. This is convenient so that you can build containers on
-systems where you do not have root privileges.
+The Sylabs Cloud also provides a :ref:`Remote Builder <remote_builder>`,
+allowing you to build containers on a secure remote service. This is
+convenient so that you can build containers on systems where you do not
+have root privileges.
 
 .. _make_a_account:
 
----------------
-Make an Account
----------------
+*****************
+ Make an Account
+*****************
 
 Making an account is easy, and straightforward:
 
- 1. Go to: https://cloud.sylabs.io/library.
- 2. Click "Sign in to Sylabs" (top right corner).
- 3. Select your method to sign in, with Google, GitHub, GitLab, or Microsoft.
- 4. Type your passwords, and that's it!
+   #. Go to: https://cloud.sylabs.io/library.
+   #. Click "Sign in to Sylabs" (top right corner).
+   #. Select your method to sign in, with Google, GitHub, GitLab, or
+      Microsoft.
+   #. Type your passwords, and that's it!
 
 .. _creating_a_access_token:
 
------------------------
-Creating a Access token
------------------------
+*************************
+ Creating a Access token
+*************************
 
 Access tokens for pushing a container, and remote builder.
 
 To generate a access token, do the following steps:
 
-  1) Go to: https://cloud.sylabs.io/
-  2) Click "Sign In" and follow the sign in steps.
-  3) Click on your login id (same and updated button as the Sign in one).
-  4) Select "Access Tokens" from the drop down menu.
-  5) Enter a name for your new access token, such as "test token"
-  6) Click the "Create a New Access Token" button.
-  7) Click "Copy token to Clipboard" from the "New API Token" page.
-  8) Run ``singularity remote login`` and paste the access token at the prompt.
+   #. Go to: https://cloud.sylabs.io/
+   #. Click "Sign In" and follow the sign in steps.
+   #. Click on your login id (same and updated button as the Sign in
+      one).
+   #. Select "Access Tokens" from the drop down menu.
+   #. Enter a name for your new access token, such as "test token"
+   #. Click the "Create a New Access Token" button.
+   #. Click "Copy token to Clipboard" from the "New API Token" page.
+   #. Run ``singularity remote login`` and paste the access token at the
+      prompt.
 
 Now that you have your token, you are ready to push your container!
 
 .. _push:
 
--------------------
-Pushing a Container
--------------------
+*********************
+ Pushing a Container
+*********************
 
-The ``singularity push`` command will push a container to the
-container library with the given URL. Here's an example of a typical
-push command:
+The ``singularity push`` command will push a container to the container
+library with the given URL. Here's an example of a typical push command:
 
-.. code-block::
+.. code::
 
-    $ singularity push my-container.sif library://your-name/project-dir/my-container:latest
+   $ singularity push my-container.sif library://your-name/project-dir/my-container:latest
 
 The ``:latest`` is the container tag. Tags are used to have different
 version of the same container.
 
 .. note::
-    When pushing your container, there's no need to add a ``.sif`` (Singularity Image Format) to the end of the container name, (like
-    on your local machine), because all containers on the library are SIF containers.
 
-Let's assume you have your container (v1.0.1), and you want to push
-that container without deleting your ``:latest`` container, then you
-can add a version tag to that container, like so:
+   When pushing your container, there's no need to add a ``.sif``
+   (Singularity Image Format) to the end of the container name, (like on
+   your local machine), because all containers on the library are SIF
+   containers.
 
-.. code-block::
+Let's assume you have your container (v1.0.1), and you want to push that
+container without deleting your ``:latest`` container, then you can add
+a version tag to that container, like so:
 
-    $ singularity push my-container.sif library://your-name/project-dir/my-container:1.0.1
+.. code::
+
+   $ singularity push my-container.sif library://your-name/project-dir/my-container:1.0.1
 
 You can download the container with that tag by replacing the
 ``:latest``, with the tagged container you want to download.
 
-To set a description against the container image as you push it, use
-the `-D` flag introduced in {Singularity} 3.7. This provides an
-alternative to setting the description via the web interface:
+To set a description against the container image as you push it, use the
+`-D` flag introduced in {Singularity} 3.7. This provides an alternative
+to setting the description via the web interface:
 
-.. code-block:: console
+.. code:: console
 
-    $ singularity push -D "My alpine 3.11 container" alpine_3.11.sif library://myuser/examples/alpine:3.11
-    2.7MiB / 2.7MiB [=========================================================================] 100 % 1.1 MiB/s 0s
+   $ singularity push -D "My alpine 3.11 container" alpine_3.11.sif library://myuser/examples/alpine:3.11
+   2.7MiB / 2.7MiB [=========================================================================] 100 % 1.1 MiB/s 0s
 
-    Library storage: using 13.24 MiB out of 11.00 GiB quota (0.1% used)
-    Container URL: https://cloud.sylabs.io/library/myuser/examples/alpine
+   Library storage: using 13.24 MiB out of 11.00 GiB quota (0.1% used)
+   Container URL: https://cloud.sylabs.io/library/myuser/examples/alpine
 
 Note that when you push to a library that supports it, {Singularity} 3.7
 and above will report your quota usage and the direct URL to view the
 container in your web browser.
-               
+
 .. _pull:
 
--------------------
-Pulling a container
--------------------
+*********************
+ Pulling a container
+*********************
 
-The ``singularity pull`` command will download a container from the `Library <https://cloud.sylabs.io/library>`_
-(``library://``), `Docker Hub <https://hub.docker.com/>`_ (``docker://``), and also
-`Shub <https://singularity-hub.org>`_ (``shub://``).
+The ``singularity pull`` command will download a container from the
+`Library <https://cloud.sylabs.io/library>`_ (``library://``), `Docker
+Hub <https://hub.docker.com/>`_ (``docker://``), and also `Shub
+<https://singularity-hub.org>`_ (``shub://``).
 
 .. note::
-    When pulling from Docker, the container will automatically be converted to a SIF (Singularity Image Format) container.
+
+   When pulling from Docker, the container will automatically be
+   converted to a SIF (Singularity Image Format) container.
 
 Here's a typical pull command:
 
-.. code-block::
+.. code::
 
-    $ singularity pull file-out.sif library://alpine:latest
+   $ singularity pull file-out.sif library://alpine:latest
 
-    # or pull from docker:
+   # or pull from docker:
 
-    $ singularity pull file-out.sif docker://alpine:latest
+   $ singularity pull file-out.sif docker://alpine:latest
 
 .. note::
-    If there's no tag after the container name, {Singularity} automatically will pull the container with the ``:latest`` tag.
 
-To pull a container with a specific tag, just add the tag to the library URL:
+   If there's no tag after the container name, {Singularity}
+   automatically will pull the container with the ``:latest`` tag.
 
-.. code-block::
+To pull a container with a specific tag, just add the tag to the library
+URL:
 
-    $ singularity pull file-out.sif library://alpine:3.8
+.. code::
 
-Of course, you can pull your own containers. Here's what that will look like:
+   $ singularity pull file-out.sif library://alpine:3.8
+
+Of course, you can pull your own containers. Here's what that will look
+like:
 
 Pulling your own container
---------------------------
+==========================
 
-Pulling your own container is just like pulling from Github, Docker, etc...
+Pulling your own container is just like pulling from Github, Docker,
+etc...
 
-.. code-block::
+.. code::
 
-    $ singularity pull out-file.sif library://your-name/project-dir/my-container:latest
+   $ singularity pull out-file.sif library://your-name/project-dir/my-container:latest
 
-    # or use a different tag:
+   # or use a different tag:
 
-    $ singularity pull out-file.sif library://your-name/project-dir/my-container:1.0.1
+   $ singularity pull out-file.sif library://your-name/project-dir/my-container:1.0.1
 
 .. note::
-    You *don't* have to specify a output file, one will be created automatically, but it's good practice to always
-    specify your output file.
 
---------------------------
-Verify/Sign your Container
---------------------------
+   You *don't* have to specify a output file, one will be created
+   automatically, but it's good practice to always specify your output
+   file.
 
-Verify containers that you pull from the library, ensuring they are bit-for-bit reproductions of the original image.
+****************************
+ Verify/Sign your Container
+****************************
 
-Check out :ref:`this page <signNverify>` on how to: :ref:`verify a container <verify_container_from_library>`,
-:ref:`making PGP key, and sign your own containers <sign_your_own_containers>`.
+Verify containers that you pull from the library, ensuring they are
+bit-for-bit reproductions of the original image.
+
+Check out :ref:`this page <signNverify>` on how to: :ref:`verify a
+container <verify_container_from_library>`, :ref:`making PGP key, and
+sign your own containers <sign_your_own_containers>`.
 
 .. _search_the_library:
 
-------------------------------------
-Searching the Library for Containers
-------------------------------------
+**************************************
+ Searching the Library for Containers
+**************************************
 
 To find interesting or useful containers in the library, you can open
 https://cloud.sylabs.io/library in your browser and search from there
 through the web GUI.
 
-Alternatively, from the CLI you can use ``singularity search
-<query>``. This will search the library for container images matching
-``<query>``.
+Alternatively, from the CLI you can use ``singularity search <query>``.
+This will search the library for container images matching ``<query>``.
 
 Using the CLI Search
---------------------
+====================
 
 Here is an example of searching the library for ``centos``:
 
-.. code-block:: console
+.. code:: console
 
-    singularity search centos
-    Found 72 container images for amd64 matching "centos":
+   singularity search centos
+   Found 72 container images for amd64 matching "centos":
 
-	library://dcsouthwick/iotools/centos7:latest
+       library://dcsouthwick/iotools/centos7:latest
 
-	library://dcsouthwick/iotools/centos7:sha256.48e81523aaad3d74e7af8b154ac5e75f2726cc6cab37f718237d8f89d905ff89
-		Minimal centos7 image from yum bootstrap
+       library://dcsouthwick/iotools/centos7:sha256.48e81523aaad3d74e7af8b154ac5e75f2726cc6cab37f718237d8f89d905ff89
+               Minimal centos7 image from yum bootstrap
 
-	library://dtrudg/linux/centos:7,centos7,latest
+       library://dtrudg/linux/centos:7,centos7,latest
 
-	library://dtrudg/linux/centos:centos6,6
+       library://dtrudg/linux/centos:centos6,6
 
-	library://emmeff/centos/centos:8
+       library://emmeff/centos/centos:8
 
-	library://essen1999/default/centos-tree:latest
+       library://essen1999/default/centos-tree:latest
 
-	library://gallig/default/centos_benchmark-signed:7.7.1908
-		Signed by: 6B44B0BC9CD273CC6A71DA8CED6FA43EF8771A02
+       library://gallig/default/centos_benchmark-signed:7.7.1908
+               Signed by: 6B44B0BC9CD273CC6A71DA8CED6FA43EF8771A02
 
-	library://gmk/default/centos7-devel:latest
-		Signed by: 7853F08767A4596B3C1AD95E48E1080AB16ED1BC
-
+       library://gmk/default/centos7-devel:latest
+               Signed by: 7853F08767A4596B3C1AD95E48E1080AB16ED1BC
 
 Containers can have multiple tags, and these are shown separated by
-commas after the ``:`` in the
-URL. E.g. ``library://dtrudg/linux/centos:7,centos7,latest`` is a
-single container image with 3 tags, ``7``, ``centos7``, and
-``latest``. You can ``singularity pull`` the container image using any
-one of these tags.
-                
-                
+commas after the ``:`` in the URL. E.g.
+``library://dtrudg/linux/centos:7,centos7,latest`` is a single container
+image with 3 tags, ``7``, ``centos7``, and ``latest``. You can
+``singularity pull`` the container image using any one of these tags.
+
 Note that the results show ``amd64`` containers only. By default
 ``search`` returns only containers with an architecture matching your
 current system. To e.g. search for ``arm64`` containers from an
 ``amd64`` machine you can use the ``--arch`` flag:
 
-.. code-block:: console
+.. code:: console
 
-    singularity search --arch arm64 alpine
-    Found 5 container images for arm64 matching "alpine":
+   singularity search --arch arm64 alpine
+   Found 5 container images for arm64 matching "alpine":
 
-	library://dtrudg-sylabs-2/multiarch/alpine:latest
+       library://dtrudg-sylabs-2/multiarch/alpine:latest
 
-	library://geoffroy.vallee/alpine/alpine:latest
-		Signed by: 9D56FA7CAFB4A37729751B8A21749D0D6447B268
+       library://geoffroy.vallee/alpine/alpine:latest
+               Signed by: 9D56FA7CAFB4A37729751B8A21749D0D6447B268
 
-	library://library/default/alpine:3.11.5,latest,3,3.11
+       library://library/default/alpine:3.11.5,latest,3,3.11
 
-	library://library/default/alpine:3.9,3.9.2
+       library://library/default/alpine:3.9,3.9.2
 
-	library://sylabs/tests/passphrase_encrypted_alpine:3.11.5
+       library://sylabs/tests/passphrase_encrypted_alpine:3.11.5
 
-        
 You can also limit results to only signed containers with the
 ``--signed`` flag:
 
-.. code-block:: console
+.. code:: console
 
-    singularity search --signed alpine
-    Found 45 container images for amd64 matching "alpine":
+   singularity search --signed alpine
+   Found 45 container images for amd64 matching "alpine":
 
-	library://deep/default/alpine:latest,1.0.1
-		Signed by: 8883491F4268F173C6E5DC49EDECE4F3F38D871E
+       library://deep/default/alpine:latest,1.0.1
+               Signed by: 8883491F4268F173C6E5DC49EDECE4F3F38D871E
 
-	library://godloved/secure/alpine:20200514.0.0
-		Signed base image built directly from mirrors suitable for secure building. Make sure to check that the fingerprint is B7761495F83E6BF7686CA5F0C1A7D02200787921
-		Signed by: B7761495F83E6BF7686CA5F0C1A7D02200787921
+       library://godloved/secure/alpine:20200514.0.0
+               Signed base image built directly from mirrors suitable for secure building. Make sure to check that the fingerprint is B7761495F83E6BF7686CA5F0C1A7D02200787921
+               Signed by: B7761495F83E6BF7686CA5F0C1A7D02200787921
 
-	library://godlovedc/blah/alpine:sha256.63259fd0a2acb88bb652702c08c1460b071df51149ff85dc88db5034532a14a0
-		Signed by: 8883491F4268F173C6E5DC49EDECE4F3F38D871E
+       library://godlovedc/blah/alpine:sha256.63259fd0a2acb88bb652702c08c1460b071df51149ff85dc88db5034532a14a0
+               Signed by: 8883491F4268F173C6E5DC49EDECE4F3F38D871E
 
-	library://heffaywrit/base/alpine:latest
-		Signed by: D4038BDDE21017435DFE5ADA9F2D10A25D64C1EF
+       library://heffaywrit/base/alpine:latest
+               Signed by: D4038BDDE21017435DFE5ADA9F2D10A25D64C1EF
 
-	library://hellseva/class/alpine:latest
-		Signed by: 6D60F95E86A593603897164F8E09E44D12A7111C
+       library://hellseva/class/alpine:latest
+               Signed by: 6D60F95E86A593603897164F8E09E44D12A7111C
 
-	library://hpc110/default/alpine-miniconda:cupy
-		Signed by: 9FF48D6202271D3C842C53BD0D237BE8BB5B5C76
-        ...
-            
+       library://hpc110/default/alpine-miniconda:cupy
+               Signed by: 9FF48D6202271D3C842C53BD0D237BE8BB5B5C76
+       ...
+
 .. _remote_builder:
 
---------------
-Remote Builder
---------------
+****************
+ Remote Builder
+****************
 
-The remote builder service can build your container in the cloud removing the requirement for root access.
+The remote builder service can build your container in the cloud
+removing the requirement for root access.
 
 Here's a typical remote build command:
 
-.. code-block::
+.. code::
 
-    $ singularity build --remote file-out.sif docker://ubuntu:18.04
-
+   $ singularity build --remote file-out.sif docker://ubuntu:18.04
 
 Building from a definition file:
---------------------------------
+================================
 
 This is our definition file. Let's call it ``ubuntu.def``:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    bootstrap: library
-    from: ubuntu:18.04
+   bootstrap: library
+   from: ubuntu:18.04
 
-    %runscript
-        echo "hello world from ubuntu container!"
+   %runscript
+       echo "hello world from ubuntu container!"
 
-Now, to build the container, use the ``--remote`` flag, and without ``sudo``:
+Now, to build the container, use the ``--remote`` flag, and without
+``sudo``:
 
-.. code-block::
+.. code::
 
-    $ singularity build --remote ubuntu.sif ubuntu.def
+   $ singularity build --remote ubuntu.sif ubuntu.def
 
 .. note::
-    Make sure you have a :ref:`access token <creating_a_access_token>`, otherwise the build will fail.
+
+   Make sure you have a :ref:`access token <creating_a_access_token>`,
+   otherwise the build will fail.
 
 After building, you can test your container like so:
 
-.. code-block::
+.. code::
 
-    $ ./ubuntu.sif
-    hello world from ubuntu container!
+   $ ./ubuntu.sif
+   hello world from ubuntu container!
 
-You can also use the web GUI to build containers remotely. First, go to https://cloud.sylabs.io/builder (make sure you are signed in).
-Then you can copy and paste, upload, or type your definition file. When you are finished, click build. Then you can download the container
-with the URL.
+You can also use the web GUI to build containers remotely. First, go to
+https://cloud.sylabs.io/builder (make sure you are signed in). Then you
+can copy and paste, upload, or type your definition file. When you are
+finished, click build. Then you can download the container with the URL.

--- a/contributing.rst
+++ b/contributing.rst
@@ -1,205 +1,211 @@
 .. _contributing:
 
-============
-Contributing
-============
+##############
+ Contributing
+##############
 
-{Singularity} is an open source project, meaning we have the challenge of limited 
-resources. We are grateful for any support that you can offer. Helping other 
-users, raising issues, helping write documentation, or contributing code are all 
-ways to help!
+{Singularity} is an open source project, meaning we have the challenge
+of limited resources. We are grateful for any support that you can
+offer. Helping other users, raising issues, helping write documentation,
+or contributing code are all ways to help!
 
-------------------
-Join the community
-------------------
+********************
+ Join the community
+********************
 
-This is a huge endeavor, and your help would be greatly appreciated! Post to 
-online communities about {Singularity}, and request that your distribution vendor, 
-service provider, and system administrators include {Singularity} for you!
+This is a huge endeavor, and your help would be greatly appreciated!
+Post to online communities about {Singularity}, and request that your
+distribution vendor, service provider, and system administrators include
+{Singularity} for you!
 
 {Singularity} Google Group
 ==========================
 
-If you have been using {Singularity} and having good luck with it, join our 
-`Google Group  <https://groups.google.com/g/singularity-ce>`_  and help out 
-other users! 
+If you have been using {Singularity} and having good luck with it, join
+our `Google Group <https://groups.google.com/g/singularity-ce>`_ and
+help out other users!
 
 {Singularity} on Slack
 ======================
 
-Many of our users come to Slack for quick help with an issue. You can find us at 
-`singularity-container <https://singularity-container.slack.com/>`_.
+Many of our users come to Slack for quick help with an issue. You can
+find us at `singularity-container
+<https://singularity-container.slack.com/>`_.
 
 .. _contributing-to-documentation:
 
 .. _report-a-issue:
 
---------------
-Raise an Issue
---------------
+****************
+ Raise an Issue
+****************
 
-For general bugs/issues, you can open an issue `at the GitHub repo 
-<https://github.com/hpcng/singularity/issues/new>`_. However, if you find a 
-security  related issue/problem, please email the Singularity Security Team directly at 
-`singularity-security@hpcng.org <mailto:singularity-security@hpcng.org>`_. More information about the 
-Singularity security policies and procedures can be found `here 
+For general bugs/issues, you can open an issue `at the GitHub repo
+<https://github.com/hpcng/singularity/issues/new>`_. However, if you
+find a security related issue/problem, please email the Singularity Security Team directly at
+singularity-security@hpcng.org. More information about the Singularity security policies
+and procedures can be found `here
 <https://singularity.hpcng.org/security-policy/>`__
 
--------------------
-Write Documentation
--------------------
+*********************
+ Write Documentation
+*********************
 
-We (like almost all open source software providers) have a documentation 
-dilemma… We tend to focus on the code features and functionality before working 
-on documentation. And there is very good reason for this: we want to share the 
-love so nobody feels left out!
+We (like almost all open source software providers) have a documentation
+dilemma… We tend to focus on the code features and functionality before
+working on documentation. And there is very good reason for this: we
+want to share the love so nobody feels left out!
 
-You can contribute to the documentation by `raising an issue to suggest an 
-improvement <https://github.com/hpcng/singularity-userdocs/issues/new>`_ or by 
-sending a `pull request 
-<https://github.com/hpcng/singularity-userdocs/compare>`_ on `our repository 
-for documentation <https://github.com/hpcng/singularity-userdocs>`_.
+You can contribute to the documentation by `raising an issue to suggest
+an improvement
+<https://github.com/hpcng/singularity-userdocs/issues/new>`_ or by
+sending a `pull request
+<https://github.com/hpcng/singularity-userdocs/compare>`_ on `our
+repository for documentation
+<https://github.com/hpcng/singularity-userdocs>`_.
 
 The current documentation is generated with:
 
-- `reStructured Text (RST) <http://docutils.sourceforge.net/rst.html>`_ and `ReadTheDocs <https://readthedocs.org/>`_.
+-  `reStructured Text (RST) <http://docutils.sourceforge.net/rst.html>`_
+   and `ReadTheDocs <https://readthedocs.org/>`_.
 
 Other dependencies include:
 
-- `Python 3.5 or newer <https://www.python.org/downloads/>`_.
+-  `Python 3.5 or newer <https://www.python.org/downloads/>`_.
+-  `Sphinx <https://pypi.org/project/Sphinx/>`_.
 
-- `Sphinx <https://pypi.org/project/Sphinx/>`_.
-
-More information about contributing to the documentation, instructions on how to 
-install the dependencies, and how to generate the files can be obtained 
-`here 
+More information about contributing to the documentation, instructions
+on how to install the dependencies, and how to generate the files can be
+obtained `here
 <https://github.com/hpcng/singularity-userdocs/blob/master/README.md>`__.
 
-For more information on using Git and GitHub to create a pull request suggesting 
-additions and edits to the docs, see the :ref:`section on contributing to the
-code <contribute-to-the-code>`. The procedure is identical for contributions to 
-the documentation and the code base.
+For more information on using Git and GitHub to create a pull request
+suggesting additions and edits to the docs, see the :ref:`section on
+contributing to the code <contribute-to-the-code>`. The procedure is
+identical for contributions to the documentation and the code base.
 
 .. _contribute-to-the-code:
 
-----------------------
-Contribute to the code
-----------------------
+************************
+ Contribute to the code
+************************
 
-We use the traditional 
-`GitHub Flow <https://guides.github.com/introduction/flow/>`_ to develop. This 
-means that you fork the main repo, create a new branch to make changes, and
+We use the traditional `GitHub Flow
+<https://guides.github.com/introduction/flow/>`_ to develop. This means
+that you fork the main repo, create a new branch to make changes, and
 submit a pull request (PR) to the master branch.
 
-Check out our official `CONTRIBUTING.md 
-<https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md>`_ document, 
-which also includes a `code of conduct 
+Check out our official `CONTRIBUTING.md
+<https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md>`_
+document, which also includes a `code of conduct
 <https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md#code-of-conduct>`_.
-
 
 Step 1. Fork the repo
 =====================
 
-To contribute to {Singularity}, you should obtain a GitHub account and fork the 
-`{Singularity} <https://github.com/hpcng/singularity>`_ repository. Once forked, 
-clone your fork of the repo to your computer. (Obviously, you should replace 
-``your-username`` with your GitHub username.)
+To contribute to {Singularity}, you should obtain a GitHub account and
+fork the `{Singularity} <https://github.com/hpcng/singularity>`_
+repository. Once forked, clone your fork of the repo to your computer.
+(Obviously, you should replace ``your-username`` with your GitHub
+username.)
 
-.. code-block::
+.. code::
 
-    $ git clone https://github.com/your-username/singularity.git && \
-        cd singularity/
+   $ git clone https://github.com/your-username/singularity.git && \
+       cd singularity/
 
 Step 2. Checkout a new branch
 =============================
 
-`Branches <https://guides.github.com/introduction/flow//>`_ are a way of 
-isolating your features from the main branch. Given that we’ve just cloned the 
-repo, we will probably want to make a new branch from master in which to work on
-our new feature. Lets call that branch ``new-feature``:
+`Branches <https://guides.github.com/introduction/flow//>`_ are a way of
+isolating your features from the main branch. Given that we’ve just
+cloned the repo, we will probably want to make a new branch from master
+in which to work on our new feature. Lets call that branch
+``new-feature``:
 
-.. code-block::
+.. code::
 
-    $ git checkout master && \
-        git checkout -b new-feature
+   $ git checkout master && \
+       git checkout -b new-feature
 
 .. note::
 
-    You can always check which branch you are in by running ``git branch``.
+   You can always check which branch you are in by running ``git
+   branch``.
 
 Step 3. Make your changes
 =========================
 
-On your new branch, go nuts! Make changes, test them, and when you are happy 
-commit the changes to the branch:
+On your new branch, go nuts! Make changes, test them, and when you are
+happy commit the changes to the branch:
 
-.. code-block::
+.. code::
 
-    $ git add file-changed1 file-changed2...
+   $ git add file-changed1 file-changed2...
 
-    $ git commit -m "what changed?"
+   $ git commit -m "what changed?"
 
-This commit message is important - it should describe exactly the changes that 
-you have made. Good commit messages read like so:
+This commit message is important - it should describe exactly the
+changes that you have made. Good commit messages read like so:
 
-.. code-block::
+.. code::
 
-    $ git commit -m "changed function getConfig in functions.go to output csv to fix #2"
+   $ git commit -m "changed function getConfig in functions.go to output csv to fix #2"
 
-    $ git commit -m "updated docs about shell to close #10"
+   $ git commit -m "updated docs about shell to close #10"
 
-The tags ``close #10`` and ``fix #2`` are referencing issues that are posted on 
-the upstream repo where you will direct your pull request. When your PR is 
-merged into the master branch, these messages will automatically close the 
-issues, and further, they will link your commits directly to the issues they 
-intend to fix. This will help future maintainers understand your contribution, 
-or (hopefully not) revert the code back to a previous version if necessary.
+The tags ``close #10`` and ``fix #2`` are referencing issues that are
+posted on the upstream repo where you will direct your pull request.
+When your PR is merged into the master branch, these messages will
+automatically close the issues, and further, they will link your commits
+directly to the issues they intend to fix. This will help future
+maintainers understand your contribution, or (hopefully not) revert the
+code back to a previous version if necessary.
 
 Step 4. Push your branch to your fork
 =====================================
 
-When you are done with your commits, you should push your branch to your fork 
-(and you can also continuously push commits here as you work):
+When you are done with your commits, you should push your branch to your
+fork (and you can also continuously push commits here as you work):
 
-.. code-block::
+.. code::
 
-    $ git push origin new-feature
+   $ git push origin new-feature
 
+Note that you should always check the status of your branches to see
+what has been pushed (or not):
 
-Note that you should always check the status of your branches to see what has 
-been pushed (or not):
+.. code::
 
-.. code-block::
-
-    $ git status
-
+   $ git status
 
 Step 5. Submit a Pull Request
 =============================
 
-Once you have pushed your branch, then you can go to your fork (in the web GUI 
-on GitHub) and `submit a Pull Request
-<https://help.github.com/articles/creating-a-pull-request/>`_. Regardless of the 
-name of your branch, your PR should be submitted to the Singularity ``master`` 
-branch. Submitting your PR will open a conversation thread for the maintainers 
-of {Singularity} to discuss your contribution. At this time, the continuous 
-integration that is linked with the code base will also be executed. If there is 
-an issue, or if the maintainers suggest changes, you can continue to push 
-commits to your branch and they will update the Pull Request.
+Once you have pushed your branch, then you can go to your fork (in the
+web GUI on GitHub) and `submit a Pull Request
+<https://help.github.com/articles/creating-a-pull-request/>`_.
+Regardless of the name of your branch, your PR should be submitted to
+the Singularity ``master`` branch. Submitting your PR will open a
+conversation thread for the maintainers of {Singularity} to discuss your
+contribution. At this time, the continuous integration that is linked
+with the code base will also be executed. If there is an issue, or if
+the maintainers suggest changes, you can continue to push commits to
+your branch and they will update the Pull Request.
 
 Step 6. Keep your branch in sync
 ================================
 
-Cloning the repo will create an exact copy of the {Singularity} repository at that 
-moment. As you work, your branch may become out of date as others merge changes
-into the upstream master. In the event that you need to update a branch, you 
-will need to follow the next steps:
+Cloning the repo will create an exact copy of the {Singularity}
+repository at that moment. As you work, your branch may become out of
+date as others merge changes into the upstream master. In the event that
+you need to update a branch, you will need to follow the next steps:
 
-.. code-block::
+.. code::
 
-    $ git remote add upstream https://github.com/hpcng/singularity.git && # to add a new remote named "upstream" \
-        git checkout master && # or another branch to be updated \
-        git pull upstream master && \
-        git push origin master && # to update your fork \
-        git checkout new-feature && \
-        git merge master 
+   $ git remote add upstream https://github.com/hpcng/singularity.git && # to add a new remote named "upstream" \
+       git checkout master && # or another branch to be updated \
+       git pull upstream master && \
+       git push origin master && # to update your fork \
+       git checkout new-feature && \
+       git merge master

--- a/contributing.rst
+++ b/contributing.rst
@@ -105,7 +105,7 @@ To contribute to {Singularity}, you should obtain a GitHub account and fork the
 clone your fork of the repo to your computer. (Obviously, you should replace 
 ``your-username`` with your GitHub username.)
 
-.. code-block:: none
+.. code-block::
 
     $ git clone https://github.com/your-username/singularity.git && \
         cd singularity/
@@ -118,7 +118,7 @@ isolating your features from the main branch. Given that we’ve just cloned the
 repo, we will probably want to make a new branch from master in which to work on
 our new feature. Lets call that branch ``new-feature``:
 
-.. code-block:: none
+.. code-block::
 
     $ git checkout master && \
         git checkout -b new-feature
@@ -133,7 +133,7 @@ Step 3. Make your changes
 On your new branch, go nuts! Make changes, test them, and when you are happy 
 commit the changes to the branch:
 
-.. code-block:: none
+.. code-block::
 
     $ git add file-changed1 file-changed2...
 
@@ -142,7 +142,7 @@ commit the changes to the branch:
 This commit message is important - it should describe exactly the changes that 
 you have made. Good commit messages read like so:
 
-.. code-block:: none
+.. code-block::
 
     $ git commit -m "changed function getConfig in functions.go to output csv to fix #2"
 
@@ -161,7 +161,7 @@ Step 4. Push your branch to your fork
 When you are done with your commits, you should push your branch to your fork 
 (and you can also continuously push commits here as you work):
 
-.. code-block:: none
+.. code-block::
 
     $ git push origin new-feature
 
@@ -169,7 +169,7 @@ When you are done with your commits, you should push your branch to your fork
 Note that you should always check the status of your branches to see what has 
 been pushed (or not):
 
-.. code-block:: none
+.. code-block::
 
     $ git status
 
@@ -195,7 +195,7 @@ moment. As you work, your branch may become out of date as others merge changes
 into the upstream master. In the event that you need to update a branch, you 
 will need to follow the next steps:
 
-.. code-block:: none
+.. code-block::
 
     $ git remote add upstream https://github.com/hpcng/singularity.git && # to add a new remote named "upstream" \
         git checkout master && # or another branch to be updated \

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -1,299 +1,294 @@
-
 .. _definition-files:
 
-================
-Definition Files
-================
+##################
+ Definition Files
+##################
 
 .. _sec:deffiles:
 
-A {Singularity} Definition File (or "def file" for short) is like a set of
-blueprints explaining how to build a custom container. It includes specifics
-about the base OS to build or the base container to start from, software to
-install, environment variables to set at runtime, files to add from the host
-system, and container metadata.
+A {Singularity} Definition File (or "def file" for short) is like a set
+of blueprints explaining how to build a custom container. It includes
+specifics about the base OS to build or the base container to start
+from, software to install, environment variables to set at runtime,
+files to add from the host system, and container metadata.
 
---------
-Overview
---------
-
+**********
+ Overview
+**********
 
 A {Singularity} Definition file is divided into two parts:
 
-#. **Header**: The Header describes the core operating system to build within
-   the container. Here you will configure the base operating system features
-   needed within the container. You can specify, the Linux distribution, the
-   specific version, and the packages that must be part of the core install
-   (borrowed from the host system).
+#. **Header**: The Header describes the core operating system to build
+   within the container. Here you will configure the base operating
+   system features needed within the container. You can specify, the
+   Linux distribution, the specific version, and the packages that must
+   be part of the core install (borrowed from the host system).
 
-#. **Sections**: The rest of the definition is comprised of sections, (sometimes
-   called scriptlets or blobs of data). Each section is defined by a ``%``
-   character followed by the name of the particular section. All sections are
-   optional, and a def file may contain more than one instance of a given
-   section. Sections that are executed at build time are executed with the
-   ``/bin/sh`` interpreter and can accept ``/bin/sh`` options. Similarly,
-   sections that produce scripts to be executed at runtime can accept options
-   intended for ``/bin/sh``
+#. **Sections**: The rest of the definition is comprised of sections,
+   (sometimes called scriptlets or blobs of data). Each section is
+   defined by a ``%`` character followed by the name of the particular
+   section. All sections are optional, and a def file may contain more
+   than one instance of a given section. Sections that are executed at
+   build time are executed with the ``/bin/sh`` interpreter and can
+   accept ``/bin/sh`` options. Similarly, sections that produce scripts
+   to be executed at runtime can accept options intended for ``/bin/sh``
 
-For more in-depth and practical examples of def files, see the `Singularity examples
-repository <https://github.com/hpcng/singularity/tree/master/examples>`_
+For more in-depth and practical examples of def files, see the `Singularity
+examples repository <https://github.com/hpcng/singularity/tree/master/examples>`_
 
 For a comparison between Dockerfile and {Singularity} definition file,
 please see: :ref:`this section <sec:deffile-vs-dockerfile>`.
 
-------
-Header
-------
+********
+ Header
+********
 
-The header should be written at the top of the def file. It tells {Singularity}
-about the base operating system that it should use to build the container. It is
-composed of several keywords.
+The header should be written at the top of the def file. It tells
+{Singularity} about the base operating system that it should use to
+build the container. It is composed of several keywords.
 
-The only keyword that is required for every type of build is ``Bootstrap``.
-It determines the *bootstrap agent*  that will be used to create the base
-operating system you want to use. For example, the ``library`` bootstrap agent
-will pull a container from the `Container Library
-<https://cloud.sylabs.io/library>`_ as a base. Similarly, the ``docker``
-bootstrap agent will pull docker layers from `Docker Hub
+The only keyword that is required for every type of build is
+``Bootstrap``. It determines the *bootstrap agent* that will be used to
+create the base operating system you want to use. For example, the
+``library`` bootstrap agent will pull a container from the `Container
+Library <https://cloud.sylabs.io/library>`_ as a base. Similarly, the
+``docker`` bootstrap agent will pull docker layers from `Docker Hub
 <https://hub.docker.com/>`_ as a base OS to start your image.
 
-Starting with {Singularity} 3.2, the ``Bootstrap`` keyword needs to be the first
-entry in the header section.  This breaks compatibility with older versions
-that allow the parameters of the header to appear in any order.
+Starting with {Singularity} 3.2, the ``Bootstrap`` keyword needs to be
+the first entry in the header section. This breaks compatibility with
+older versions that allow the parameters of the header to appear in any
+order.
 
-Depending on the value assigned to ``Bootstrap``, other keywords may also be
-valid in the header. For example, when using the ``library`` bootstrap agent,
-the ``From`` keyword becomes valid. Observe the following example for building a
-Debian container from the Container Library:
+Depending on the value assigned to ``Bootstrap``, other keywords may
+also be valid in the header. For example, when using the ``library``
+bootstrap agent, the ``From`` keyword becomes valid. Observe the
+following example for building a Debian container from the Container
+Library:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: library
-    From: debian:7
+   Bootstrap: library
+   From: debian:7
 
-A def file that uses an official mirror to install Centos-7 might look like
-this:
+A def file that uses an official mirror to install Centos-7 might look
+like this:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: yum
-    OSVersion: 7
-    MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
-    Include: yum
+   Bootstrap: yum
+   OSVersion: 7
+   MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
+   Include: yum
 
-Each bootstrap agent enables its own options and keywords. You can read about
-them and see examples in the :ref:`appendix section<buildmodules>`:
-
+Each bootstrap agent enables its own options and keywords. You can read
+about them and see examples in the :ref:`appendix section
+<buildmodules>`:
 
 Preferred bootstrap agents
 ==========================
 
--  :ref:`library <build-library-module>` (images hosted on the `Container Library <https://cloud.sylabs.io/library>`_)
-
+-  :ref:`library <build-library-module>` (images hosted on the
+   `Container Library <https://cloud.sylabs.io/library>`_)
 -  :ref:`docker <build-docker-module>` (images hosted on Docker Hub)
-
 -  :ref:`shub <build-shub>` (images hosted on Singularity Hub)
-
 -  :ref:`oras <build-oras>` (images from supporting OCI registries)
-
--  :ref:`scratch <scratch-agent>` (a flexible option for building a container from scratch)
+-  :ref:`scratch <scratch-agent>` (a flexible option for building a
+   container from scratch)
 
 Other bootstrap agents
 ======================
 
 -  :ref:`localimage <build-localimage>` (images saved on your machine)
-
--  :ref:`yum <build-yum>` (yum based systems such as CentOS and Scientific Linux)
-
--  :ref:`debootstrap <build-debootstrap>` (apt based systems such as Debian and Ubuntu)
-
--  :ref:`oci <cli-oci-bootstrap-agent>` (bundle compliant with OCI Image Specification)
-
--  :ref:`oci-archive <cli-oci-archive-bootstrap-agent>` (tar files obeying the OCI Image Layout Specification)
-
--  :ref:`docker-daemon <docker-daemon-archive>` (images managed by the locally running docker daemon)
-
--  :ref:`docker-archive <docker-daemon-archive>` (archived docker images)
-
+-  :ref:`yum <build-yum>` (yum based systems such as CentOS and
+   Scientific Linux)
+-  :ref:`debootstrap <build-debootstrap>` (apt based systems such as
+   Debian and Ubuntu)
+-  :ref:`oci <cli-oci-bootstrap-agent>` (bundle compliant with OCI Image
+   Specification)
+-  :ref:`oci-archive <cli-oci-archive-bootstrap-agent>` (tar files
+   obeying the OCI Image Layout Specification)
+-  :ref:`docker-daemon <docker-daemon-archive>` (images managed by the
+   locally running docker daemon)
+-  :ref:`docker-archive <docker-daemon-archive>` (archived docker
+   images)
 -  :ref:`arch <build-arch>` (Arch Linux)
-
 -  :ref:`busybox <build-busybox>` (BusyBox)
-
--  :ref:`zypper <build-zypper>` (zypper based systems such as Suse and OpenSuse)
-
+-  :ref:`zypper <build-zypper>` (zypper based systems such as Suse and
+   OpenSuse)
 
 SIF Image Verification / Fingerprints Header
 ============================================
 
-If the bootstrap image is in the SIF format, then verification will
-be performed at build time. This verification checks whether the image
-has been signed. If it has been signed the integrity of the image is
+If the bootstrap image is in the SIF format, then verification will be
+performed at build time. This verification checks whether the image has
+been signed. If it has been signed the integrity of the image is
 checked, and the signatures matched to public keys if available. This
-process is equivalent to running ``singularity verify`` on the
-bootstrap image.
+process is equivalent to running ``singularity verify`` on the bootstrap
+image.
 
-By default a failed verification, e.g. against an unsigned image, or
-one that has been modified after signing, will produce a warning but
-the build will continue.
+By default a failed verification, e.g. against an unsigned image, or one
+that has been modified after signing, will produce a warning but the
+build will continue.
 
 To enforce that the bootstrap image verifies correctly and has been
 signed by one or more keys, you can use the ``Fingerprints:`` header
 introduced in {Singularity} 3.7.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: localimage
-    From: test.sif
-    Fingerprints: 12045C8C0B1004D058DE4BEDA20C27EE7FF7BA84,22045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
+   Bootstrap: localimage
+   From: test.sif
+   Fingerprints: 12045C8C0B1004D058DE4BEDA20C27EE7FF7BA84,22045C8C0B1004D058DE4BEDA20C27EE7FF7BA84
 
 If, at build time, the image is not signed with keys corresponding to
 *all* of the listed fingerprints, the build will fail.
 
 The ``Fingerprints:`` header can be used with bootstrap agents that
-provide a SIF image. The ``library`` agent always retrieves a SIF
-image. The ``localimage`` agent can be used to refer to SIF or other
-types of images.
+provide a SIF image. The ``library`` agent always retrieves a SIF image.
+The ``localimage`` agent can be used to refer to SIF or other types of
+images.
 
-The ``Fingerprints:`` header has no effect if the bootstrap image is
-not in SIF format.
-
+The ``Fingerprints:`` header has no effect if the bootstrap image is not
+in SIF format.
 
 .. note::
 
-   The verification occurs before the bootstrap image is extracted
-   into a temporary directory for the build process. The fingerprint
-   check ensures the correct image was retrieved for the build, but
-   does not protect against malicious changes that could be made
-   during the build process on a compromised machine.
+   The verification occurs before the bootstrap image is extracted into
+   a temporary directory for the build process. The fingerprint check
+   ensures the correct image was retrieved for the build, but does not
+   protect against malicious changes that could be made during the build
+   process on a compromised machine.
 
+**********
+ Sections
+**********
 
---------
-Sections
---------
+The main content of the bootstrap file is broken into sections.
+Different sections add different content or execute commands at
+different times during the build process. Note that if any command
+fails, the build process will halt.
 
-The main content of the bootstrap file is broken into sections. Different
-sections add different content or execute commands at different times during the
-build process. Note that if any command fails, the build process will halt.
+Here is an example definition file that uses every available section. We
+will discuss each section in turn. It is not necessary to include every
+section (or any sections at all) within a def file. Furthermore,
+multiple sections of the same name can be included and will be appended
+to one another during the build process.
 
-Here is an example definition file that uses every available section. We will
-discuss each section in turn. It is not necessary to include every section (or
-any sections at all) within a def file. Furthermore, multiple sections of the
-same name can be included and will be appended to one another during the build
-process.
+.. code:: singularity
 
-.. code-block:: singularity
+   Bootstrap: library
+   From: ubuntu:18.04
+   Stage: build
 
-    Bootstrap: library
-    From: ubuntu:18.04
-    Stage: build
+   %setup
+       touch /file1
+       touch ${SINGULARITY_ROOTFS}/file2
 
-    %setup
-        touch /file1
-        touch ${SINGULARITY_ROOTFS}/file2
+   %files
+       /file1
+       /file1 /opt
 
-    %files
-        /file1
-        /file1 /opt
+   %environment
+       export LISTEN_PORT=12345
+       export LC_ALL=C
 
-    %environment
-        export LISTEN_PORT=12345
-        export LC_ALL=C
+   %post
+       apt-get update && apt-get install -y netcat
+       NOW=`date`
+       echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT
 
-    %post
-        apt-get update && apt-get install -y netcat
-        NOW=`date`
-        echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT
+   %runscript
+       echo "Container was created $NOW"
+       echo "Arguments received: $*"
+       exec echo "$@"
 
-    %runscript
-        echo "Container was created $NOW"
-        echo "Arguments received: $*"
-        exec echo "$@"
+   %startscript
+       nc -lp $LISTEN_PORT
 
-    %startscript
-        nc -lp $LISTEN_PORT
+   %test
+       grep -q NAME=\"Ubuntu\" /etc/os-release
+       if [ $? -eq 0 ]; then
+           echo "Container base is Ubuntu as expected."
+       else
+           echo "Container base is not Ubuntu."
+           exit 1
+       fi
 
-    %test
-        grep -q NAME=\"Ubuntu\" /etc/os-release
-        if [ $? -eq 0 ]; then
-            echo "Container base is Ubuntu as expected."
-        else
-            echo "Container base is not Ubuntu."
-            exit 1
-        fi
+   %labels
+       Author d@sylabs.io
+       Version v0.0.1
 
-    %labels
-        Author d@sylabs.io
-        Version v0.0.1
+   %help
+       This is a demo container used to illustrate a def file that uses all
+       supported sections.
 
-    %help
-        This is a demo container used to illustrate a def file that uses all
-        supported sections.
-
-Although the order of the sections in the def file is unimportant, they have
-been documented below in the order of their execution during the build process
-for logical understanding.
+Although the order of the sections in the def file is unimportant, they
+have been documented below in the order of their execution during the
+build process for logical understanding.
 
 %setup
 ======
 
-During the build process, commands in the ``%setup`` section are first executed
-on the host system outside of the container after the base OS has been installed.
-You can reference the container file system with the ``$SINGULARITY_ROOTFS``
-environment variable in the ``%setup`` section.
+During the build process, commands in the ``%setup`` section are first
+executed on the host system outside of the container after the base OS
+has been installed. You can reference the container file system with the
+``$SINGULARITY_ROOTFS`` environment variable in the ``%setup`` section.
 
 .. note::
 
-    Be careful with the ``%setup`` section! This scriptlet is executed outside
-    of the container on the host system itself, and is executed with elevated
-    privileges. Commands in ``%setup`` can alter and potentially damage the
-    host.
+   Be careful with the ``%setup`` section! This scriptlet is executed
+   outside of the container on the host system itself, and is executed
+   with elevated privileges. Commands in ``%setup`` can alter and
+   potentially damage the host.
 
 Consider the example from the definition file above:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %setup
-        touch /file1
-        touch ${SINGULARITY_ROOTFS}/file2
+   %setup
+       touch /file1
+       touch ${SINGULARITY_ROOTFS}/file2
 
-Here, ``file1`` is created at the root of the file system **on the host**.
-We'll use ``file1`` to demonstrate the usage of the ``%files`` section below.
-The ``file2`` is created at the root of the file system **within the
-container**.
+Here, ``file1`` is created at the root of the file system **on the
+host**. We'll use ``file1`` to demonstrate the usage of the ``%files``
+section below. The ``file2`` is created at the root of the file system
+**within the container**.
 
-In later versions of {Singularity} the ``%files`` section is provided as a safer
-alternative to copying files from the host system into the container during the
-build. Because of the potential danger involved in running the ``%setup``
-scriptlet with elevated privileges on the host system during the build, it's
-use is generally discouraged.
+In later versions of {Singularity} the ``%files`` section is provided as
+a safer alternative to copying files from the host system into the
+container during the build. Because of the potential danger involved in
+running the ``%setup`` scriptlet with elevated privileges on the host
+system during the build, it's use is generally discouraged.
 
 %files
 ======
 
-The ``%files`` section allows you to copy files into the container with greater
-safety than using the ``%setup`` section. Its general form is:
+The ``%files`` section allows you to copy files into the container with
+greater safety than using the ``%setup`` section. Its general form is:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %files [from <stage>]
-        <source> [<destination>]
-        ...
+   %files [from <stage>]
+       <source> [<destination>]
+       ...
 
-Each line is a ``<source>`` and ``<destination>`` pair. The ``<source>`` is either:
+Each line is a ``<source>`` and ``<destination>`` pair. The ``<source>``
+is either:
 
-  1. A valid path on your host system
-  2. A valid path in a previous stage of the build
+  #. A valid path on your host system
+  #. A valid path in a previous stage of the build
 
 while the ``<destination>`` is always a path into the current container. If the
-``<destination>`` path is omitted it will be assumed to be the same as ``<source>``.
-To show how copying from your host system works, let's consider the example from
-the definition file above:
+``<destination>`` path is omitted it will be assumed to be the same as
+``<source>``. To show how copying from your host system works, let's
+consider the example from the definition file above:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %files
-        /file1
-        /file1 /opt
+   %files
+       /file1
+       /file1 /opt
 
 ``file1`` was created in the root of the host file system during the ``%setup``
 section (see above).  The ``%files`` scriptlet will copy ``file1`` to the root
@@ -303,181 +298,184 @@ container in ``/opt``.
 Files can also be copied from other stages by providing the source location in the
 previous stage and the destination in the current container.
 
-.. code-block:: singularity
+.. code:: singularity
 
-  %files from stage_name
-    /root/hello /bin/hello
+   %files from stage_name
+     /root/hello /bin/hello
 
-The only difference in behavior between copying files from your host system and copying them
-from previous stages is that in the former case symbolic links are always followed
-during the copy to the container, while in the latter symbolic links are preserved.
+The only difference in behavior between copying files from your host
+system and copying them from previous stages is that in the former case
+symbolic links are always followed during the copy to the container,
+while in the latter symbolic links are preserved.
 
-Files in the ``%files`` section are always copied before the ``%post`` section is
-executed so that they are available during the build and configuration process.
+Files in the ``%files`` section are always copied before the ``%post``
+section is executed so that they are available during the build and
+configuration process.
 
 %app*
 =====
 
-In some circumstances, it may be redundant to build different containers for
-each app with nearly equivalent dependencies. {Singularity} supports installing
-apps within internal modules based on the concept of the `Scientific Filesystem (SCIF) <https://sci-f.github.io/>`_.
-More information on defining and using SCIF Apps :ref:`here <apps>`.
+In some circumstances, it may be redundant to build different containers
+for each app with nearly equivalent dependencies. {Singularity} supports
+installing apps within internal modules based on the concept of the
+`Scientific Filesystem (SCIF) <https://sci-f.github.io/>`_. More
+information on defining and using SCIF Apps :ref:`here <apps>`.
 
 %post
 =====
 
-This section is where you can download files from the internet with tools like ``git``
-and ``wget``, install new software and libraries, write configuration files,
-create new directories, etc.
+This section is where you can download files from the internet with
+tools like ``git`` and ``wget``, install new software and libraries,
+write configuration files, create new directories, etc.
 
 Consider the example from the definition file above:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %post
-        apt-get update && apt-get install -y netcat
-        NOW=`date`
-        echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT
+   %post
+       apt-get update && apt-get install -y netcat
+       NOW=`date`
+       echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT
 
+This ``%post`` scriptlet uses the Ubuntu package manager ``apt`` to
+update the container and install the program ``netcat`` (that will be
+used in the ``%startscript`` section below).
 
-This ``%post`` scriptlet uses the Ubuntu package manager ``apt`` to update the
-container and install the program ``netcat`` (that will be used in the
-``%startscript`` section below).
-
-The script is also setting an environment variable at build time.  Note that the
-value of this variable cannot be anticipated, and therefore cannot be set during
-the ``%environment`` section. For situations like this, the ``$SINGULARITY_ENVIRONMENT``
-variable is provided. Redirecting text to this variable will cause it to be
-written to a file called ``/.singularity.d/env/91-environment.sh`` that will be
-sourced at runtime.
+The script is also setting an environment variable at build time. Note
+that the value of this variable cannot be anticipated, and therefore
+cannot be set during the ``%environment`` section. For situations like
+this, the ``$SINGULARITY_ENVIRONMENT`` variable is provided. Redirecting
+text to this variable will cause it to be written to a file called
+``/.singularity.d/env/91-environment.sh`` that will be sourced at
+runtime.
 
 %test
 =====
 
 The ``%test`` section runs at the very end of the build process to
 validate the container using a method of your choice. You can also
-execute this scriptlet through the container itself, using the
-``test`` command.
+execute this scriptlet through the container itself, using the ``test``
+command.
 
 Consider the example from the def file above:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %test
-        grep -q NAME=\"Ubuntu\" /etc/os-release
-        if [ $? -eq 0 ]; then
-            echo "Container base is Ubuntu as expected."
-        else
-            echo "Container base is not Ubuntu."
-            exit 1
-        fi
-
+   %test
+       grep -q NAME=\"Ubuntu\" /etc/os-release
+       if [ $? -eq 0 ]; then
+           echo "Container base is Ubuntu as expected."
+       else
+           echo "Container base is not Ubuntu."
+           exit 1
+       fi
 
 This (somewhat silly) script tests if the base OS is Ubuntu. You could
-also write a script to test that binaries were appropriately
-downloaded and built, or that software works as expected on custom
-hardware. If you want to build a container without running the
-``%test`` section (for example, if the build system does not have the
-same hardware that will be used on the production system), you can do
-so with the ``--notest`` build option:
+also write a script to test that binaries were appropriately downloaded
+and built, or that software works as expected on custom hardware. If you
+want to build a container without running the ``%test`` section (for
+example, if the build system does not have the same hardware that will
+be used on the production system), you can do so with the ``--notest``
+build option:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build --notest my_container.sif my_container.def
+   $ sudo singularity build --notest my_container.sif my_container.def
 
-Running the test command on a container built with this def file yields the
-following:
+Running the test command on a container built with this def file yields
+the following:
 
-.. code-block::
+.. code::
 
-    $ singularity test my_container.sif
-    Container base is Ubuntu as expected.
+   $ singularity test my_container.sif
+   Container base is Ubuntu as expected.
 
-One common use of the ``%test`` section is to run a quick check that
-the programs you intend to install in the container are present. If
-you installed the program ``samtools``, which shows a usage screen when
-run without any options, you might test it can be run with:
+One common use of the ``%test`` section is to run a quick check that the
+programs you intend to install in the container are present. If you
+installed the program ``samtools``, which shows a usage screen when run
+without any options, you might test it can be run with:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %test
-        # Run samtools - exits okay with usage screen if installed
-        samtools
+   %test
+       # Run samtools - exits okay with usage screen if installed
+       samtools
 
 If ``samtools`` is not successfully installed in the container then the
-``singularity test`` will exit with an error such as ``samtools:
-command not found``.
+``singularity test`` will exit with an error such as ``samtools: command
+not found``.
 
-Some programs return an error code when run without mandatory
-options. If you want to ignore this, and just check the program is
-present and can be called, you can run it as ``myprog || true`` in
-your test:
+Some programs return an error code when run without mandatory options.
+If you want to ignore this, and just check the program is present and
+can be called, you can run it as ``myprog || true`` in your test:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %test
-        # Run bwa - exits with error code if installed and run without
-        # options
-        bwa || true
+   %test
+       # Run bwa - exits with error code if installed and run without
+       # options
+       bwa || true
 
-The ``|| true`` means that if the command before it is found but
-returns an error code it will be ignored, and replaced with the error
-code from ``true`` - which is always ``0`` indicating success.
+The ``|| true`` means that if the command before it is found but returns
+an error code it will be ignored, and replaced with the error code from
+``true`` - which is always ``0`` indicating success.
 
 Because the ``%test`` section is a shell scriptlet, complex tests are
-possible. Your scriptlet should usually be written so it will exit
-with a non-zero error code if there is a problem during the tests.
+possible. Your scriptlet should usually be written so it will exit with
+a non-zero error code if there is a problem during the tests.
 
-Now, the following sections are all inserted into the container filesystem in
-single step:
+Now, the following sections are all inserted into the container
+filesystem in single step:
 
 %environment
 ============
 
-The ``%environment`` section allows you to define environment variables that
-will be set at runtime. Note that these variables are not made available at
-build time by their inclusion in the ``%environment`` section. This means that
-if you need the same variables during the build process, you should also define
-them in your ``%post`` section. Specifically:
+The ``%environment`` section allows you to define environment variables
+that will be set at runtime. Note that these variables are not made
+available at build time by their inclusion in the ``%environment``
+section. This means that if you need the same variables during the build
+process, you should also define them in your ``%post`` section.
+Specifically:
 
--  **during build**: The ``%environment`` section is written to a file in the
-   container metadata directory. This file is not sourced.
+-  **during build**: The ``%environment`` section is written to a file
+   in the container metadata directory. This file is not sourced.
+-  **during runtime**: The file in the container metadata directory is
+   sourced.
 
--  **during runtime**: The file in the container metadata directory is sourced.
+You should use the same conventions that you would use in a ``.bashrc``
+or ``.profile`` file. Consider this example from the def file above:
 
-You should use the same conventions that you would use in a ``.bashrc`` or
-``.profile`` file. Consider this example from the def file above:
+.. code:: singularity
 
-.. code-block:: singularity
+   %environment
+       export LISTEN_PORT=12345
+       export LC_ALL=C
 
-    %environment
-        export LISTEN_PORT=12345
-        export LC_ALL=C
+The ``$LISTEN_PORT`` variable will be used in the ``%startscript``
+section below. The ``$LC_ALL`` variable is useful for many programs
+(often written in Perl) that complain when no locale is set.
 
-The ``$LISTEN_PORT`` variable will be used in the ``%startscript`` section
-below. The ``$LC_ALL`` variable is useful for many programs (often written in
-Perl) that complain when no locale is set.
+After building this container, you can verify that the environment
+variables are set appropriately at runtime with the following command:
 
-After building this container, you can verify that the environment variables are
-set appropriately at runtime with the following command:
+.. code::
 
-.. code-block::
+   $ singularity exec my_container.sif env | grep -E 'LISTEN_PORT|LC_ALL'
+   LISTEN_PORT=12345
+   LC_ALL=C
 
-    $ singularity exec my_container.sif env | grep -E 'LISTEN_PORT|LC_ALL'
-    LISTEN_PORT=12345
-    LC_ALL=C
+In the special case of variables generated at build time, you can also
+add environment variables to your container in the ``%post`` section.
 
-In the special case of variables generated at build time, you can also add
-environment variables to your container in the ``%post`` section.
+At build time, the content of the ``%environment`` section is written to
+a file called ``/.singularity.d/env/90-environment.sh`` inside of the
+container. Text redirected to the ``$SINGULARITY_ENVIRONMENT`` variable
+during ``%post`` is added to a file called
+``/.singularity.d/env/91-environment.sh``.
 
-At build time, the content of the ``%environment`` section is written to a file
-called ``/.singularity.d/env/90-environment.sh`` inside of the container.  Text
-redirected to the ``$SINGULARITY_ENVIRONMENT`` variable during ``%post`` is
-added to a file called ``/.singularity.d/env/91-environment.sh``.
-
-At runtime, scripts in ``/.singularity/env`` are sourced in order. This means
-that variables in the ``%post`` section take precedence over those added  via
-``%environment``.
+At runtime, scripts in ``/.singularity/env`` are sourced in order. This
+means that variables in the ``%post`` section take precedence over those
+added via ``%environment``.
 
 See :ref:`Environment and Metadata <environment-and-metadata>` for more
 information about the {Singularity} container environment.
@@ -487,201 +485,206 @@ information about the {Singularity} container environment.
 %startscript
 ============
 
-Similar to the ``%runscript`` section, the contents of the ``%startscript``
-section is written to a file within the container at build time.  This file is
-executed when the ``instance start`` command is issued.
+Similar to the ``%runscript`` section, the contents of the
+``%startscript`` section is written to a file within the container at
+build time. This file is executed when the ``instance start`` command is
+issued.
 
 Consider the example from the def file above.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %startscript
-        nc -lp $LISTEN_PORT
+   %startscript
+       nc -lp $LISTEN_PORT
 
-Here the netcat program is used to listen for TCP traffic on the port indicated
-by the ``$LISTEN_PORT`` variable (set in the ``%environment`` section above).
-The script can be invoked like so:
+Here the netcat program is used to listen for TCP traffic on the port
+indicated by the ``$LISTEN_PORT`` variable (set in the ``%environment``
+section above). The script can be invoked like so:
 
-.. code-block::
+.. code::
 
-    $ singularity instance start my_container.sif instance1
-    INFO:    instance started successfully
+   $ singularity instance start my_container.sif instance1
+   INFO:    instance started successfully
 
-    $ lsof | grep LISTEN
-    nc        19061               vagrant    3u     IPv4             107409      0t0        TCP *:12345 (LISTEN)
+   $ lsof | grep LISTEN
+   nc        19061               vagrant    3u     IPv4             107409      0t0        TCP *:12345 (LISTEN)
 
-    $ singularity instance stop instance1
-    Stopping instance1 instance of /home/vagrant/my_container.sif (PID=19035)
-
+   $ singularity instance stop instance1
+   Stopping instance1 instance of /home/vagrant/my_container.sif (PID=19035)
 
 .. _runscript:
 
 %runscript
 ==========
 
-The contents of the ``%runscript`` section are written to a file within the
-container that is executed when the container image is run (either via the
-``singularity run`` command or by executing the container directly as a
-command). When the container is invoked, arguments following the container name
-are passed to the runscript. This means that you can (and should) process
-arguments within your runscript.
+The contents of the ``%runscript`` section are written to a file within
+the container that is executed when the container image is run (either
+via the ``singularity run`` command or by executing the container
+directly as a command). When the container is invoked, arguments
+following the container name are passed to the runscript. This means
+that you can (and should) process arguments within your runscript.
 
 Consider the example from the def file above:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %runscript
-        echo "Container was created $NOW"
-        echo "Arguments received: $*"
-        exec echo "$@"
+   %runscript
+       echo "Container was created $NOW"
+       echo "Arguments received: $*"
+       exec echo "$@"
 
-In this runscript, the time that the container was created is echoed via the
-``$NOW`` variable (set in the ``%post`` section above). The options passed to
-the container at runtime are printed as a single string (``$*``) and then they
-are passed to echo via a quoted array (``$@``) which ensures that all of the
-arguments are properly parsed by the executed command. The ``exec`` preceding
-the final ``echo`` command replaces the current entry in the process table
-(which originally was the call to {Singularity}). Thus the runscript shell process
-ceases to exist, and only the process running within the container remains.
+In this runscript, the time that the container was created is echoed via
+the ``$NOW`` variable (set in the ``%post`` section above). The options
+passed to the container at runtime are printed as a single string
+(``$*``) and then they are passed to echo via a quoted array (``$@``)
+which ensures that all of the arguments are properly parsed by the
+executed command. The ``exec`` preceding the final ``echo`` command
+replaces the current entry in the process table (which originally was
+the call to {Singularity}). Thus the runscript shell process ceases to
+exist, and only the process running within the container remains.
 
-Running the container built using this def file will yield the following:
+Running the container built using this def file will yield the
+following:
 
-.. code-block::
+.. code::
 
-    $ ./my_container.sif
-    Container was created Thu Dec  6 20:01:56 UTC 2018
-    Arguments received:
+   $ ./my_container.sif
+   Container was created Thu Dec  6 20:01:56 UTC 2018
+   Arguments received:
 
-    $ ./my_container.sif this that and the other
-    Container was created Thu Dec  6 20:01:56 UTC 2018
-    Arguments received: this that and the other
-    this that and the other
-
+   $ ./my_container.sif this that and the other
+   Container was created Thu Dec  6 20:01:56 UTC 2018
+   Arguments received: this that and the other
+   this that and the other
 
 %labels
 =======
 
 The ``%labels`` section is used to add metadata to the file
-``/.singularity.d/labels.json`` within your container. The general format is a
-name-value pair.
+``/.singularity.d/labels.json`` within your container. The general
+format is a name-value pair.
 
 Consider the example from the def file above:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %labels
-        Author d@sylabs.io
-        Version v0.0.1
-        MyLabel Hello World
+   %labels
+       Author d@sylabs.io
+       Version v0.0.1
+       MyLabel Hello World
 
-
-Note that labels are defined by key-value pairs. To define a label just add it
-on the labels section and after the first space character add the correspondent value to the label.
+Note that labels are defined by key-value pairs. To define a label just
+add it on the labels section and after the first space character add the
+correspondent value to the label.
 
 In the previous example, the first label name is ``Author``` with a
-value of ``d@sylabs.io``. The second label name is ``Version`` with a value of ``v0.0.1``.
-Finally, the last label named ``MyLabel`` has the value of ``Hello World``.
+value of ``d@sylabs.io``. The second label name is ``Version`` with a
+value of ``v0.0.1``. Finally, the last label named ``MyLabel`` has the
+value of ``Hello World``.
 
-To inspect the available labels on your image you can do so by running the following command:
+To inspect the available labels on your image you can do so by running
+the following command:
 
-.. code-block::
+.. code::
 
-    $ singularity inspect my_container.sif
+   $ singularity inspect my_container.sif
 
-    {
-      "Author": "d@sylabs.io",
-      "Version": "v0.0.1",
-      "MyLabel": "Hello World",
-      "org.label-schema.build-date": "Thursday_6_December_2018_20:1:56_UTC",
-      "org.label-schema.schema-version": "1.0",
-      "org.label-schema.usage": "/.singularity.d/runscript.help",
-      "org.label-schema.usage.singularity.deffile.bootstrap": "library",
-      "org.label-schema.usage.singularity.deffile.from": "ubuntu:18.04",
-      "org.label-schema.usage.singularity.runscript.help": "/.singularity.d/runscript.help",
-      "org.label-schema.usage.singularity.version": "3.0.1"
-    }
+   {
+     "Author": "d@sylabs.io",
+     "Version": "v0.0.1",
+     "MyLabel": "Hello World",
+     "org.label-schema.build-date": "Thursday_6_December_2018_20:1:56_UTC",
+     "org.label-schema.schema-version": "1.0",
+     "org.label-schema.usage": "/.singularity.d/runscript.help",
+     "org.label-schema.usage.singularity.deffile.bootstrap": "library",
+     "org.label-schema.usage.singularity.deffile.from": "ubuntu:18.04",
+     "org.label-schema.usage.singularity.runscript.help": "/.singularity.d/runscript.help",
+     "org.label-schema.usage.singularity.version": "3.0.1"
+   }
 
-Some labels that are captured automatically from the build process. You can read
-more about labels and metadata :ref:`here <environment-and-metadata>`.
+Some labels that are captured automatically from the build process. You
+can read more about labels and metadata :ref:`here
+<environment-and-metadata>`.
 
 %help
 =====
 
-Any text in the ``%help`` section is transcribed into a metadata file in the
-container during the build. This text can then be displayed using the
-``run-help`` command.
+Any text in the ``%help`` section is transcribed into a metadata file in
+the container during the build. This text can then be displayed using
+the ``run-help`` command.
 
 Consider the example from the def file above:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %help
-        This is a demo container used to illustrate a def file that uses all
-        supported sections.
+   %help
+       This is a demo container used to illustrate a def file that uses all
+       supported sections.
 
 After building the help can be displayed like so:
 
-.. code-block::
+.. code::
 
-    $ singularity run-help my_container.sif
-        This is a demo container used to illustrate a def file that uses all
-        supported sections.
+   $ singularity run-help my_container.sif
+       This is a demo container used to illustrate a def file that uses all
+       supported sections.
 
-------------------
-Multi-Stage Builds
-------------------
+********************
+ Multi-Stage Builds
+********************
 
-Starting with {Singularity} v3.2 multi-stage builds are supported where one environment
-can be used for compilation, then the resulting binary can be copied into a final
-environment. This allows a slimmer final image that does not require the entire
-development stack.
+Starting with {Singularity} v3.2 multi-stage builds are supported where
+one environment can be used for compilation, then the resulting binary
+can be copied into a final environment. This allows a slimmer final
+image that does not require the entire development stack.
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: docker
-    From: golang:1.12.3-alpine3.9
-    Stage: devel
+   Bootstrap: docker
+   From: golang:1.12.3-alpine3.9
+   Stage: devel
 
-    %post
-      # prep environment
-      export PATH="/go/bin:/usr/local/go/bin:$PATH"
-      export HOME="/root"
-      cd /root
+   %post
+     # prep environment
+     export PATH="/go/bin:/usr/local/go/bin:$PATH"
+     export HOME="/root"
+     cd /root
 
-      # insert source code, could also be copied from the host with %files
-      cat << EOF > hello.go
-      package main
-      import "fmt"
+     # insert source code, could also be copied from the host with %files
+     cat << EOF > hello.go
+     package main
+     import "fmt"
 
-      func main() {
-        fmt.Printf("Hello World!\n")
-      }
-    EOF
+     func main() {
+       fmt.Printf("Hello World!\n")
+     }
+   EOF
 
-      go build -o hello hello.go
+     go build -o hello hello.go
 
 
-    # Install binary into the final image
-    Bootstrap: library
-    From: alpine:3.9
-    Stage: final
+   # Install binary into the final image
+   Bootstrap: library
+   From: alpine:3.9
+   Stage: final
 
-    # install binary from stage one
-    %files from devel
-      /root/hello /bin/hello
+   # install binary from stage one
+   %files from devel
+     /root/hello /bin/hello
 
-The names of stages are arbitrary. Each of these sections will be executed in
-the same order as described for a single stage build except the files from the
-previous stage are copied before ``%setup`` section of the next stage. Files
-can only be copied from stages declared before the current stage in the definition.
-E.g., the ``devel`` stage in the above definition cannot copy files from the
-``final`` stage, but the ``final`` stage can copy files from the ``devel`` stage.
+The names of stages are arbitrary. Each of these sections will be
+executed in the same order as described for a single stage build except
+the files from the previous stage are copied before ``%setup`` section
+of the next stage. Files can only be copied from stages declared before
+the current stage in the definition. E.g., the ``devel`` stage in the
+above definition cannot copy files from the ``final`` stage, but the
+``final`` stage can copy files from the ``devel`` stage.
 
 .. _apps:
 
----------
-SCIF Apps
----------
+***********
+ SCIF Apps
+***********
 
 SCIF is a standard for encapsulating multiple apps into a container. A
 container with SCIF apps has multiple entry points, and you can choose
@@ -692,120 +695,122 @@ collection of different containers.
 {Singularity} implements SCIF, and you can read more about how to use it
 below.
 
-SCIF is not specific to {Singularity}. You can learn more about it at the
-project's site: `<https://sci-f.github.io/>`_ which includes extended
+SCIF is not specific to {Singularity}. You can learn more about it at
+the project's site: https://sci-f.github.io/ which includes extended
 tutorials, the specification, and other information.
 
 SCIF %app* sections
 ===================
 
 SCIF apps within a {Singularity} container are created using ``%app*``
-sections in a definition file. These ``%app*`` sections, which will impact the
-way the container runs a specific ``--app`` can exist alongside any of the 
-primary sections (i.e.  ``%post``,``%runscript``, ``%environment``, etc.).  As
-with the other sections, the ordering of the ``%app*`` sections isn’t important.
+sections in a definition file. These ``%app*`` sections, which will
+impact the way the container runs a specific ``--app`` can exist
+alongside any of the primary sections (i.e. ``%post``,``%runscript``,
+``%environment``, etc.). As with the other sections, the ordering of the
+``%app*`` sections isn’t important.
 
-The following runscript demonstrates how to build 2 different apps into the
-same container using SCIF modules:
+The following runscript demonstrates how to build 2 different apps into
+the same container using SCIF modules:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: docker
-    From: ubuntu
+   Bootstrap: docker
+   From: ubuntu
 
-    %environment
-        GLOBAL=variables
-        AVAILABLE="to all apps"
+   %environment
+       GLOBAL=variables
+       AVAILABLE="to all apps"
 
-    ##############################
-    # foo
-    ##############################
+   ##############################
+   # foo
+   ##############################
 
-    %apprun foo
-        exec echo "RUNNING FOO"
+   %apprun foo
+       exec echo "RUNNING FOO"
 
-    %applabels foo
-       BESTAPP FOO
+   %applabels foo
+      BESTAPP FOO
 
-    %appinstall foo
-       touch foo.exec
+   %appinstall foo
+      touch foo.exec
 
-    %appenv foo
-        SOFTWARE=foo
-        export SOFTWARE
+   %appenv foo
+       SOFTWARE=foo
+       export SOFTWARE
 
-    %apphelp foo
-        This is the help for foo.
+   %apphelp foo
+       This is the help for foo.
 
-    %appfiles foo
-       foo.txt
+   %appfiles foo
+      foo.txt
 
-    ##############################
-    # bar
-    ##############################
+   ##############################
+   # bar
+   ##############################
 
-    %apphelp bar
-        This is the help for bar.
+   %apphelp bar
+       This is the help for bar.
 
-    %applabels bar
-       BESTAPP BAR
+   %applabels bar
+      BESTAPP BAR
 
-    %appinstall bar
-        touch bar.exec
+   %appinstall bar
+       touch bar.exec
 
-    %appenv bar
-        SOFTWARE=bar
-        export SOFTWARE
+   %appenv bar
+       SOFTWARE=bar
+       export SOFTWARE
 
-An ``%appinstall`` section is the equivalent of ``%post`` but for a particular
-app. Similarly, ``%appenv`` equates to the app version of ``%environment`` and
-so on.
+An ``%appinstall`` section is the equivalent of ``%post`` but for a
+particular app. Similarly, ``%appenv`` equates to the app version of
+``%environment`` and so on.
 
-After installing apps into modules using the ``%app*`` sections, the ``--app``
-option becomes available allowing the following functions:
+After installing apps into modules using the ``%app*`` sections, the
+``--app`` option becomes available allowing the following functions:
 
 To run a specific app within the container:
 
-.. code-block::
+.. code::
 
-    % singularity run --app foo my_container.sif
-    RUNNING FOO
+   % singularity run --app foo my_container.sif
+   RUNNING FOO
 
-The same environment variable, ``$SOFTWARE`` is defined for both apps in the def
-file above. You can execute the following command to search the list of active
-environment variables and ``grep`` to determine if the variable changes
-depending on the app we specify:
+The same environment variable, ``$SOFTWARE`` is defined for both apps in
+the def file above. You can execute the following command to search the
+list of active environment variables and ``grep`` to determine if the
+variable changes depending on the app we specify:
 
-.. code-block::
+.. code::
 
-    $ singularity exec --app foo my_container.sif env | grep SOFTWARE
-    SOFTWARE=foo
+   $ singularity exec --app foo my_container.sif env | grep SOFTWARE
+   SOFTWARE=foo
 
-    $ singularity exec --app bar my_container.sif env | grep SOFTWARE
-    SOFTWARE=bar
+   $ singularity exec --app bar my_container.sif env | grep SOFTWARE
+   SOFTWARE=bar
 
---------------------------------
-Best Practices for Build Recipes
---------------------------------
+**********************************
+ Best Practices for Build Recipes
+**********************************
 
 When crafting your recipe, it is best to consider the following:
 
-#. Always install packages, programs, data, and files into operating system
-   locations (e.g. not ``/home``, ``/tmp`` , or any other directories that might
-   get commonly binded on).
+#. Always install packages, programs, data, and files into operating
+   system locations (e.g. not ``/home``, ``/tmp`` , or any other
+   directories that might get commonly binded on).
 
-#. Document your container. If your runscript doesn’t supply help, write a
-   ``%help`` or ``%apphelp`` section. A good container tells the user how to
-   interact with it.
+#. Document your container. If your runscript doesn’t supply help, write
+   a ``%help`` or ``%apphelp`` section. A good container tells the user
+   how to interact with it.
 
-#. If you require any special environment variables to be defined, add them to
-   the ``%environment`` and ``%appenv`` sections of the build recipe.
+#. If you require any special environment variables to be defined, add
+   them to the ``%environment`` and ``%appenv`` sections of the build
+   recipe.
 
 #. Files should always be owned by a system account (UID less than 500).
 
 #. Ensure that sensitive files like ``/etc/passwd``, ``/etc/group``, and
    ``/etc/shadow`` do not contain secrets.
 
-#. Build production containers from a definition file instead of a sandbox that
-   has been manually changed. This ensures the greatest possibility of
-   reproducibility and mitigates the "black box" effect.
+#. Build production containers from a definition file instead of a
+   sandbox that has been manually changed. This ensures the greatest
+   possibility of reproducibility and mitigates the "black box" effect.

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -381,14 +381,14 @@ hardware. If you want to build a container without running the
 same hardware that will be used on the production system), you can do
 so with the ``--notest`` build option:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build --notest my_container.sif my_container.def
 
 Running the test command on a container built with this def file yields the
 following:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity test my_container.sif
     Container base is Ubuntu as expected.
@@ -461,7 +461,7 @@ Perl) that complain when no locale is set.
 After building this container, you can verify that the environment variables are
 set appropriately at runtime with the following command:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity exec my_container.sif env | grep -E 'LISTEN_PORT|LC_ALL'
     LISTEN_PORT=12345
@@ -502,7 +502,7 @@ Here the netcat program is used to listen for TCP traffic on the port indicated
 by the ``$LISTEN_PORT`` variable (set in the ``%environment`` section above).
 The script can be invoked like so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity instance start my_container.sif instance1
     INFO:    instance started successfully
@@ -546,7 +546,7 @@ ceases to exist, and only the process running within the container remains.
 
 Running the container built using this def file will yield the following:
 
-.. code-block:: none
+.. code-block::
 
     $ ./my_container.sif
     Container was created Thu Dec  6 20:01:56 UTC 2018
@@ -584,7 +584,7 @@ Finally, the last label named ``MyLabel`` has the value of ``Hello World``.
 
 To inspect the available labels on your image you can do so by running the following command:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity inspect my_container.sif
 
@@ -621,7 +621,7 @@ Consider the example from the def file above:
 
 After building the help can be displayed like so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run-help my_container.sif
         This is a demo container used to illustrate a def file that uses all
@@ -766,7 +766,7 @@ option becomes available allowing the following functions:
 
 To run a specific app within the container:
 
-.. code-block:: none
+.. code-block::
 
     % singularity run --app foo my_container.sif
     RUNNING FOO
@@ -776,7 +776,7 @@ file above. You can execute the following command to search the list of active
 environment variables and ``grep`` to determine if the variable changes
 depending on the app we specify:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity exec --app foo my_container.sif env | grep SOFTWARE
     SOFTWARE=foo

--- a/encryption.rst
+++ b/encryption.rst
@@ -1,66 +1,68 @@
 .. _encryption:
 
-====================
-Encrypted Containers
-====================
+######################
+ Encrypted Containers
+######################
 
-Users can build a secure, confidential container environment by encrypting the 
-root file system.
+Users can build a secure, confidential container environment by
+encrypting the root file system.
 
---------
-Overview
---------
+**********
+ Overview
+**********
 
-In {Singularity} >= v3.4.0 a new feature to build and run encrypted containers has
-been added to allow users to encrypt the file system image within a SIF.  This
-encryption can be performed using either a passphrase or asymmetrically via an
-RSA key pair in Privacy Enhanced Mail (PEM/PKCS1) format. The container is encrypted
-in transit, at rest, and even while running. In other words, there is no
-intermediate, decrypted version of the container on disk.  Container decryption
-occurs at runtime completely within kernel space.  
-
-
-.. note::
-
-        This feature utilizes the Linux ``dm-crypt`` library and ``cryptsetup``
-        utility and requires cryptsetup version of >= 2.0.0.  This version
-        should be standard with recent Linux versions such as Ubuntu 18.04,
-        Debian 10 and CentOS/RHEL 7, but users of older Linux versions may have
-        to update.
-
-----------------------
-Encrypting a container
-----------------------
-
-A container can be encrypted either by supplying a plaintext passphrase or a 
-PEM file containing an asymmetric RSA public key.  Of these two methods the PEM
-file is more secure and is therefore recommended for production use. 
+In {Singularity} >= v3.4.0 a new feature to build and run encrypted
+containers has been added to allow users to encrypt the file system
+image within a SIF. This encryption can be performed using either a
+passphrase or asymmetrically via an RSA key pair in Privacy Enhanced
+Mail (PEM/PKCS1) format. The container is encrypted in transit, at rest,
+and even while running. In other words, there is no intermediate,
+decrypted version of the container on disk. Container decryption occurs
+at runtime completely within kernel space.
 
 .. note::
 
-        In {Singularity} 3.4, the definition file stored with the container will
-        not be encrypted. If it contains sensitive information you should remove
-        it before encryption via ``singularity sif del 1 myimage.sif``. Metadata
-        encryption will be addressed in a future release.
+   This feature utilizes the Linux ``dm-crypt`` library and
+   ``cryptsetup`` utility and requires cryptsetup version of >= 2.0.0.
+   This version should be standard with recent Linux versions such as
+   Ubuntu 18.04, Debian 10 and CentOS/RHEL 7, but users of older Linux
+   versions may have to update.
 
-An ``-e|--encrypt`` flag to ``singularity build`` is used to indicate that the container needs to 
-be encrypted.
+************************
+ Encrypting a container
+************************
 
-A passphrase or a key-file used to perform the encryption is supplied at build time
-via an environment variable or a command line option. 
+A container can be encrypted either by supplying a plaintext passphrase
+or a PEM file containing an asymmetric RSA public key. Of these two
+methods the PEM file is more secure and is therefore recommended for
+production use.
+
+.. note::
+
+   In {Singularity} 3.4, the definition file stored with the container
+   will not be encrypted. If it contains sensitive information you
+   should remove it before encryption via ``singularity sif del 1
+   myimage.sif``. Metadata encryption will be addressed in a future
+   release.
+
+An ``-e|--encrypt`` flag to ``singularity build`` is used to indicate
+that the container needs to be encrypted.
+
+A passphrase or a key-file used to perform the encryption is supplied at
+build time via an environment variable or a command line option.
 
 +------------------------+-------------------------------------------+--------------------------+
 | **Encryption Method**  | **Environment Variable**                  | **Commandline Option**   |
 +------------------------+-------------------------------------------+--------------------------+
 | Passphrase             | ``SINGULARITY_ENCRYPTION_PASSPHRASE``     | ``--passphrase``         |
 +------------------------+-------------------------------------------+--------------------------+
-| Asymmetric Key (PEM)   | ``SINGULARITY_ENCRYPTION_PEM_PATH``       | ``--pem-path``           | 
+| Asymmetric Key (PEM)   | ``SINGULARITY_ENCRYPTION_PEM_PATH``       | ``--pem-path``           |
 +------------------------+-------------------------------------------+--------------------------+
 
 The ``-e|--encrypt`` flag is implicitly set when the ``--passphrase`` or
-``--pem-path`` flags are passed with the build command.  If multiple encryption
-related flags and/or environment variables are set, the following precedence is
-respected.  
+``--pem-path`` flags are passed with the build command. If multiple
+encryption related flags and/or environment variables are set, the
+following precedence is respected.
 
 #. ``--pem-path``
 #. ``--passphrase``
@@ -72,152 +74,157 @@ Passphrase Encryption
 
 .. note::
 
-        Passphrase encryption is less secure than encrypting containers using an 
-        RSA key pair (detailed below).  Passphrase encryption is provided as a 
-        convenience, and as a way for users to familiarize themselves with the 
-        encrypted container workflow, but users running encrypted containers in 
-        production are encouraged to use asymmetric keys.   
+   Passphrase encryption is less secure than encrypting containers using
+   an RSA key pair (detailed below). Passphrase encryption is provided
+   as a convenience, and as a way for users to familiarize themselves
+   with the encrypted container workflow, but users running encrypted
+   containers in production are encouraged to use asymmetric keys.
 
-In case of plaintext passphrase encryption, a passphrase is supplied by one of 
-the following methods.
+In case of plaintext passphrase encryption, a passphrase is supplied by
+one of the following methods.
 
 Encrypting with a passphrase interactively
 ------------------------------------------
 
-.. code-block::
+.. code::
 
-        $ sudo singularity build --passphrase encrypted.sif encrypted.def
-        Enter encryption passphrase: <secret>
-        INFO:    Starting build...
+   $ sudo singularity build --passphrase encrypted.sif encrypted.def
+   Enter encryption passphrase: <secret>
+   INFO:    Starting build...
 
 Using an environment variable
 -----------------------------
 
-.. code-block::
+.. code::
 
-        $ sudo SINGULARITY_ENCRYPTION_PASSPHRASE=<secret> singularity build --encrypt encrypted.sif encrypted.def
-        Starting build...
+   $ sudo SINGULARITY_ENCRYPTION_PASSPHRASE=<secret> singularity build --encrypt encrypted.sif encrypted.def
+   Starting build...
 
-In this case it is necessary to use the ``--encrypt`` flag since the presence of
-an environment variable alone will not trigger the encrypted build workflow.
+In this case it is necessary to use the ``--encrypt`` flag since the
+presence of an environment variable alone will not trigger the encrypted
+build workflow.
 
-While this example shows how an environment variable can be used to set a
-passphrase, you should set the environment variable in a way that will not 
-record your passphrase on the command line.  For instance, you could save a 
-plain text passphrase in a file (e.g. ``secret.txt``) and use it like so.
+While this example shows how an environment variable can be used to set
+a passphrase, you should set the environment variable in a way that will
+not record your passphrase on the command line. For instance, you could
+save a plain text passphrase in a file (e.g. ``secret.txt``) and use it
+like so.
 
-.. code-block::
+.. code::
 
-        $ export SINGULARITY_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
+   $ export SINGULARITY_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
 
-        $ sudo -E singularity build --encrypt encrypted.sif encrypted.def
-        Starting build...
+   $ sudo -E singularity build --encrypt encrypted.sif encrypted.def
+   Starting build...
 
 PEM File Encryption
 ===================
 
-{Singularity} currently supports RSA encryption using a public/private key-pair. 
-Keys are supplied in PEM format. The public key is used to encrypt containers that
-can be decrypted on a host that has access to the secret private key.
+{Singularity} currently supports RSA encryption using a public/private
+key-pair. Keys are supplied in PEM format. The public key is used to
+encrypt containers that can be decrypted on a host that has access to
+the secret private key.
 
-You can create a pair of RSA keys suitable for encrypting your container with 
-the ``ssh-keygen`` command, and then create a PEM file with a few specific flags 
-like so:
+You can create a pair of RSA keys suitable for encrypting your container
+with the ``ssh-keygen`` command, and then create a PEM file with a few
+specific flags like so:
 
-.. code-block::
+.. code::
 
-        # Generate a key pair
-        $ ssh-keygen -t rsa -b 2048
-        Generating public/private rsa key pair.
-        Enter file in which to save the key (/home/vagrant/.ssh/id_rsa): rsa
-        Enter passphrase (empty for no passphrase):
-        Enter same passphrase again:
-        [snip...]
+   # Generate a key pair
+   $ ssh-keygen -t rsa -b 2048
+   Generating public/private rsa key pair.
+   Enter file in which to save the key (/home/vagrant/.ssh/id_rsa): rsa
+   Enter passphrase (empty for no passphrase):
+   Enter same passphrase again:
+   [snip...]
 
-        # Convert the public key to PEM PKCS1 format
-        $ ssh-keygen -f ./rsa.pub -e -m pem >rsa_pub.pem
+   # Convert the public key to PEM PKCS1 format
+   $ ssh-keygen -f ./rsa.pub -e -m pem >rsa_pub.pem
 
-        # Rename the private key (already PEM PKCS1) to a nice name
-        $ mv rsa rsa_pri.pem
+   # Rename the private key (already PEM PKCS1) to a nice name
+   $ mv rsa rsa_pri.pem
 
-You would use the ``rsa_pub.pem`` file to encrypt your container and the ``rsa_pri.pem`` 
-file to run it.  
+You would use the ``rsa_pub.pem`` file to encrypt your container and the
+``rsa_pri.pem`` file to run it.
 
 Encrypting with a command line option
---------------------------------------
+-------------------------------------
 
-.. code-block::
+.. code::
 
-        $ sudo singularity build --pem-path=rsa_pub.pem encrypted.sif encrypted.def
-        Starting build...
+   $ sudo singularity build --pem-path=rsa_pub.pem encrypted.sif encrypted.def
+   Starting build...
 
 Encrypting with an environment variable
 ---------------------------------------
 
-.. code-block::
+.. code::
 
-        $ sudo SINGULARITY_ENCRYPTION_PEM_PATH=rsa_pub.pem singularity build --encrypt encrypted.sif encrypted.def
-        Starting build...
+   $ sudo SINGULARITY_ENCRYPTION_PEM_PATH=rsa_pub.pem singularity build --encrypt encrypted.sif encrypted.def
+   Starting build...
 
-In this case it is necessary to use the ``--encrypt`` flag since the presence of
-an environment variable alone will not trigger the encrypted build workflow.
+In this case it is necessary to use the ``--encrypt`` flag since the
+presence of an environment variable alone will not trigger the encrypted
+build workflow.
 
-------------------------------
-Running an encrypted container
-------------------------------
+********************************
+ Running an encrypted container
+********************************
 
-To ``run``, ``shell``, or ``exec`` an encrypted image, credentials to decrypt 
-the image need to be supplied at runtime either in a key-file or a plaintext 
-passphrase.
+To ``run``, ``shell``, or ``exec`` an encrypted image, credentials to
+decrypt the image need to be supplied at runtime either in a key-file or
+a plaintext passphrase.
 
 Running a container encrypted with a passphrase
 ===============================================
 
-A passphrase can be supplied at runtime by either of the ways listed in the 
-sections above.
+A passphrase can be supplied at runtime by either of the ways listed in
+the sections above.
 
 Running with a passphrase interactively
 ---------------------------------------
 
-.. code-block::
+.. code::
 
-        $ singularity run --passphrase encrypted.sif
-        Enter passphrase for encrypted container: <secret>
+   $ singularity run --passphrase encrypted.sif
+   Enter passphrase for encrypted container: <secret>
 
 Running with a passphrase in an environment variable
 ----------------------------------------------------
 
-.. code-block::
+.. code::
 
-        $ SINGULARITY_ENCRYPTION_PASSPHRASE="secret" singularity run encrypted.sif
+   $ SINGULARITY_ENCRYPTION_PASSPHRASE="secret" singularity run encrypted.sif
 
-While this example shows how an environment variable can be used to set a
-passphrase, you should set the environment variable in a way that will not 
-record your passphrase on the command line.  For instance, you could save a 
-plain text passphrase in a file (e.g. ``secret.txt``) and use it like so.
+While this example shows how an environment variable can be used to set
+a passphrase, you should set the environment variable in a way that will
+not record your passphrase on the command line. For instance, you could
+save a plain text passphrase in a file (e.g. ``secret.txt``) and use it
+like so.
 
-.. code-block::
+.. code::
 
-        $ export SINGULARITY_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
+   $ export SINGULARITY_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
 
-        $ singularity run encrypted.sif
+   $ singularity run encrypted.sif
 
 Running a container encrypted with a PEM file
 =============================================
 
-A private key is supplied using either of the methods listed in the Encryption 
-section above.
+A private key is supplied using either of the methods listed in the
+Encryption section above.
 
 Running using a command line option
 -----------------------------------
 
-.. code-block::
+.. code::
 
-        $ singularity run --pem-path=rsa_pri.pem encrypted.sif
+   $ singularity run --pem-path=rsa_pri.pem encrypted.sif
 
 Running using an environment variable
 -------------------------------------
 
-.. code-block::
+.. code::
 
-        $ SINGULARITY_ENCRYPTION_PEM_PATH=rsa_pri.pem singularity run encrypted.sif
+   $ SINGULARITY_ENCRYPTION_PEM_PATH=rsa_pri.pem singularity run encrypted.sif

--- a/encryption.rst
+++ b/encryption.rst
@@ -84,7 +84,7 @@ the following methods.
 Encrypting with a passphrase interactively
 ------------------------------------------
 
-.. code-block:: none
+.. code-block::
 
         $ sudo singularity build --passphrase encrypted.sif encrypted.def
         Enter encryption passphrase: <secret>
@@ -93,7 +93,7 @@ Encrypting with a passphrase interactively
 Using an environment variable
 -----------------------------
 
-.. code-block:: none
+.. code-block::
 
         $ sudo SINGULARITY_ENCRYPTION_PASSPHRASE=<secret> singularity build --encrypt encrypted.sif encrypted.def
         Starting build...
@@ -106,7 +106,7 @@ passphrase, you should set the environment variable in a way that will not
 record your passphrase on the command line.  For instance, you could save a 
 plain text passphrase in a file (e.g. ``secret.txt``) and use it like so.
 
-.. code-block:: none
+.. code-block::
 
         $ export SINGULARITY_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
 
@@ -124,7 +124,7 @@ You can create a pair of RSA keys suitable for encrypting your container with
 the ``ssh-keygen`` command, and then create a PEM file with a few specific flags 
 like so:
 
-.. code-block:: none
+.. code-block::
 
         # Generate a key pair
         $ ssh-keygen -t rsa -b 2048
@@ -146,7 +146,7 @@ file to run it.
 Encrypting with a command line option
 --------------------------------------
 
-.. code-block:: none
+.. code-block::
 
         $ sudo singularity build --pem-path=rsa_pub.pem encrypted.sif encrypted.def
         Starting build...
@@ -154,7 +154,7 @@ Encrypting with a command line option
 Encrypting with an environment variable
 ---------------------------------------
 
-.. code-block:: none
+.. code-block::
 
         $ sudo SINGULARITY_ENCRYPTION_PEM_PATH=rsa_pub.pem singularity build --encrypt encrypted.sif encrypted.def
         Starting build...
@@ -179,7 +179,7 @@ sections above.
 Running with a passphrase interactively
 ---------------------------------------
 
-.. code-block:: none
+.. code-block::
 
         $ singularity run --passphrase encrypted.sif
         Enter passphrase for encrypted container: <secret>
@@ -187,7 +187,7 @@ Running with a passphrase interactively
 Running with a passphrase in an environment variable
 ----------------------------------------------------
 
-.. code-block:: none
+.. code-block::
 
         $ SINGULARITY_ENCRYPTION_PASSPHRASE="secret" singularity run encrypted.sif
 
@@ -196,7 +196,7 @@ passphrase, you should set the environment variable in a way that will not
 record your passphrase on the command line.  For instance, you could save a 
 plain text passphrase in a file (e.g. ``secret.txt``) and use it like so.
 
-.. code-block:: none
+.. code-block::
 
         $ export SINGULARITY_ENCRYPTION_PASSPHRASE=$(cat secret.txt)
 
@@ -211,13 +211,13 @@ section above.
 Running using a command line option
 -----------------------------------
 
-.. code-block:: none
+.. code-block::
 
         $ singularity run --pem-path=rsa_pri.pem encrypted.sif
 
 Running using an environment variable
 -------------------------------------
 
-.. code-block:: none
+.. code-block::
 
         $ SINGULARITY_ENCRYPTION_PEM_PATH=rsa_pri.pem singularity run encrypted.sif

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -100,7 +100,7 @@ List and Login to Remotes
 
 To ``list`` existing remote endpoints, run this:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote list
 
@@ -166,14 +166,14 @@ Add & Remove Remotes
 
 To ``add`` a remote endpoint (for the current user only):
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote add <remote_name> <remote_uri>
 
 For example, if you have an installation of {Singularity} enterprise
 hosted at enterprise.example.com:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote add myremote https://enterprise.example.com
 
@@ -188,7 +188,7 @@ web address needed to do this will always be given.
 To ``add`` a global remote endpoint (available to all users on the
 system) an administrative user should run:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity remote add --global <remote_name> <remote_uri>
 
@@ -204,14 +204,14 @@ system) an administrative user should run:
 
 Conversely, to ``remove`` an endpoint:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote remove <remote_name>
 
 Use the ``--global`` option as the root user to remove a global
 endpoint:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity remote remove --global <remote_name>
 
@@ -222,13 +222,13 @@ Set the Default Remote
 A remote endpoint can be set as the default to use with commands such
 as ``push``, ``pull`` etc. via ``remote use``:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote use <remote_name>
 
 The default remote shows up with a ``YES`` under the ``ACTIVE`` column in the output of ``remote list``:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote list
     Cloud Services Endpoints
@@ -271,7 +271,7 @@ The default remote shows up with a ``YES`` under the ``ACTIVE`` column in the ou
 {Singularity} 3.7 introduces the ability for an administrator to make a remote
 the only usable remote for the system by using the ``--exclusive`` flag:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity remote use --exclusive company-remote
     INFO:    Remote "company-remote" now in use.
@@ -294,7 +294,7 @@ the only usable remote for the system by using the ``--exclusive`` flag:
 
 This, in turn, prevents users from changing the remote they use:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote use myremote
     FATAL:   could not use myremote: remote company-remote has been set exclusive by the system administrator
@@ -325,7 +325,7 @@ it is the keyserver associated to the current remote endpoint. We can also see
 the ``INSECURE`` column indicating that {Singularity} will use TLS when
 communicating with the keyserver.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote list
     Cloud Services Endpoints
@@ -344,7 +344,7 @@ communicating with the keyserver.
 
 We can add a key server to list of keyservers with:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity remote add-keyserver https://pgp.example.com
     $ singularity remote list
@@ -367,7 +367,7 @@ Here we can see that the ``https://pgp.example.com`` keyserver was appended to
 our list. If we would like to specify the order in the list that this key is
 placed, we can use the ``--order`` flag:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity remote add-keyserver --order 1 https://pgp.example.com
     $ singularity remote list
@@ -396,7 +396,7 @@ searching for public keys.
 If a keyserver requires authentication before usage, users can login before
 using it:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote login --username ian https://pgp.example.com
     Password (or token when username is empty):
@@ -404,7 +404,7 @@ using it:
 
 Now we can see that ``https://pgp.example.com`` is logged in:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote list
     Cloud Services Endpoints
@@ -452,7 +452,7 @@ registry basis with the ``remote`` command group.
 Users can login to an oci registry with the ``remote login`` command by
 specifying a ``docker://`` prefix to the registry hostname:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote login --username ian docker://docker.io
     Password (or token when username is empty):
@@ -487,7 +487,7 @@ communicating with the registry.
 
 We can login to multiple OCI registries at the same time:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity remote login --username ian docker://registry.example.com
     Password (or token when username is empty):

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -1,483 +1,500 @@
-================
-Remote Endpoints
-================
+##################
+ Remote Endpoints
+##################
 
---------
-Overview
---------
+**********
+ Overview
+**********
 
-The ``remote`` command group allows users to manage the service endpoints
-{Singularity} will interact with for many common command flows. This includes
-managing credentials for image storage services, remote builders, and key
-servers used to locate public keys for SIF image verification. Currently,
-there are three main types of remote endpoints managed by this command group:
-the public Sylabs Cloud (or local {Singularity} Enterprise installation), OCI
-registries and keyservers.
+The ``remote`` command group allows users to manage the service
+endpoints {Singularity} will interact with for many common command
+flows. This includes managing credentials for image storage services,
+remote builders, and key servers used to locate public keys for SIF
+image verification. Currently, there are three main types of remote
+endpoints managed by this command group: the public Sylabs Cloud (or
+local {Singularity} Enterprise installation), OCI registries and
+keyservers.
 
--------------------
-Public Sylabs Cloud
--------------------
+*********************
+ Public Sylabs Cloud
+*********************
 
 Sylabs introduced the online `Sylabs Cloud
 <https://cloud.sylabs.io/home>`_ to enable users to `Create
 <https://cloud.sylabs.io/builder>`_, `Secure
 <https://cloud.sylabs.io/keystore?sign=true>`_, and `Share
-<https://cloud.sylabs.io/library>`_ their container
-images with others.
+<https://cloud.sylabs.io/library>`_ their container images with others.
 
 A fresh, default installation of {Singularity} is configured to connect
-to the public `cloud.sylabs.io <https://cloud.sylabs.io>`__
-services. If you only want to use the public services you just need to
-obtain an authentication token, and then ``singularity remote login``:
+to the public `cloud.sylabs.io <https://cloud.sylabs.io>`__ services. If
+you only want to use the public services you just need to obtain an
+authentication token, and then ``singularity remote login``:
 
-  1) Go to: https://cloud.sylabs.io/
-  2) Click "Sign In" and follow the sign in steps.
-  3) Click on your login id (same and updated button as the Sign in one).
-  4) Select "Access Tokens" from the drop down menu.
-  5) Enter a name for your new access token, such as "test token"
-  6) Click the "Create a New Access Token" button.
-  7) Click "Copy token to Clipboard" from the "New API Token" page.
-  8) Run ``singularity remote login`` and paste the access token at the prompt.
+   #. Go to: https://cloud.sylabs.io/
+   #. Click "Sign In" and follow the sign in steps.
+   #. Click on your login id (same and updated button as the Sign in
+      one).
+   #. Select "Access Tokens" from the drop down menu.
+   #. Enter a name for your new access token, such as "test token"
+   #. Click the "Create a New Access Token" button.
+   #. Click "Copy token to Clipboard" from the "New API Token" page.
+   #. Run ``singularity remote login`` and paste the access token at the
+      prompt.
 
-Once your token is stored, you can check that you are able to connect
-to the services with the ``status`` subcommand:
+Once your token is stored, you can check that you are able to connect to
+the services with the ``status`` subcommand:
 
 .. code:: console
 
-    $ singularity remote status
-    INFO:    Checking status of default remote.
-    SERVICE    STATUS  VERSION             URI
-    Builder    OK      v1.1.14-0-gc7a68c1  https://build.sylabs.io
-    Consent    OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/consent
-    Keyserver  OK      v1.13.0-0-g13c778b  https://keys.sylabs.io
-    Library    OK      v1.0.16-0-gb7eeae4  https://library.sylabs.io
-    Token      OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/token
-    INFO:    Access Token Verified!
+   $ singularity remote status
+   INFO:    Checking status of default remote.
+   SERVICE    STATUS  VERSION             URI
+   Builder    OK      v1.1.14-0-gc7a68c1  https://build.sylabs.io
+   Consent    OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/consent
+   Keyserver  OK      v1.13.0-0-g13c778b  https://keys.sylabs.io
+   Library    OK      v1.0.16-0-gb7eeae4  https://library.sylabs.io
+   Token      OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/token
+   INFO:    Access Token Verified!
 
-    Valid authentication token set (logged in).
+   Valid authentication token set (logged in).
 
 If you see any errors you may need to check if your system requires
 proxy environment variables to be set, or if a firewall is blocking
 access to ``*.sylabs.io``. Talk to your system administrator.
 
-You can interact with the public Sylabs Cloud using various {Singularity} commands:
+You can interact with the public Sylabs Cloud using various
+{Singularity} commands:
 
-`pull <cli/singularity_pull.html>`_,
-`push <cli/singularity_push.html>`_,
-`build --remote <cli/singularity_build.html#options>`_,
-`key <cli/singularity_key.html>`_,
-`search <cli/singularity_search.html>`_,
-`verify <cli/singularity_verify.html>`_,
-`exec <cli/singularity_exec.html>`_,
-`shell <cli/singularity_shell.html>`_,
-`run <cli/singularity_run.html>`_,
-`instance <cli/singularity_instance.html>`_
+`pull
+<cli/singularity_pull.html>`_,
+`push
+<cli/singularity_push.html>`_,
+`build --remote
+<cli/singularity_build.html#options>`_,
+`key
+<cli/singularity_key.html>`_,
+`search
+<cli/singularity_search.html>`_,
+`verify
+<cli/singularity_verify.html>`_,
+`exec
+<cli/singularity_exec.html>`_,
+`shell
+<cli/singularity_shell.html>`_,
+`run
+<cli/singularity_run.html>`_,
+`instance
+<cli/singularity_instance.html>`_
 
 .. note::
 
-   Using ``docker://``, ``oras://`` and ``shub://`` URIs with these commands
-   does not interact with the Sylabs Cloud.
+   Using ``docker://``, ``oras://`` and ``shub://`` URIs with these
+   commands does not interact with the Sylabs Cloud.
 
--------------------------
-Managing Remote Endpoints
--------------------------
+***************************
+ Managing Remote Endpoints
+***************************
 
-Users can setup and switch between multiple remote endpoints, which
-are stored in their ``~/.singularity/remote.yaml``
-file. Alternatively, remote endpoints can be set system-wide by an
-administrator.
+Users can setup and switch between multiple remote endpoints, which are
+stored in their ``~/.singularity/remote.yaml`` file. Alternatively,
+remote endpoints can be set system-wide by an administrator.
 
-A remote endpoint may be the public Sylabs Cloud, a private
-installation of Singularity Enterprise, or community-developed service
-that are API compatible.
+A remote endpoint may be the public Sylabs Cloud, a private installation
+of Singularity Enterprise, or community-developed service that are API
+compatible.
 
-Generally, users and administrators should manage remote endpoints
-using the ``singularity remote`` command, and avoid editing
-``remote.yaml`` configuration files directly.
+Generally, users and administrators should manage remote endpoints using
+the ``singularity remote`` command, and avoid editing ``remote.yaml``
+configuration files directly.
 
 List and Login to Remotes
 =========================
 
 To ``list`` existing remote endpoints, run this:
 
-.. code-block::
+.. code::
 
-    $ singularity remote list
+   $ singularity remote list
 
-    Cloud Services Endpoints
-    ========================
+   Cloud Services Endpoints
+   ========================
 
-    NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud  cloud.sylabs.io  YES     YES     NO
+   NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud  cloud.sylabs.io  YES     YES     NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                     GLOBAL  INSECURE  ORDER
-    https://keys.sylabs.io  YES     NO        1*
+   URI                     GLOBAL  INSECURE  ORDER
+   https://keys.sylabs.io  YES     NO        1*
 
+The ``YES`` in the ``ACTIVE`` column for ``SylabsCloud`` shows that this
+is the current default remote endpoint.
 
-The ``YES`` in the ``ACTIVE`` column for ``SylabsCloud`` shows that this is the
-current default remote endpoint.
+To ``login`` to a remote, for the first time or if your token expires or
+was revoked:
 
-To ``login`` to a remote, for the first time or if your token expires
-or was revoked:
+.. code:: console
 
-.. code-block:: console
+   # Login to the default remote endpoint
+   $ singularity remote login
 
-    # Login to the default remote endpoint
-    $ singularity remote login
+   # Login to another remote endpoint
+   $ singularity remote login <remote_name>
 
-    # Login to another remote endpoint
-    $ singularity remote login <remote_name>
-
-    # example...
-    $ singularity remote login SylabsCloud
-    singularity remote login SylabsCloud
-    INFO:    Authenticating with remote: SylabsCloud
-    Generate an API Key at https://cloud.sylabs.io/auth/tokens, and paste here:
-    API Key:
-    INFO:    API Key Verified!
-
+   # example...
+   $ singularity remote login SylabsCloud
+   singularity remote login SylabsCloud
+   INFO:    Authenticating with remote: SylabsCloud
+   Generate an API Key at https://cloud.sylabs.io/auth/tokens, and paste here:
+   API Key:
+   INFO:    API Key Verified!
 
 If you ``login`` to a remote that you already have a valid token for,
 you will be prompted, and the new token will be verified, before it
-replaces your existing credential. If you enter an incorrect token
-your existing token will not be replaced:
+replaces your existing credential. If you enter an incorrect token your
+existing token will not be replaced:
 
-.. code-block:: console
+.. code:: console
 
-    $ singularity remote login
-    An access token is already set for this remote. Replace it? [N/y]y
-    Generate an access token at https://cloud.sylabs.io/auth/tokens, and paste it here.
-    Token entered will be hidden for security.
-    Access Token:
-    FATAL:   while verifying token: error response from server: Invalid Credentials
+   $ singularity remote login
+   An access token is already set for this remote. Replace it? [N/y]y
+   Generate an access token at https://cloud.sylabs.io/auth/tokens, and paste it here.
+   Token entered will be hidden for security.
+   Access Token:
+   FATAL:   while verifying token: error response from server: Invalid Credentials
 
-    # Previous token is still in place
+   # Previous token is still in place
 
 .. note::
 
-    It is important for users to be aware that the login command will store the
-    supplied credentials or tokens unencrypted in your home directory.
+   It is important for users to be aware that the login command will
+   store the supplied credentials or tokens unencrypted in your home
+   directory.
 
 Add & Remove Remotes
 ====================
 
 To ``add`` a remote endpoint (for the current user only):
 
-.. code-block::
+.. code::
 
-    $ singularity remote add <remote_name> <remote_uri>
+   $ singularity remote add <remote_name> <remote_uri>
 
 For example, if you have an installation of {Singularity} enterprise
 hosted at enterprise.example.com:
 
-.. code-block::
+.. code::
 
-    $ singularity remote add myremote https://enterprise.example.com
+   $ singularity remote add myremote https://enterprise.example.com
 
-    INFO:    Remote "myremote" added.
-    INFO:    Authenticating with remote: myremote
-    Generate an API Key at https://enterprise.example.com/auth/tokens, and paste here:
-    API Key:
+   INFO:    Remote "myremote" added.
+   INFO:    Authenticating with remote: myremote
+   Generate an API Key at https://enterprise.example.com/auth/tokens, and paste here:
+   API Key:
 
-You will be prompted to setup an API key as the remote is added. The
-web address needed to do this will always be given.
+You will be prompted to setup an API key as the remote is added. The web
+address needed to do this will always be given.
 
 To ``add`` a global remote endpoint (available to all users on the
 system) an administrative user should run:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity remote add --global <remote_name> <remote_uri>
+   $ sudo singularity remote add --global <remote_name> <remote_uri>
 
-    # example..
+   # example..
 
-    $ sudo singularity remote add --global company-remote https://enterprise.example.com
-    INFO:    Remote "company-remote" added.
-    INFO:    Global option detected. Will not automatically log into remote.
+   $ sudo singularity remote add --global company-remote https://enterprise.example.com
+   INFO:    Remote "company-remote" added.
+   INFO:    Global option detected. Will not automatically log into remote.
 
-.. note:: Global remote configurations can only be modified by the
-     root user and are stored in the ``etc/singularity/remote.yaml``
-     file, at the {Singularity} installation location.
+.. note::
+
+   Global remote configurations can only be modified by the root user
+   and are stored in the ``etc/singularity/remote.yaml`` file, at the
+   {Singularity} installation location.
 
 Conversely, to ``remove`` an endpoint:
 
-.. code-block::
+.. code::
 
-    $ singularity remote remove <remote_name>
+   $ singularity remote remove <remote_name>
 
 Use the ``--global`` option as the root user to remove a global
 endpoint:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity remote remove --global <remote_name>
-
+   $ sudo singularity remote remove --global <remote_name>
 
 Set the Default Remote
 ======================
 
-A remote endpoint can be set as the default to use with commands such
-as ``push``, ``pull`` etc. via ``remote use``:
+A remote endpoint can be set as the default to use with commands such as
+``push``, ``pull`` etc. via ``remote use``:
 
-.. code-block::
+.. code::
 
-    $ singularity remote use <remote_name>
+   $ singularity remote use <remote_name>
 
-The default remote shows up with a ``YES`` under the ``ACTIVE`` column in the output of ``remote list``:
+The default remote shows up with a ``YES`` under the ``ACTIVE`` column
+in the output of ``remote list``:
 
-.. code-block::
+.. code::
 
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    NAME            URI                     ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud     cloud.sylabs.io         YES     YES     NO
-    company-remote  enterprise.example.com  NO      YES     NO
-    myremote        enterprise.example.com  NO      NO      NO
+   NAME            URI                     ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud     cloud.sylabs.io         YES     YES     NO
+   company-remote  enterprise.example.com  NO      YES     NO
+   myremote        enterprise.example.com  NO      NO      NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                     GLOBAL  INSECURE  ORDER
-    https://keys.sylabs.io  YES     NO        1*
+   URI                     GLOBAL  INSECURE  ORDER
+   https://keys.sylabs.io  YES     NO        1*
 
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
-    $ singularity remote use myremote
-    INFO:    Remote "myremote" now in use.
+   $ singularity remote use myremote
+   INFO:    Remote "myremote" now in use.
 
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    NAME            URI                     ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud     cloud.sylabs.io         NO      YES     NO
-    company-remote  enterprise.example.com  NO      YES     NO
-    myremote        enterprise.example.com  YES     NO      NO
+   NAME            URI                     ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud     cloud.sylabs.io         NO      YES     NO
+   company-remote  enterprise.example.com  NO      YES     NO
+   myremote        enterprise.example.com  YES     NO      NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                       GLOBAL  INSECURE  ORDER
-    https://keys.example.com  YES     NO        1*
+   URI                       GLOBAL  INSECURE  ORDER
+   https://keys.example.com  YES     NO        1*
 
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
+{Singularity} 3.7 introduces the ability for an administrator to make a
+remote the only usable remote for the system by using the
+``--exclusive`` flag:
 
-{Singularity} 3.7 introduces the ability for an administrator to make a remote
-the only usable remote for the system by using the ``--exclusive`` flag:
+.. code::
 
-.. code-block::
+   $ sudo singularity remote use --exclusive company-remote
+   INFO:    Remote "company-remote" now in use.
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    $ sudo singularity remote use --exclusive company-remote
-    INFO:    Remote "company-remote" now in use.
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   NAME            URI                     ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud     cloud.sylabs.io         NO      YES     NO
+   company-remote  enterprise.example.com  YES     YES     YES
+   myremote        enterprise.example.com  NO      NO      NO
 
-    NAME            URI                     ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud     cloud.sylabs.io         NO      YES     NO
-    company-remote  enterprise.example.com  YES     YES     YES
-    myremote        enterprise.example.com  NO      NO      NO
+   Keyservers
+   ==========
 
-    Keyservers
-    ==========
+   URI                       GLOBAL  INSECURE  ORDER
+   https://keys.example.com  YES     NO        1*
 
-    URI                       GLOBAL  INSECURE  ORDER
-    https://keys.example.com  YES     NO        1*
-
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
 This, in turn, prevents users from changing the remote they use:
 
-.. code-block::
+.. code::
 
-    $ singularity remote use myremote
-    FATAL:   could not use myremote: remote company-remote has been set exclusive by the system administrator
+   $ singularity remote use myremote
+   FATAL:   could not use myremote: remote company-remote has been set exclusive by the system administrator
 
 If you do not want to switch remote with ``remote use`` you can:
 
-* Make ``push`` and ``pull`` use an alternative library server with
-  the ``--library`` option.
-* Make ``build --remote`` use an alternative remote builder with the
-  ``--builder`` option.
-* Make ``keys`` use an alternative keyserver with the ``-url`` option.
+-  Make ``push`` and ``pull`` use an alternative library server with the
+   ``--library`` option.
+-  Make ``build --remote`` use an alternative remote builder with the
+   ``--builder`` option.
+-  Make ``keys`` use an alternative keyserver with the ``-url`` option.
 
-------------------------
-Keyserver Configurations
-------------------------
+**************************
+ Keyserver Configurations
+**************************
 
-By default, {Singularity} will use the keyserver correlated to the active cloud
-service endpoint. This behavior can be changed or supplemented via the
-``add-keyserver`` and ``remove-keyserver`` commands. These commands allow an
-administrator to create a global list of key servers used to verify container
-signatures by default, where ``order 1`` is the first in the list. Other
-operations performed by {Singularity} that reach out to a keyserver will only
-use the first entry, or ``order 1``, keyserver.
+By default, {Singularity} will use the keyserver correlated to the
+active cloud service endpoint. This behavior can be changed or
+supplemented via the ``add-keyserver`` and ``remove-keyserver``
+commands. These commands allow an administrator to create a global list
+of key servers used to verify container signatures by default, where
+``order 1`` is the first in the list. Other operations performed by
+{Singularity} that reach out to a keyserver will only use the first
+entry, or ``order 1``, keyserver.
 
-When we list our default remotes, we can see that the default keyserver is
-``https://keys.sylabs.io`` and the asterisk next to its order indicates that
-it is the keyserver associated to the current remote endpoint. We can also see
-the ``INSECURE`` column indicating that {Singularity} will use TLS when
-communicating with the keyserver.
+When we list our default remotes, we can see that the default keyserver
+is ``https://keys.sylabs.io`` and the asterisk next to its order
+indicates that it is the keyserver associated to the current remote
+endpoint. We can also see the ``INSECURE`` column indicating that
+{Singularity} will use TLS when communicating with the keyserver.
 
-.. code-block::
+.. code::
 
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud  cloud.sylabs.io  YES     YES     NO
+   NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud  cloud.sylabs.io  YES     YES     NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                     GLOBAL  INSECURE  ORDER
-    https://keys.sylabs.io  YES     NO        1*
+   URI                     GLOBAL  INSECURE  ORDER
+   https://keys.sylabs.io  YES     NO        1*
 
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
 We can add a key server to list of keyservers with:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity remote add-keyserver https://pgp.example.com
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   $ sudo singularity remote add-keyserver https://pgp.example.com
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud  cloud.sylabs.io  YES     YES     NO
+   NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud  cloud.sylabs.io  YES     YES     NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                      GLOBAL  INSECURE  ORDER
-    https://keys.sylabs.io   YES     NO        1*
-    https://pgp.example.com  YES     NO        2
+   URI                      GLOBAL  INSECURE  ORDER
+   https://keys.sylabs.io   YES     NO        1*
+   https://pgp.example.com  YES     NO        2
 
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
-Here we can see that the ``https://pgp.example.com`` keyserver was appended to
-our list. If we would like to specify the order in the list that this key is
-placed, we can use the ``--order`` flag:
+Here we can see that the ``https://pgp.example.com`` keyserver was
+appended to our list. If we would like to specify the order in the list
+that this key is placed, we can use the ``--order`` flag:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity remote add-keyserver --order 1 https://pgp.example.com
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   $ sudo singularity remote add-keyserver --order 1 https://pgp.example.com
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud  cloud.sylabs.io  YES     YES     NO
+   NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud  cloud.sylabs.io  YES     YES     NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                      GLOBAL  INSECURE  ORDER
-    https://pgp.example.com  YES     NO        1
-    https://keys.sylabs.io   YES     NO        2*
+   URI                      GLOBAL  INSECURE  ORDER
+   https://pgp.example.com  YES     NO        1
+   https://keys.sylabs.io   YES     NO        2*
 
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
-Since we specified ``--order 1``, the ``https://pgp.example.com`` keyserver was
-placed as the first entry in the list and the default keyserver was moved to
-second in the list. With the keyserver configuration above, all image default
-image verification performed by {Singularity} will first reach out to
-``https://pgp.example.com`` and then to ``https://keys.sylabs.io`` when
-searching for public keys.
+Since we specified ``--order 1``, the ``https://pgp.example.com``
+keyserver was placed as the first entry in the list and the default
+keyserver was moved to second in the list. With the keyserver
+configuration above, all image default image verification performed by
+{Singularity} will first reach out to ``https://pgp.example.com`` and
+then to ``https://keys.sylabs.io`` when searching for public keys.
 
-If a keyserver requires authentication before usage, users can login before
-using it:
+If a keyserver requires authentication before usage, users can login
+before using it:
 
-.. code-block::
+.. code::
 
-    $ singularity remote login --username ian https://pgp.example.com
-    Password (or token when username is empty):
-    INFO:    Token stored in /home/ian/.singularity/remote.yaml
+   $ singularity remote login --username ian https://pgp.example.com
+   Password (or token when username is empty):
+   INFO:    Token stored in /home/ian/.singularity/remote.yaml
 
 Now we can see that ``https://pgp.example.com`` is logged in:
 
-.. code-block::
+.. code::
 
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud  cloud.sylabs.io  YES     YES     NO
+   NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud  cloud.sylabs.io  YES     YES     NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                      GLOBAL  INSECURE  ORDER
-    https://pgp.example.com  YES     NO        1
-    https://keys.sylabs.io   YES     NO        2*
+   URI                      GLOBAL  INSECURE  ORDER
+   https://pgp.example.com  YES     NO        1
+   https://keys.sylabs.io   YES     NO        2*
 
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
-    Authenticated Logins
-    =================================
+   Authenticated Logins
+   =================================
 
-    URI                     INSECURE
-    https://pgp.example.com NO
+   URI                     INSECURE
+   https://pgp.example.com NO
 
 .. note::
-    It is important for users to be aware that the login command will store the
-    supplied credentials or tokens unencrypted in your home directory.
+
+   It is important for users to be aware that the login command will
+   store the supplied credentials or tokens unencrypted in your home
+   directory.
 
 .. _sec:managing_oci_registries:
 
------------------------
-Managing OCI Registries
------------------------
+*************************
+ Managing OCI Registries
+*************************
 
-It is common for users of {Singularity} to use OCI registries as sources for
-their container images. Some registries require credentials to access certain
-images or the registry itself. Previously, the only methods in {Singularity} to
-supply credentials to registries were to supply credentials for each command or
-set environment variables for a single registry.
-See :ref:`Authentication via Interactive Login <sec:authentication_via_docker_login>`
-and :ref:`Authentication via Environment Variables <sec:authentication_via_environment_variables>`
+It is common for users of {Singularity} to use OCI registries as sources
+for their container images. Some registries require credentials to
+access certain images or the registry itself. Previously, the only
+methods in {Singularity} to supply credentials to registries were to
+supply credentials for each command or set environment variables for a
+single registry. See :ref:`Authentication via Interactive Login
+<sec:authentication_via_docker_login>` and :ref:`Authentication via
+Environment Variables <sec:authentication_via_environment_variables>`
 
-{Singularity} 3.7 introduces the ability for users to supply credentials on a per
-registry basis with the ``remote`` command group.
+{Singularity} 3.7 introduces the ability for users to supply credentials
+on a per registry basis with the ``remote`` command group.
 
 Users can login to an oci registry with the ``remote login`` command by
 specifying a ``docker://`` prefix to the registry hostname:
 
-.. code-block::
+.. code::
 
-    $ singularity remote login --username ian docker://docker.io
-    Password (or token when username is empty):
-    INFO:    Token stored in /home/ian/.singularity/remote.yaml
+   $ singularity remote login --username ian docker://docker.io
+   Password (or token when username is empty):
+   INFO:    Token stored in /home/ian/.singularity/remote.yaml
 
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud  cloud.sylabs.io  YES     YES     NO
+   NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud  cloud.sylabs.io  YES     YES     NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                     GLOBAL  INSECURE  ORDER
-    https://keys.sylabs.io  YES     NO        1*
+   URI                     GLOBAL  INSECURE  ORDER
+   https://keys.sylabs.io  YES     NO        1*
 
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
-    Authenticated Logins
-    =================================
+   Authenticated Logins
+   =================================
 
-    URI                 INSECURE
-    docker://docker.io  NO
+   URI                 INSECURE
+   docker://docker.io  NO
 
 Now we can see that ``docker://docker.io`` shows up under
 ``Authenticated Logins`` and {Singularity} will automatically supply the
@@ -487,48 +504,55 @@ communicating with the registry.
 
 We can login to multiple OCI registries at the same time:
 
-.. code-block::
+.. code::
 
-    $ singularity remote login --username ian docker://registry.example.com
-    Password (or token when username is empty):
-    INFO:    Token stored in /home/ian/.singularity/remote.yaml
+   $ singularity remote login --username ian docker://registry.example.com
+   Password (or token when username is empty):
+   INFO:    Token stored in /home/ian/.singularity/remote.yaml
 
-    $ singularity remote list
-    Cloud Services Endpoints
-    ========================
+   $ singularity remote list
+   Cloud Services Endpoints
+   ========================
 
-    NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
-    SylabsCloud  cloud.sylabs.io  YES     YES     NO
+   NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
+   SylabsCloud  cloud.sylabs.io  YES     YES     NO
 
-    Keyservers
-    ==========
+   Keyservers
+   ==========
 
-    URI                     GLOBAL  INSECURE  ORDER
-    https://keys.sylabs.io  YES     NO        1*
+   URI                     GLOBAL  INSECURE  ORDER
+   https://keys.sylabs.io  YES     NO        1*
 
-    * Active cloud services keyserver
+   * Active cloud services keyserver
 
-    Authenticated Logins
-    =================================
+   Authenticated Logins
+   =================================
 
-    URI                            INSECURE
-    docker://docker.io             NO
-    docker://registry.example.com  NO
+   URI                            INSECURE
+   docker://docker.io             NO
+   docker://registry.example.com  NO
 
-{Singularity} will supply the correct credentials for the registry based off of
-the hostname when using the following commands with a ``docker://`` or
-``oras://`` URI:
+{Singularity} will supply the correct credentials for the registry based
+off of the hostname when using the following commands with a
+``docker://`` or ``oras://`` URI:
 
-`pull <cli/singularity_pull.html>`_,
-`push <cli/singularity_push.html>`_,
-`build <cli/singularity_build.html>`_,
-`exec <cli/singularity_exec.html>`_,
-`shell <cli/singularity_shell.html>`_,
-`run <cli/singularity_run.html>`_,
-`instance <cli/singularity_instance.html>`_
-
+`pull
+<cli/singularity_pull.html>`_,
+`push
+<cli/singularity_push.html>`_,
+`build
+<cli/singularity_build.html>`_,
+`exec
+<cli/singularity_exec.html>`_,
+`shell
+<cli/singularity_shell.html>`_,
+`run
+<cli/singularity_run.html>`_,
+`instance
+<cli/singularity_instance.html>`_
 
 .. note::
 
-    It is important for users to be aware that the login command will store the
-    supplied credentials or tokens unencrypted in your home directory.
+   It is important for users to be aware that the login command will
+   store the supplied credentials or tokens unencrypted in your home
+   directory.

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -1,36 +1,35 @@
 .. _environment-and-metadata:
 
-========================
-Environment and Metadata
-========================
+##########################
+ Environment and Metadata
+##########################
 
 .. _sec:envandmetadata:
 
-Environment variables are values you can set in a session, which can
-be used to influence the behavior of programs. It's often considered
-best practice to use environment variables to pass settings to a
-program in a container, because they are easily set and don't rely on
-writing and binding in program-specific configuration files. When
-building a container you may need to set fixed or default environment
-variables. When running containers you may need to set or override
-environment variables.
+Environment variables are values you can set in a session, which can be
+used to influence the behavior of programs. It's often considered best
+practice to use environment variables to pass settings to a program in a
+container, because they are easily set and don't rely on writing and
+binding in program-specific configuration files. When building a
+container you may need to set fixed or default environment variables.
+When running containers you may need to set or override environment
+variables.
 
 The :ref:`metadata <sec:metadata>` of a container is information that
 describes the container. {Singularity} automatically records important
-information such as the definition file used to build a
-container. Other details such as the version of {Singularity} used are
-present as :ref:`labels <sec:labels>` on a container. You can also
-specify your own to be recorded against your container.
+information such as the definition file used to build a container. Other
+details such as the version of {Singularity} used are present as
+:ref:`labels <sec:labels>` on a container. You can also specify your own
+to be recorded against your container.
 
-----------------------------
-Changes in {Singularity} 3.6
-----------------------------
+******************************
+ Changes in {Singularity} 3.6
+******************************
 
-{Singularity} 3.6 modified the ways in which environment variables
-are handled to allow long-term stability and consistency that has
-been lacking in prior versions. It also introduced new ways of setting
-environment variables, such as the ``--env`` and ``--env-file``
-options.
+{Singularity} 3.6 modified the ways in which environment variables are
+handled to allow long-term stability and consistency that has been
+lacking in prior versions. It also introduced new ways of setting
+environment variables, such as the ``--env`` and ``--env-file`` options.
 
 .. warning::
 
@@ -39,45 +38,49 @@ options.
    carefully. Some behavior has changed.
 
 Summary of changes
-------------------
+==================
 
- - When building a container, the environment defined in the base
-   image (e.g. a Docker image) is available during the ``%post``
-   section of the build.
- - An environment variable set in a container image, from the
-   bootstrap base image, or in the ``%environment`` section of a
-   definition file *will not* be overridden by a host environment
-   variable of the same name. The ``--env``, ``--env-file``, or
-   ``SINGULARITYENV_`` methods must be used to explicitly override a
-   environment variable set by the container image.
+   -  When building a container, the environment defined in the base
+      image (e.g. a Docker image) is available during the ``%post``
+      section of the build.
 
+   -  An environment variable set in a container image, from the
+      bootstrap base image, or in the ``%environment`` section of a
+      definition file *will not* be overridden by a host environment
+      variable of the same name. The ``--env``, ``--env-file``, or
+      ``SINGULARITYENV_`` methods must be used to explicitly override a
+      environment variable set by the container image.
 
---------------------
-Environment Overview
---------------------
+**********************
+ Environment Overview
+**********************
 
 When you run a program in a container with {Singularity}, the
 environment variables that the program sees are a combination of:
 
- - The environment variables set in the base image (e.g. Docker image)
-   used to build the container.
- - The environment variables set in the ``%environment`` section of
-   the definition file used to build the container.
- - *Most* of the environment variables set on your host, which are
-   passed into the container.
- - Any variables you set specifically for the container at runtime,
-   using the ``--env``, ``--env-file`` options, or by setting
-   ``SINGULARITYENV_`` variables outside of the container.
- - The ``PATH`` variable can be manipulated to add entries.
- - Runtime variables ``SINGULARITY_xxx`` set by {Singularity} to provide
-   information about the container.
+   -  The environment variables set in the base image (e.g. Docker
+      image) used to build the container.
 
-The environment variables from the base image or definition file used
-to build a container always apply, but can be overridden.
+   -  The environment variables set in the ``%environment`` section of
+      the definition file used to build the container.
+
+   -  *Most* of the environment variables set on your host, which are
+      passed into the container.
+
+   -  Any variables you set specifically for the container at runtime,
+      using the ``--env``, ``--env-file`` options, or by setting
+      ``SINGULARITYENV_`` variables outside of the container.
+
+   -  The ``PATH`` variable can be manipulated to add entries.
+
+   -  Runtime variables ``SINGULARITY_xxx`` set by {Singularity} to
+      provide information about the container.
+
+The environment variables from the base image or definition file used to
+build a container always apply, but can be overridden.
 
 You can choose to exclude passing environment variables from the host
-into the container with the ``-e`` or ``--cleanenv``
-option.
+into the container with the ``-e`` or ``--cleanenv`` option.
 
 We'll go through each place environment variables can be defined, so
 that you can understand how the final environment in a container is
@@ -87,9 +90,9 @@ If you are interested in variables available when you are *building* a
 container, rather than when running a container, see :ref:`build
 environment section <build-environment>`.
 
------------------------------
-Environment from a base image
------------------------------
+*******************************
+ Environment from a base image
+*******************************
 
 When you build a container with {Singularity} you might *bootstrap* from
 a library or Docker image, or using Linux distribution bootstrap tools
@@ -102,79 +105,84 @@ environment variables will be set. If you are using a ``library`` or
 base image.
 
 If I build a singularity container from the image
-``docker://python:3.7`` then when I run the container I can see that
-the ``PYTHON_VERSION`` variable is set in the container:
+``docker://python:3.7`` then when I run the container I can see that the
+``PYTHON_VERSION`` variable is set in the container:
 
-.. code-block::
+.. code::
 
    $ singularity exec python.sif env | grep PYTHON_VERSION
    PYTHON_VERSION=3.7.7
 
-This happens because  the ``Dockerfile`` used to build  that container has
+This happens because the ``Dockerfile`` used to build that container has
 ``ENV PYTHON_VERSION 3.7.7`` set inside it.
 
 You can always override the value of these base image environment
 variables, if needed. See below.
 
-----------------------------------
-Environment from a definition file
-----------------------------------
+************************************
+ Environment from a definition file
+************************************
 
 Environment variables can be included in your container by adding them
-to your definition file. Use ``export`` in the ``%environment``
-section of a definition file to set a container environment variable:
+to your definition file. Use ``export`` in the ``%environment`` section
+of a definition file to set a container environment variable:
 
-.. code-block:: singularity
+.. code:: singularity
 
-        Bootstrap: library
-        From: default/alpine
+   Bootstrap: library
+   From: default/alpine
 
-        %environment
-            export MYVAR="Hello"
+   %environment
+       export MYVAR="Hello"
 
-        %runscript
-            echo $MYVAR
+   %runscript
+       echo $MYVAR
 
+Now the value of ``MYVAR`` is ``Hello`` when the container is launched.
+The ``%runscript`` is set to echo the value.
 
-Now the value of ``MYVAR`` is ``Hello`` when the container
-is launched. The ``%runscript`` is set to echo the value.
+.. code::
 
-.. code-block::
-
-   $ singularity run env.sif 
+   $ singularity run env.sif
    Hello
 
 .. warning::
-   {Singularity} 3.6 uses an embedded shell interpreter to evaluate and setup container
-   environments, therefore all commands executed from the ``%environment`` section have
-   an execution timeout of **5 seconds** for {Singularity} 3.6 and a **1 minute** timeout since
-   {Singularity} 3.7. While it is fine to source a script from there, it is not recommended
-   to use this section to run potentially long initialization tasks because this would
-   impact users running the image and the execution could abort due to timeout.
 
--------------------------
-Environment from the host
--------------------------
+   {Singularity} 3.6 uses an embedded shell interpreter to evaluate and
+   setup container environments, therefore all commands executed from
+   the ``%environment`` section have an execution timeout of **5
+   seconds** for {Singularity} 3.6 and a **1 minute** timeout since
+   {Singularity} 3.7. While it is fine to source a script from there, it
+   is not recommended to use this section to run potentially long
+   initialization tasks because this would impact users running the
+   image and the execution could abort due to timeout.
 
-If you have environment variables set outside of your container, on
-the host, then by default they will be available inside the
-container. Except that:
+***************************
+ Environment from the host
+***************************
 
- - The ``PS1`` shell prompt is reset for a container specific prompt.
- - The ``PATH`` environment variable will be modified to contain default values.
- - The ``LD_LIBRARY_PATH`` is modified to a default
-   ``/.singularity.d/libs``, that will include NVIDIA / ROCm libraries
-   if applicable.
+If you have environment variables set outside of your container, on the
+host, then by default they will be available inside the container.
+Except that:
+
+   -  The ``PS1`` shell prompt is reset for a container specific prompt.
+
+   -  The ``PATH`` environment variable will be modified to contain
+      default values.
+
+   -  The ``LD_LIBRARY_PATH`` is modified to a default
+      ``/.singularity.d/libs``, that will include NVIDIA / ROCm
+      libraries if applicable.
 
 Also, an environment variable set on the host *will not* override a
 variable of the same name that has been set inside the container image.
-   
+
 If you *do not want* the host environment variables to pass into the
-container you can use the ``-e`` or ``--cleanenv`` option. This gives
-a clean environment inside the container, with a minimal set of
+container you can use the ``-e`` or ``--cleanenv`` option. This gives a
+clean environment inside the container, with a minimal set of
 environment variables for correct operation of most software.
 
-.. code-block::
+.. code::
 
    $ singularity exec --cleanenv env.sif env
    HOME=/home/dave
@@ -182,14 +190,13 @@ environment variables for correct operation of most software.
    LD_LIBRARY_PATH=/.singularity.d/libs
    PATH=/startpath:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
    PROMPT_COMMAND=PS1="Singularity> "; unset PROMPT_COMMAND
-   PS1=Singularity> 
+   PS1=Singularity>
    PWD=/home/dave/doc-tesrts
    SINGULARITY_COMMAND=exec
    SINGULARITY_CONTAINER=/home/dave/doc-tesrts/env.sif
    SINGULARITY_ENVIRONMENT=/.singularity.d/env/91-environment.sh
    SINGULARITY_NAME=env.sif
    TERM=xterm-256color
-
 
 .. warning::
 
@@ -200,9 +207,9 @@ environment variables for correct operation of most software.
    such as ``PYTHONPATH`` that can change the way code runs, and
    consider using ``--cleanenv``.
 
-------------------------------------------
-Environment from the {Singularity} runtime
-------------------------------------------
+********************************************
+ Environment from the {Singularity} runtime
+********************************************
 
 It can be useful for a program to know when it is running in a
 {Singularity} container, and some basic information about the container
@@ -210,39 +217,42 @@ environment. {Singularity} will automatically set a number of
 environment variables in a container that can be inspected by any
 program running in the container.
 
-  - ``SINGULARITY_COMMAND`` - how the container was started,
-    e.g. ``exec`` / ``run`` / ``shell``.
-  - ``SINGULARITY_CONTAINER`` - the full path to the container image.
-  - ``SINGULARITY_ENVIRONMENT`` - path inside the container to the
-    shell script holding the container image environment settings.
-  - ``SINGULARITY_NAME`` - name of the container image,
-    e.g. ``myfile.sif`` or ``docker://ubuntu``.
-  - ``SINGULARITY_BIND`` - a list of bind paths that the user
-    requested, via flags or environment variables, when running the
-    container.
+   -  ``SINGULARITY_COMMAND`` - how the container was started, e.g.
+      ``exec`` / ``run`` / ``shell``.
 
-   
---------------------------------
-Overriding environment variables
---------------------------------
+   -  ``SINGULARITY_CONTAINER`` - the full path to the container image.
 
-You can override variables that have been set in the container image,
-or define additional variables, in various ways as appropriate for
-your workflow.
+   -  ``SINGULARITY_ENVIRONMENT`` - path inside the container to the
+      shell script holding the container image environment settings.
+
+   -  ``SINGULARITY_NAME`` - name of the container image, e.g.
+      ``myfile.sif`` or ``docker://ubuntu``.
+
+   -  ``SINGULARITY_BIND`` - a list of bind paths that the user
+      requested, via flags or environment variables, when running the
+      container.
+
+**********************************
+ Overriding environment variables
+**********************************
+
+You can override variables that have been set in the container image, or
+define additional variables, in various ways as appropriate for your
+workflow.
 
 ``--env`` option
-----------------
+================
 
 *New in {Singularity} 3.6*
 
 The ``--env`` option on the ``run/exec/shell`` commands allows you to
 specify environment variables as ``NAME=VALUE`` pairs:
 
-.. code-block::
+.. code::
 
-   $ singularity run env.sif 
+   $ singularity run env.sif
    Hello
-   
+
    $ singularity run --env MYVAR=Goodbye env.sif
    Goodbye
 
@@ -250,33 +260,30 @@ Separate multiple variables with commas, e.g. ``--env
 MYVAR=A,MYVAR2=B``, and use shell quoting / shell escape if your
 variables include special characters.
 
-
 ``--env-file`` option
----------------------
+=====================
 
 *New in {Singularity} 3.6*
 
 The ``--env-file`` option lets you provide a file that contains
 environment variables as ``NAME=VALUE`` pairs, e.g.:
 
+.. code::
 
-.. code-block::
+   $ cat myenvs
+   MYVAR="Hello from a file"
 
-  $ cat myenvs 
-  MYVAR="Hello from a file"
-
-  $ singularity run --env-file myenvs env.sif 
-  Hello from a file
-
+   $ singularity run --env-file myenvs env.sif
+   Hello from a file
 
 ``SINGULARITYENV_`` prefix
---------------------------
+==========================
 
 If you export an environment variable on your host called
 ``SINGULARITYENV_xxx`` *before* you run a container, then it will set
 the environment variable ``xxx`` inside the container:
 
-.. code-block::
+.. code::
 
    $ singularity run env.sif
    Hello
@@ -285,41 +292,38 @@ the environment variable ``xxx`` inside the container:
    $ singularity run env.sif
    Overridden
 
-
 Manipulating ``PATH``
----------------------
+=====================
 
-``PATH`` is a special environment variable that tells a system where
-to look for programs that can be run. ``PATH`` contains multiple
-filesystem locations (paths) separated by colons. When you ask to run a
-program ``myprog``, the system looks through these locations one by
-one, until it finds ``myprog``.
+``PATH`` is a special environment variable that tells a system where to
+look for programs that can be run. ``PATH`` contains multiple filesystem
+locations (paths) separated by colons. When you ask to run a program
+``myprog``, the system looks through these locations one by one, until
+it finds ``myprog``.
 
-To ensure containers work correctly, when a host ``PATH`` might
-contain a lot of host-specific locations that are not present in the
-container, {Singularity} will ensure ``PATH`` in the container is set to
-a default.
+To ensure containers work correctly, when a host ``PATH`` might contain
+a lot of host-specific locations that are not present in the container,
+{Singularity} will ensure ``PATH`` in the container is set to a default.
 
-.. code-block::
+.. code::
 
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-This covers the standard locations for software installed using a
-system package manager in most Linux distributions. If you have
-software installed elsewhere in the container, then you can override
-this by setting ``PATH`` in the container definition ``%environment``
-block.
+This covers the standard locations for software installed using a system
+package manager in most Linux distributions. If you have software
+installed elsewhere in the container, then you can override this by
+setting ``PATH`` in the container definition ``%environment`` block.
 
 If your container depends on things that are bind mounted into it, or
 you have another need to modify the ``PATH`` variable when starting a
 container, you can do so with ``SINGULARITYENV_APPEND_PATH`` or
 ``SINGULARITYENV_PREPEND_PATH``.
 
-If you set a variable on your host called
-``SINGULARITYENV_APPEND_PATH`` then its value will be appended
-(added to the end) of the ``PATH`` variable in the container.
+If you set a variable on your host called ``SINGULARITYENV_APPEND_PATH``
+then its value will be appended (added to the end) of the ``PATH``
+variable in the container.
 
-.. code-block::
+.. code::
 
    $ singularity exec env.sif sh -c 'echo $PATH'
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -332,10 +336,10 @@ Alternatively you could use the ``--env`` option to set a
 ``APPEND_PATH`` variable, e.g. ``--env APPEND_PATH=/endpath``.
 
 If you set a variable on your host called
-``SINGULARITYENV_PREPEND_PATH`` then its value will be prepended
-(added to the start) of the ``PATH`` variable in the container.
+``SINGULARITYENV_PREPEND_PATH`` then its value will be prepended (added
+to the start) of the ``PATH`` variable in the container.
 
-.. code-block::
+.. code::
 
    $ singularity exec env.sif sh -c 'echo $PATH'
    /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -347,44 +351,44 @@ If you set a variable on your host called
 Alternatively you could use the ``--env`` option to set a
 ``PREPEND_PATH`` variable, e.g. ``--env PREPEND_PATH=/startpath``.
 
-
 Evaluating container variables
-------------------------------
+==============================
 
 When setting environment variables with ``--env`` etc. you can specify
-an escaped variable name, e.g. ``\$PATH`` to evaluate the value of
-that variable in the container.
+an escaped variable name, e.g. ``\$PATH`` to evaluate the value of that
+variable in the container.
 
-For example, ``--env PATH="\$PATH:/endpath"`` would have the same
-effect as ``--env APPEND_PATH="/endpath"``.
-
-
+For example, ``--env PATH="\$PATH:/endpath"`` would have the same effect
+as ``--env APPEND_PATH="/endpath"``.
 
 Environment Variable Precedence
--------------------------------
+===============================
 
 When a container is run with {Singularity} 3.6, the container
 environment is constructed in the following order:
 
-  - Clear the environment, keeping just ``HOME`` and ``SINGULARITY_APPNAME``.
-  - Take Docker defined environment variables, where Docker was the base image source.
-  - If ``PATH`` is not defined set the {Singularity} default ``PATH`` *or*
-  - If ``PATH`` is defined, add any missing path parts from {Singularity} defaults
-  - Take environment variables defined explicitly in the image
-    (``%environment``). These can override any previously set values.
-  - Set SCIF (``--app``) environment variables
-  - Set base environment essential vars (``PS1`` and ``LD_LIBRARY_PATH``)
-  - Inject ``SINGULARITYENV_`` / ``--env`` / ``--env-file`` variables
-    so they can override or modify any previous values:
-  - Source any remaining scripts from ``/singularity.d/env`` 
-
+   -  Clear the environment, keeping just ``HOME`` and
+      ``SINGULARITY_APPNAME``.
+   -  Take Docker defined environment variables, where Docker was the
+      base image source.
+   -  If ``PATH`` is not defined set the {Singularity} default ``PATH``
+      *or*
+   -  If ``PATH`` is defined, add any missing path parts from
+      {Singularity} defaults
+   -  Take environment variables defined explicitly in the image
+      (``%environment``). These can override any previously set values.
+   -  Set SCIF (``--app``) environment variables
+   -  Set base environment essential vars (``PS1`` and
+      ``LD_LIBRARY_PATH``)
+   -  Inject ``SINGULARITYENV_`` / ``--env`` / ``--env-file`` variables
+      so they can override or modify any previous values:
+   -  Source any remaining scripts from ``/singularity.d/env``
 
 .. _sec:umask:
 
-
---------------------------------
-Umask / Default File Permissions
---------------------------------
+**********************************
+ Umask / Default File Permissions
+**********************************
 
 The ``umask`` value on a Linux system controls the default permissions
 for newly created files. It is not an environment variable, but
@@ -393,37 +397,35 @@ new files.
 
 .. note::
 
-   A detailed description of what the ``umask`` is, and how it works
-   can be found at `Wikipedia
-   <https://en.wikipedia.org/wiki/Umask>`__.
+   A detailed description of what the ``umask`` is, and how it works can
+   be found at `Wikipedia <https://en.wikipedia.org/wiki/Umask>`__.
 
-   
 {Singularity} 3.7 and above set the ``umask`` in the container to match
 the value outside, unless:
 
-  - The ``--fakeroot`` option is used, in which case a ``0022`` umask
-    is set so that ``root`` owned newly created files have expected
-    'system default' permissions, and can be accessed by other
-    non-root users who may use the same container later.
-  - The ``--no-umask`` option is used, in which case a ``0022`` umask
-    is set.
+   -  The ``--fakeroot`` option is used, in which case a ``0022`` umask
+      is set so that ``root`` owned newly created files have expected
+      'system default' permissions, and can be accessed by other
+      non-root users who may use the same container later.
+
+   -  The ``--no-umask`` option is used, in which case a ``0022`` umask
+      is set.
 
 .. note::
 
-   In {Singularity} 3.6 and below a default ``0022`` umask was always applied.
-
+   In {Singularity} 3.6 and below a default ``0022`` umask was always
+   applied.
 
 .. _sec:metadata:
 
-------------------
-Container Metadata
-------------------
+********************
+ Container Metadata
+********************
 
 Each {Singularity} container has metadata describing the container, how
 it was built, etc. This metadata includes the definition file used to
-build the container and labels, which are specific pieces of
-information set automatically or explicitly when the container is
-built.
+build the container and labels, which are specific pieces of information
+set automatically or explicitly when the container is built.
 
 For containers that are generated with {Singularity} version 3.0 and
 later, default labels are represented using the `rc1 Label Schema
@@ -432,49 +434,46 @@ later, default labels are represented using the `rc1 Label Schema
 .. _sec:labels:
 
 Inherited Labels
-----------------
+================
 
-When building a container from an existing image, either directly from a URI or
-with a definition file, your container will inherit the labels that are set in
-that base image. For example the ``LABEL`` a Docker container sets in its
-``Dockerfile``, or a SIF container that sets labels in its definition file as
-described below.
+When building a container from an existing image, either directly from a
+URI or with a definition file, your container will inherit the labels
+that are set in that base image. For example the ``LABEL`` a Docker
+container sets in its ``Dockerfile``, or a SIF container that sets
+labels in its definition file as described below.
 
-Inherited labels can only be overwritten during a build when the build is
-performed using the ``--force`` option. {Singularity} will warn that it is not
-modifying an existing label when ``--force`` is not used:
+Inherited labels can only be overwritten during a build when the build
+is performed using the ``--force`` option. {Singularity} will warn that
+it is not modifying an existing label when ``--force`` is not used:
 
-.. code-block::
+.. code::
 
-  $ singularity build test2.sif test2.def
-  ...
-  INFO:    Adding labels
-  WARNING: Label: OWNER already exists and force option is false, not overwriting
-
+   $ singularity build test2.sif test2.def
+   ...
+   INFO:    Adding labels
+   WARNING: Label: OWNER already exists and force option is false, not overwriting
 
 .. note::
 
-  {Singularity} 3.0 through 3.8 did not inherit labels from Docker/OCI images
-  during a build.
-
+   {Singularity} 3.0 through 3.8 did not inherit labels from Docker/OCI
+   images during a build.
 
 Custom Labels
--------------
+=============
 
 You can add custom labels to your container using the ``%labels``
 section in a definition file:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: library
-    From: ubuntu:latest
+   Bootstrap: library
+   From: ubuntu:latest
 
-    %labels
-      OWNER Joana
+   %labels
+     OWNER Joana
 
-      
 Dynamic Build Time Labels
--------------------------
+=========================
 
 You may wish to set a label to a value that is not known in advance,
 when you are writing the definition file, but can be obtained in the
@@ -485,264 +484,257 @@ building.
 file defined by the ``SINGULARITY_LABELS`` environment variable in the
 ``%post`` section:
 
-.. code-block:: singularity
-               
-    Bootstrap: library
-    From: ubuntu:latest
+.. code:: singularity
 
-    # These labels take a fixed value in the definition
-    %labels
-      OWNER Joana
+   Bootstrap: library
+   From: ubuntu:latest
 
-    # We can now also set labels to a value at build time
-    %post
-      VAL="$(myprog --version)"
-      echo "my.label $VAL" >> "$SINGULARITY_LABELS"
+   # These labels take a fixed value in the definition
+   %labels
+     OWNER Joana
 
-Labels must be added to the file one per line, in a ``NAME VALUE`` format,
-where the name and value are separated by a space.
+   # We can now also set labels to a value at build time
+   %post
+     VAL="$(myprog --version)"
+     echo "my.label $VAL" >> "$SINGULARITY_LABELS"
 
+Labels must be added to the file one per line, in a ``NAME VALUE``
+format, where the name and value are separated by a space.
 
 Inspecting Metadata
--------------------
+===================
 
 .. _inspect-command:
 
 The ``inspect`` command gives you the ability to view the labels and/or
 other metadata that were added to your container when it was built.
 
-^^^^^^^^^^^^^^^^^^^^^
-``-l``/  ``--labels``
-^^^^^^^^^^^^^^^^^^^^^
+``-l``/ ``--labels``
+--------------------
 
-Running inspect without any options, or with the ``-l`` or
-``--labels`` options will display any labels set on the container
+Running inspect without any options, or with the ``-l`` or ``--labels``
+options will display any labels set on the container
 
-.. code-block:: console
+.. code:: console
 
-    $ singularity inspect ubuntu.sif 
-    my.label: version 1.2.3
-    OWNER: Joana
-    org.label-schema.build-arch: amd64
-    org.label-schema.build-date: Thursday_12_November_2020_10:51:59_CST
-    org.label-schema.schema-version: 1.0
-    org.label-schema.usage.singularity.deffile.bootstrap: library
-    org.label-schema.usage.singularity.deffile.from: ubuntu:latest
-    org.label-schema.usage.singularity.version: 3.7.0-rc.1
-                
+   $ singularity inspect ubuntu.sif
+   my.label: version 1.2.3
+   OWNER: Joana
+   org.label-schema.build-arch: amd64
+   org.label-schema.build-date: Thursday_12_November_2020_10:51:59_CST
+   org.label-schema.schema-version: 1.0
+   org.label-schema.usage.singularity.deffile.bootstrap: library
+   org.label-schema.usage.singularity.deffile.from: ubuntu:latest
+   org.label-schema.usage.singularity.version: 3.7.0-rc.1
+
 We can easily see when the container was built, the source of the base
 image, and the exact version of {Singularity} that was used to build it.
 
-The custom label ``OWNER`` that we set in our definition file is also visible.
+The custom label ``OWNER`` that we set in our definition file is also
+visible.
 
-^^^^^^^^^^^^^^^^^^^^^^
 ``-d`` / ``--deffile``
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 The ``-d`` or ``-deffile`` flag shows the definition file(s) that were
 used to build the container.
 
-.. code-block::
+.. code::
 
-    $ singularity inspect --deffile jupyter.sif
+   $ singularity inspect --deffile jupyter.sif
 
 And the output would look like:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: library
-    From: debian:9
+   Bootstrap: library
+   From: debian:9
 
-    %help
-        Container with Anaconda 2 (Conda 4.5.11 Canary) and Jupyter Notebook 5.6.0 for Debian 9.x (Stretch).
-        This installation is based on Python 2.7.15
+   %help
+       Container with Anaconda 2 (Conda 4.5.11 Canary) and Jupyter Notebook 5.6.0 for Debian 9.x (Stretch).
+       This installation is based on Python 2.7.15
 
-    %environment
-        JUP_PORT=8888
-        JUP_IPNAME=localhost
-        export JUP_PORT JUP_IPNAME
+   %environment
+       JUP_PORT=8888
+       JUP_IPNAME=localhost
+       export JUP_PORT JUP_IPNAME
 
-    %startscript
-        PORT=""
-        if [ -n "$JUP_PORT" ]; then
-        PORT="--port=${JUP_PORT}"
-        fi
+   %startscript
+       PORT=""
+       if [ -n "$JUP_PORT" ]; then
+       PORT="--port=${JUP_PORT}"
+       fi
 
-        IPNAME=""
-        if [ -n "$JUP_IPNAME" ]; then
-        IPNAME="--ip=${JUP_IPNAME}"
-        fi
+       IPNAME=""
+       if [ -n "$JUP_IPNAME" ]; then
+       IPNAME="--ip=${JUP_IPNAME}"
+       fi
 
-        exec jupyter notebook --allow-root ${PORT} ${IPNAME}
+       exec jupyter notebook --allow-root ${PORT} ${IPNAME}
 
-    %setup
-        #Create the .condarc file where the environments/channels from conda are specified, these are pulled with preference to root
-        cd /
-        touch .condarc
+   %setup
+       #Create the .condarc file where the environments/channels from conda are specified, these are pulled with preference to root
+       cd /
+       touch .condarc
 
-    %post
-        echo 'export RANDOM=123456' >>$SINGULARITY_ENVIRONMENT
-        #Installing all dependencies
-        apt-get update && apt-get -y upgrade
-        apt-get -y install \
-        build-essential \
-        wget \
-        bzip2 \
-        ca-certificates \
-        libglib2.0-0 \
-        libxext6 \
-        libsm6 \
-        libxrender1 \
-        git
-        rm -rf /var/lib/apt/lists/*
-        apt-get clean
-        #Installing Anaconda 2 and Conda 4.5.11
-        wget -c https://repo.continuum.io/archive/Anaconda2-5.3.0-Linux-x86_64.sh
-        /bin/bash Anaconda2-5.3.0-Linux-x86_64.sh -bfp /usr/local
-        #Conda configuration of channels from .condarc file
-        conda config --file /.condarc --add channels defaults
-        conda config --file /.condarc --add channels conda-forge
-        conda update conda
-        #List installed environments
-        conda list
+   %post
+       echo 'export RANDOM=123456' >>$SINGULARITY_ENVIRONMENT
+       #Installing all dependencies
+       apt-get update && apt-get -y upgrade
+       apt-get -y install \
+       build-essential \
+       wget \
+       bzip2 \
+       ca-certificates \
+       libglib2.0-0 \
+       libxext6 \
+       libsm6 \
+       libxrender1 \
+       git
+       rm -rf /var/lib/apt/lists/*
+       apt-get clean
+       #Installing Anaconda 2 and Conda 4.5.11
+       wget -c https://repo.continuum.io/archive/Anaconda2-5.3.0-Linux-x86_64.sh
+       /bin/bash Anaconda2-5.3.0-Linux-x86_64.sh -bfp /usr/local
+       #Conda configuration of channels from .condarc file
+       conda config --file /.condarc --add channels defaults
+       conda config --file /.condarc --add channels conda-forge
+       conda update conda
+       #List installed environments
+       conda list
 
 Which is the definition file for the ``jupyter.sif`` container.
 
-^^^^^^^^^^^^^^^^^^^^^^^^
 ``-r`` / ``--runscript``
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 
 The ``-r`` or ``--runscript`` option shows the runscript for the image.
 
-.. code-block::
+.. code::
 
-    $ singularity inspect --runscript jupyter.sif
+   $ singularity inspect --runscript jupyter.sif
 
 And the output would look like:
 
-.. code-block:: bash
+.. code:: bash
 
-    #!/bin/sh
-    OCI_ENTRYPOINT=""
-    OCI_CMD="bash"
-    # ENTRYPOINT only - run entrypoint plus args
-    if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
-    SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} $@"
-    fi
+   #!/bin/sh
+   OCI_ENTRYPOINT=""
+   OCI_CMD="bash"
+   # ENTRYPOINT only - run entrypoint plus args
+   if [ -z "$OCI_CMD" ] && [ -n "$OCI_ENTRYPOINT" ]; then
+   SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} $@"
+   fi
 
-    # CMD only - run CMD or override with args
-    if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
-    if [ $# -gt 0 ]; then
-        SINGULARITY_OCI_RUN="$@"
-    else
-        SINGULARITY_OCI_RUN="${OCI_CMD}"
-    fi
-    fi
+   # CMD only - run CMD or override with args
+   if [ -n "$OCI_CMD" ] && [ -z "$OCI_ENTRYPOINT" ]; then
+   if [ $# -gt 0 ]; then
+       SINGULARITY_OCI_RUN="$@"
+   else
+       SINGULARITY_OCI_RUN="${OCI_CMD}"
+   fi
+   fi
 
-    # ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
-    # override with user provided args
-    if [ $# -gt 0 ]; then
-        SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} $@"
-    else
-        SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
-    fi
+   # ENTRYPOINT and CMD - run ENTRYPOINT with CMD as default args
+   # override with user provided args
+   if [ $# -gt 0 ]; then
+       SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} $@"
+   else
+       SINGULARITY_OCI_RUN="${OCI_ENTRYPOINT} ${OCI_CMD}"
+   fi
 
-    exec $SINGULARITY_OCI_RUN
+   exec $SINGULARITY_OCI_RUN
 
-^^^^^^^^^^^^^^^^^^^
 ``-t`` / ``--test``
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 The ``-t`` or ``--test`` flag shows the test script for the image.
 
-.. code-block::
+.. code::
 
-    $ singularity inspect --test jupyter.sif
+   $ singularity inspect --test jupyter.sif
 
-This will output the corresponding ``%test`` section from the definition file.
+This will output the corresponding ``%test`` section from the definition
+file.
 
-^^^^^^^^^^^^^^^^^^^^^^^^^^
 ``-e`` / ``--environment``
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------
 
 The ``-e`` or ``--environment`` flag shows the environment variables
-that are defined in the container image. These may be set from
-one or more environment files, depending on how the container was built.
+that are defined in the container image. These may be set from one or
+more environment files, depending on how the container was built.
 
-.. code-block::
+.. code::
 
-    $ singularity inspect --environment jupyter.sif
+   $ singularity inspect --environment jupyter.sif
 
 And the output would look like:
 
-.. code-block:: bash
+.. code:: bash
 
-    ==90-environment.sh==
-    #!/bin/sh
+   ==90-environment.sh==
+   #!/bin/sh
 
-    JUP_PORT=8888
-    JUP_IPNAME=localhost
-    export JUP_PORT JUP_IPNAME
+   JUP_PORT=8888
+   JUP_IPNAME=localhost
+   export JUP_PORT JUP_IPNAME
 
-
-^^^^^^^^^^^^^^^^^^^^^^^
 ``-H`` / ``--helpfile``
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 The ``-H`` or ``-helpfile`` flag will show the container's description
 in the ``%help`` section of its definition file.
 
 You can call it this way:
 
-.. code-block::
+.. code::
 
-    $ singularity inspect --helpfile jupyter.sif
+   $ singularity inspect --helpfile jupyter.sif
 
 And the output would look like:
 
-.. code-block::
+.. code::
 
-    Container with Anaconda 2 (Conda 4.5.11 Canary) and Jupyter Notebook 5.6.0 for Debian 9.x (Stretch).
-    This installation is based on Python 2.7.15
+   Container with Anaconda 2 (Conda 4.5.11 Canary) and Jupyter Notebook 5.6.0 for Debian 9.x (Stretch).
+   This installation is based on Python 2.7.15
 
-^^^^^^^^^^^^^^^^^^^
 ``-j`` / ``--json``
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
-This flag gives you the possibility to output your labels in a JSON format.
+This flag gives you the possibility to output your labels in a JSON
+format.
 
 You can call it this way:
 
-.. code-block:: console
+.. code:: console
 
-    $ singularity inspect --json ubuntu.sif
+   $ singularity inspect --json ubuntu.sif
 
 And the output would look like:
 
-.. code-block:: json
+.. code:: json
 
-    {
-            "data": {
-                    "attributes": {
-                            "labels": {
-                                    "my.label": "version 1.2.3",
-                                    "OWNER": "Joana",
-                                    "org.label-schema.build-arch": "amd64",
-                                    "org.label-schema.build-date": "Thursday_12_November_2020_10:51:59_CST",
-                                    "org.label-schema.schema-version": "1.0",
-                                    "org.label-schema.usage.singularity.deffile.bootstrap": "library",
-                                    "org.label-schema.usage.singularity.deffile.from": "ubuntu:latest",
-                                    "org.label-schema.usage.singularity.version": "3.7.0-rc.1"
-                            }
-                    }
-            },
-            "type": "container"
-    }
+   {
+           "data": {
+                   "attributes": {
+                           "labels": {
+                                   "my.label": "version 1.2.3",
+                                   "OWNER": "Joana",
+                                   "org.label-schema.build-arch": "amd64",
+                                   "org.label-schema.build-date": "Thursday_12_November_2020_10:51:59_CST",
+                                   "org.label-schema.schema-version": "1.0",
+                                   "org.label-schema.usage.singularity.deffile.bootstrap": "library",
+                                   "org.label-schema.usage.singularity.deffile.from": "ubuntu:latest",
+                                   "org.label-schema.usage.singularity.version": "3.7.0-rc.1"
+                           }
+                   }
+           },
+           "type": "container"
+   }
 
-
--------------------------
-/.singularity.d directory
--------------------------
+***************************
+ /.singularity.d directory
+***************************
 
 The ``/.singularity.d`` directory in a container contains scripts and
 environment files that are used when a container is executed.
@@ -751,68 +743,69 @@ environment files that are used when a container is executed.
 your definition file during builds, or directly within your container
 image. Recent 3.x versions of {Singularity} replace older action scripts
 dynamically, at runtime, to support new features. In the longer term,
-metadata will be moved outside of the container, and stored only in
-the SIF file metadata descriptor.
+metadata will be moved outside of the container, and stored only in the
+SIF file metadata descriptor.
 
-.. code-block::
+.. code::
 
-    /.singularity.d/
+   /.singularity.d/
 
-    ├── actions
-    │   ├── exec
-    │   ├── run
-    │   ├── shell
-    │   ├── start
-    │   └── test
-    ├── env
-    │   ├── 01-base.sh
-    |   ├── 10-docker2singularity.sh
-    │   ├── 90-environment.sh
-    │   ├── 91-environment.sh
-    |   ├── 94-appsbase.sh
-    │   ├── 95-apps.sh
-    │   └── 99-base.sh
-    ├── labels.json
-    ├── libs
-    ├── runscript
-    ├── runscript.help
-    ├── Singularity
-    └── startscript
+   ├── actions
+   │   ├── exec
+   │   ├── run
+   │   ├── shell
+   │   ├── start
+   │   └── test
+   ├── env
+   │   ├── 01-base.sh
+   |   ├── 10-docker2singularity.sh
+   │   ├── 90-environment.sh
+   │   ├── 91-environment.sh
+   |   ├── 94-appsbase.sh
+   │   ├── 95-apps.sh
+   │   └── 99-base.sh
+   ├── labels.json
+   ├── libs
+   ├── runscript
+   ├── runscript.help
+   ├── Singularity
+   └── startscript
 
--  **actions**: This directory contains helper scripts to allow the container to
-   carry out the action commands. (e.g. ``exec`` , ``run`` or ``shell``). In
-   later versions of {Singularity}, these files may be dynamically written at
-   runtime, *and should not be modified* in the container.
+-  **actions**: This directory contains helper scripts to allow the
+   container to carry out the action commands. (e.g. ``exec`` , ``run``
+   or ``shell``). In later versions of {Singularity}, these files may be
+   dynamically written at runtime, *and should not be modified* in the
+   container.
 
 -  **env**: All ``*.sh`` files in this directory are sourced in
-   alphanumeric order when the container is started. For legacy
-   purposes there is a symbolic link called ``/environment`` that
-   points to ``/.singularity.d/env/90-environment.sh``. Whenever
-   possible, avoid modifying or creating environment files manually to
-   prevent potential issues building & running containers with future
-   versions of {Singularity}. Beginning with {Singularity} 3.6, additional
+   alphanumeric order when the container is started. For legacy purposes
+   there is a symbolic link called ``/environment`` that points to
+   ``/.singularity.d/env/90-environment.sh``. Whenever possible, avoid
+   modifying or creating environment files manually to prevent potential
+   issues building & running containers with future versions of
+   {Singularity}. Beginning with {Singularity} 3.6, additional
    facilities such as ``--env`` and ``--env-file`` are available to
    allow manipulation of the container environment at runtime.
 
--  **labels.json**: The json file that stores a containers labels described
-   above. 
+-  **labels.json**: The json file that stores a containers labels
+   described above.
 
--  **libs**: At runtime the user may request some host-system libraries to be
-   mapped into the container (with the ``--nv`` option for example). If so, this
-   is their destination.
+-  **libs**: At runtime the user may request some host-system libraries
+   to be mapped into the container (with the ``--nv`` option for
+   example). If so, this is their destination.
 
--  **runscript**: The commands in this file will be executed when the container
-   is invoked with the ``run`` command or called as an executable. For legacy
-   purposes there is a symbolic link called ``/singularity`` that points to this
-   file.
+-  **runscript**: The commands in this file will be executed when the
+   container is invoked with the ``run`` command or called as an
+   executable. For legacy purposes there is a symbolic link called
+   ``/singularity`` that points to this file.
 
--  **runscript.help**: Contains the description that was added in the ``%help``
-   section.
+-  **runscript.help**: Contains the description that was added in the
+   ``%help`` section.
 
--  **{Singularity}**: This is the definition file that was used to generate the
-   container. If more than 1 definition file was used to generate the container
-   additional {Singularity} files will appear in numeric order in a sub-directory
-   called ``bootstrap_history``.
+-  **{Singularity}**: This is the definition file that was used to
+   generate the container. If more than 1 definition file was used to
+   generate the container additional {Singularity} files will appear in
+   numeric order in a sub-directory called ``bootstrap_history``.
 
 -  **startscript**: The commands in this file will be executed when the
    container is invoked with the ``instance start`` command.

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -542,7 +542,7 @@ The custom label ``OWNER`` that we set in our definition file is also visible.
 The ``-d`` or ``-deffile`` flag shows the definition file(s) that were
 used to build the container.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity inspect --deffile jupyter.sif
 
@@ -614,7 +614,7 @@ Which is the definition file for the ``jupyter.sif`` container.
 
 The ``-r`` or ``--runscript`` option shows the runscript for the image.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity inspect --runscript jupyter.sif
 
@@ -655,7 +655,7 @@ And the output would look like:
 
 The ``-t`` or ``--test`` flag shows the test script for the image.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity inspect --test jupyter.sif
 
@@ -669,7 +669,7 @@ The ``-e`` or ``--environment`` flag shows the environment variables
 that are defined in the container image. These may be set from
 one or more environment files, depending on how the container was built.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity inspect --environment jupyter.sif
 
@@ -694,13 +694,13 @@ in the ``%help`` section of its definition file.
 
 You can call it this way:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity inspect --helpfile jupyter.sif
 
 And the output would look like:
 
-.. code-block:: none
+.. code-block::
 
     Container with Anaconda 2 (Conda 4.5.11 Canary) and Jupyter Notebook 5.6.0 for Debian 9.x (Stretch).
     This installation is based on Python 2.7.15
@@ -754,7 +754,7 @@ dynamically, at runtime, to support new features. In the longer term,
 metadata will be moved outside of the container, and stored only in
 the SIF file metadata descriptor.
 
-.. code-block:: none
+.. code-block::
 
     /.singularity.d/
 

--- a/fakeroot.rst
+++ b/fakeroot.rst
@@ -118,20 +118,20 @@ Examples
 Build from a definition file:
 -----------------------------
 
-.. code-block:: none
+.. code-block::
 
     singularity build --fakeroot /tmp/test.sif /tmp/test.def
 
 Ping from container:
 --------------------
 
-.. code-block:: none
+.. code-block::
 
     singularity exec --fakeroot --net docker://alpine ping -c1 8.8.8.8
 
 HTTP server:
 ------------
 
-.. code-block:: none
+.. code-block::
 
     singularity run --fakeroot --net --network-args="portmap=8080:80/tcp" -w docker://nginx

--- a/fakeroot.rst
+++ b/fakeroot.rst
@@ -1,43 +1,50 @@
 .. _fakeroot:
 
-================
-Fakeroot feature
-================
+##################
+ Fakeroot feature
+##################
 
---------
-Overview
---------
+**********
+ Overview
+**********
 
-The fakeroot feature (commonly referred as rootless mode) allows an unprivileged user
-to run a container as a **"fake root"** user by leveraging
-`user namespace UID/GID mapping <http://man7.org/linux/man-pages/man7/user_namespaces.7.html>`_.
+The fakeroot feature (commonly referred as rootless mode) allows an
+unprivileged user to run a container as a **"fake root"** user by
+leveraging `user namespace UID/GID mapping
+<http://man7.org/linux/man-pages/man7/user_namespaces.7.html>`_.
 
-.. note:: 
+.. note::
 
-	This feature requires a Linux kernel >= 3.8, but the recommended version is >= 3.18
+   This feature requires a Linux kernel >= 3.8, but the recommended
+   version is >= 3.18
 
-A **"fake root"** user has almost the same administrative rights as root but only **inside the container**
-and the **requested namespaces**, which means that this user:
+A **"fake root"** user has almost the same administrative rights as root
+but only **inside the container** and the **requested namespaces**,
+which means that this user:
 
-  - can set different user/group ownership for files or directories they own
-  - can change user/group identity with su/sudo commands
-  - has full privileges inside the requested namespaces (network, ipc, uts)
+   -  can set different user/group ownership for files or directories
+      they own
+   -  can change user/group identity with su/sudo commands
+   -  has full privileges inside the requested namespaces (network, ipc,
+      uts)
 
----------------------
-Restrictions/security
----------------------
+***********************
+ Restrictions/security
+***********************
 
 Filesystem
 ==========
 
-A **"fake root"** user can't access or modify files and directories for which they don't
-already have access or rights on the host filesystem, so a **"fake root"** user won't be able
-to access root-only host files like ``/etc/shadow`` or the host ``/root`` directory.
+A **"fake root"** user can't access or modify files and directories for
+which they don't already have access or rights on the host filesystem,
+so a **"fake root"** user won't be able to access root-only host files
+like ``/etc/shadow`` or the host ``/root`` directory.
 
-Additionally, all files or directories created by the **"fake root"** user are owned by
-``root:root`` inside container but as ``user:group`` outside of the container.
-Let's consider the following example, in this case "user" is authorized to use the fakeroot feature
-and can use 65536 UIDs starting at 131072 (same thing for GIDs).
+Additionally, all files or directories created by the **"fake root"**
+user are owned by ``root:root`` inside container but as ``user:group``
+outside of the container. Let's consider the following example, in this
+case "user" is authorized to use the fakeroot feature and can use 65536
+UIDs starting at 131072 (same thing for GIDs).
 
 +----------------------+-----------------------+
 | UID inside container | UID outside container |
@@ -53,64 +60,79 @@ and can use 65536 UIDs starting at 131072 (same thing for GIDs).
 | 65536                | 196607                |
 +----------------------+-----------------------+
 
-Which means if the **"fake root"** user creates a file under a ``bin`` user in the container, this file will
-be owned by ``131073:131073`` outside of container. The responsibility relies on the administrator
-to ensure that there is no overlap with the current user's UID/GID on the system.
+Which means if the **"fake root"** user creates a file under a ``bin``
+user in the container, this file will be owned by ``131073:131073``
+outside of container. The responsibility relies on the administrator to
+ensure that there is no overlap with the current user's UID/GID on the
+system.
 
 Network
 =======
 
-Restrictions are also applied to networking, if ``singularity`` is executed without the ``--net`` flag,
-the **"fake root"** user won't be able to use ``ping`` or bind a container service to a port below
-1024.
+Restrictions are also applied to networking, if ``singularity`` is
+executed without the ``--net`` flag, the **"fake root"** user won't be
+able to use ``ping`` or bind a container service to a port below 1024.
 
-With ``--net`` the **"fake root"** user has full privileges in a dedicated container network. Inside
-the container network they can bind on privileged ports below 1024, use ping, manage firewall rules,
-listen to traffic, etc. Anything done in this dedicated network won't affect the host network.
+With ``--net`` the **"fake root"** user has full privileges in a
+dedicated container network. Inside the container network they can bind
+on privileged ports below 1024, use ping, manage firewall rules, listen
+to traffic, etc. Anything done in this dedicated network won't affect
+the host network.
 
-.. note:: 
-    Of course an unprivileged user could not map host ports below than 1024 by using:
-    ``--network-args="portmap=80:80/tcp"``
+.. note::
+
+   Of course an unprivileged user could not map host ports below than
+   1024 by using: ``--network-args="portmap=80:80/tcp"``
 
 .. warning::
-    For unprivileged installation of {Singularity} or if ``allow setuid = no`` is set in ``singularity.conf``
-    users won't be able to use a ``fakeroot`` network.
 
-----------------------------
-Requirements / Configuration
-----------------------------
+   For unprivileged installation of {Singularity} or if ``allow setuid =
+   no`` is set in ``singularity.conf`` users won't be able to use a
+   ``fakeroot`` network.
 
-Fakeroot depends on user mappings set in ``/etc/subuid`` and group mappings in ``/etc/subgid``, so your username 
-needs to be listed in those files with a valid mapping (see the admin-guide for details), if you can't edit
-the files ask an administrator.
+******************************
+ Requirements / Configuration
+******************************
 
-In {Singularity} ``3.5`` a ``singularity config fakeroot`` command has been added to allow configuration
-of the ``/etc/subuid`` and ``/etc/subgid`` mappings from the {Singularity} command line. You must be a root
-user or run with ``sudo`` to use ``config fakeroot``, as the mapping files are security sensitive. See the
-admin-guide for more details.
+Fakeroot depends on user mappings set in ``/etc/subuid`` and group
+mappings in ``/etc/subgid``, so your username needs to be listed in
+those files with a valid mapping (see the admin-guide for details), if
+you can't edit the files ask an administrator.
 
------
-Usage
------
+In {Singularity} ``3.5`` a ``singularity config fakeroot`` command has
+been added to allow configuration of the ``/etc/subuid`` and
+``/etc/subgid`` mappings from the {Singularity} command line. You must
+be a root user or run with ``sudo`` to use ``config fakeroot``, as the
+mapping files are security sensitive. See the admin-guide for more
+details.
 
-If your user account is configured with valid ``subuid`` and ``subgid`` mappings you work as a fake root user
-inside a container by using the ``--fakeroot`` or ``-f`` option. 
+*******
+ Usage
+*******
 
-The ``--fakeroot`` option is available with the following singularity commands:
+If your user account is configured with valid ``subuid`` and ``subgid``
+mappings you work as a fake root user inside a container by using the
+``--fakeroot`` or ``-f`` option.
 
-  - ``shell``
-  - ``exec``
-  - ``run``
-  - ``instance start``
-  - ``build``
+The ``--fakeroot`` option is available with the following singularity
+commands:
+
+   -  ``shell``
+   -  ``exec``
+   -  ``run``
+   -  ``instance start``
+   -  ``build``
 
 Build
 =====
 
-With fakeroot an unprivileged user can now build an image from a definition file with few restrictions. Some bootstrap
-methods that require creation of block devices (like ``/dev/null``) may not always work correctly with **"fake root"**,
-{Singularity} uses seccomp filters to give programs the illusion that block device creation succeeded. This appears to
-work with ``yum`` bootstraps and *may* work with other bootstrap methods, although ``debootstrap`` is known to not work.
+With fakeroot an unprivileged user can now build an image from a
+definition file with few restrictions. Some bootstrap methods that
+require creation of block devices (like ``/dev/null``) may not always
+work correctly with **"fake root"**, {Singularity} uses seccomp filters
+to give programs the illusion that block device creation succeeded. This
+appears to work with ``yum`` bootstraps and *may* work with other
+bootstrap methods, although ``debootstrap`` is known to not work.
 
 Examples
 ========
@@ -118,20 +140,20 @@ Examples
 Build from a definition file:
 -----------------------------
 
-.. code-block::
+.. code::
 
-    singularity build --fakeroot /tmp/test.sif /tmp/test.def
+   singularity build --fakeroot /tmp/test.sif /tmp/test.def
 
 Ping from container:
 --------------------
 
-.. code-block::
+.. code::
 
-    singularity exec --fakeroot --net docker://alpine ping -c1 8.8.8.8
+   singularity exec --fakeroot --net docker://alpine ping -c1 8.8.8.8
 
 HTTP server:
 ------------
 
-.. code-block::
+.. code::
 
-    singularity run --fakeroot --net --network-args="portmap=8080:80/tcp" -w docker://nginx
+   singularity run --fakeroot --net --network-args="portmap=8080:80/tcp" -w docker://nginx

--- a/gpu.rst
+++ b/gpu.rst
@@ -78,7 +78,7 @@ versions on the `tags page on Docker Hub <https://hub.docker.com/r/tensorflow/te
 The container is large, so it's best to build or pull the docker image to a SIF
 before you start working with it:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull docker://tensorflow/tensorflow:latest-gpu
     ...
@@ -88,7 +88,7 @@ before you start working with it:
 
 Then run the container with GPU support:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run --nv tensorflow_latest-gpu.sif
 
@@ -107,7 +107,7 @@ Then run the container with GPU support:
 You can verify the GPU is available within the container by using the
 tensorflow ``list_local_devices()`` function:
 
-.. code-block:: none
+.. code-block::
 
     Singularity> python
     Python 2.7.15+ (default, Jul  9 2019, 16:51:35)
@@ -150,7 +150,7 @@ limit the GPU devices that CUDA programs see.
 E.g. to run the tensorflow container, but using only the first GPU in the host,
 we could do:
 
-.. code-block:: none
+.. code-block::
 
     $ SINGULARITYENV_CUDA_VISIBLE_DEVICES=0 singularity run --nv tensorflow_latest-gpu.sif
 
@@ -247,7 +247,7 @@ Tensorflow can be run using ``--nvccli`` in a similar manner as the
 standard ``--nv`` binding approach when run unprivleged. Build the
 large container into a sandbox:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity build --sandbox tensorflow_latest-gpu docker://tensorflow/tensorflow:latest-gpu
     INFO:    Starting build...
@@ -258,7 +258,7 @@ large container into a sandbox:
 
 Then run the container with ``nvidia-container-cli`` GPU support:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run -uw --nv --nvccli tensorflow_latest-gpu
 
@@ -277,7 +277,7 @@ Then run the container with ``nvidia-container-cli`` GPU support:
 You can verify the GPU is available within the container by using the
 tensorflow ``list_local_devices()`` function:
 
-.. code-block:: none
+.. code-block::
 
     Singularity> python
     Python 2.7.15+ (default, Jul  9 2019, 16:51:35)
@@ -316,7 +316,7 @@ the ``/dev`` tree in the container.
 For example, to pass only the 2nd and 3rd GPU into a container running
 on a system with 4 GPUs, run the following:
 
-.. code-block:: none
+.. code-block::
 
     $ export NVIDIA_VISIBLE_DEVICES=1,2
     $ singularity run -uwc --nv --nvccli tensorflow_latest-gpu
@@ -339,7 +339,7 @@ Note that:
 If you use ``--contain`` without setting ``NVIDIA_VISIBLE_DEVICES``,
 no GPUs will be available in the container, and a warning will be shown:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run -uwc --nv --nvccli tensorflow_latest-gpu
     WARNING: When using nvidia-container-cli with --contain NVIDIA_VISIBLE_DEVICES
@@ -351,7 +351,7 @@ To restore the behaviour of the standard GPU handling, set
 If your system contains Ampere or newer GPUs that support virtual MIG
 devices, you can specify MIG identifiers / UUIDs.
 
-.. code-block:: none
+.. code-block::
 
     $ export NVIDIA_VISIBLE_DEVICES=MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/7/0
 
@@ -448,7 +448,7 @@ versions on the `tags page on Docker Hub <https://hub.docker.com/r/rocm/tensorfl
 The container is large, so it's best to build or pull the docker image to a SIF
 before you start working with it:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull docker://rocm/tensorflow:latest
     ...
@@ -458,7 +458,7 @@ before you start working with it:
 
 Then run the container with GPU support:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run --rocm tensorflow_latest.sif
 
@@ -466,7 +466,7 @@ Then run the container with GPU support:
 You can verify the GPU is available within the container by using the
 tensorflow ``list_local_devices()`` function:
 
-.. code-block:: none
+.. code-block::
 
     Singularity> ipython
     Python 3.5.2 (default, Jul 10 2019, 11:58:48)
@@ -506,7 +506,7 @@ The latest versions of Blender supports OpenCL rendering. You can run Blender
 as a graphical application that will make use of a local Radeon GPU for OpenCL
 compute using the container that has been published to the Sylabs library:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity exec --rocm --bind /etc/OpenCL library://sylabs/examples/blender blender
 

--- a/gpu.rst
+++ b/gpu.rst
@@ -1,191 +1,198 @@
 .. _gpu:
 
-====================================
-GPU Support (NVIDIA CUDA & AMD ROCm)
-====================================
+######################################
+ GPU Support (NVIDIA CUDA & AMD ROCm)
+######################################
 
-{Singularity} natively supports running application containers that use NVIDIA's
-CUDA GPU compute framework, or AMD's ROCm solution. This allows easy access to
-users of GPU-enabled machine learning frameworks such as tensorflow, regardless
-of the host operating system. As long as the host has a driver and library
-installation for CUDA/ROCm then it's possible to e.g. run tensorflow in an
-up-to-date Ubuntu 20.04 container, from an older RHEL 7 host.
+{Singularity} natively supports running application containers that use
+NVIDIA's CUDA GPU compute framework, or AMD's ROCm solution. This allows
+easy access to users of GPU-enabled machine learning frameworks such as
+tensorflow, regardless of the host operating system. As long as the host
+has a driver and library installation for CUDA/ROCm then it's possible
+to e.g. run tensorflow in an up-to-date Ubuntu 20.04 container, from an
+older RHEL 7 host.
 
-Applications that support OpenCL for compute acceleration can also be used
-easily, with an additional bind option.
+Applications that support OpenCL for compute acceleration can also be
+used easily, with an additional bind option.
 
-With {Singularity} 3.9 experimental support has been introduced to
-use Nvidia's ``nvidia-container-cli`` tooling for GPU container
-setup. This functionality, accessible via the new ``--nvccli`` flag,
-improves compatibility with OCI runtimes and exposes additional
-container configuration options.
+With {Singularity} 3.9 experimental support has been introduced to use
+Nvidia's ``nvidia-container-cli`` tooling for GPU container setup. This
+functionality, accessible via the new ``--nvccli`` flag, improves
+compatibility with OCI runtimes and exposes additional container
+configuration options.
 
------------------------------
-NVIDIA GPUs & CUDA (Standard)
------------------------------
+*******************************
+ NVIDIA GPUs & CUDA (Standard)
+*******************************
 
-Commands that ``run``, or otherwise execute containers (``shell``, ``exec``) can
-take an ``--nv`` option, which will setup the container's environment to use an
-NVIDIA GPU and the basic CUDA libraries to run a CUDA enabled application.
-The ``--nv`` flag will:
+Commands that ``run``, or otherwise execute containers (``shell``,
+``exec``) can take an ``--nv`` option, which will setup the container's
+environment to use an NVIDIA GPU and the basic CUDA libraries to run a
+CUDA enabled application. The ``--nv`` flag will:
 
-* Ensure that the ``/dev/nvidiaX`` device entries are available inside the
-  container, so that the GPU cards in the host are accessible.
-* Locate and bind the basic CUDA libraries from the host into the container, so
-  that they are available to the container, and match the kernel GPU driver on
-  the host.
-* Set the ``LD_LIBRARY_PATH`` inside the container so that the bound-in version
-  of the CUDA libraries are used by applications run inside the container.
+-  Ensure that the ``/dev/nvidiaX`` device entries are available inside
+   the container, so that the GPU cards in the host are accessible.
+
+-  Locate and bind the basic CUDA libraries from the host into the
+   container, so that they are available to the container, and match the
+   kernel GPU driver on the host.
+
+-  Set the ``LD_LIBRARY_PATH`` inside the container so that the bound-in
+   version of the CUDA libraries are used by applications run inside the
+   container.
 
 Requirements
 ============
 
-To use the ``--nv`` flag to run a CUDA application inside a container you must
-ensure that:
+To use the ``--nv`` flag to run a CUDA application inside a container
+you must ensure that:
 
-* The host has a working installation of the NVIDIA GPU driver, and a matching
-  version of the basic NVIDIA/CUDA libraries. The host *does not* need to have an X
-  server running, unless you want to run graphical apps from the container.
-* The NVIDIA libraries are in the system's library search path.
-* The application inside your container was compiled for a CUDA version, and
-  device capability level, that is supported by the host card and driver.
+-  The host has a working installation of the NVIDIA GPU driver, and a
+   matching version of the basic NVIDIA/CUDA libraries. The host *does
+   not* need to have an X server running, unless you want to run
+   graphical apps from the container.
 
-These requirements are usually satisfied by installing the NVIDIA drivers and
-CUDA packages directly from the NVIDIA website. Linux distributions may provide
-NVIDIA drivers and CUDA libraries, but they are often outdated which can lead to
-problems running applications compiled for the latest versions of CUDA.
+-  The NVIDIA libraries are in the system's library search path.
 
-{Singularity} will find the NVIDIA/CUDA libraries on your host using
-the list of libraries in the configuration file
+-  The application inside your container was compiled for a CUDA
+   version, and device capability level, that is supported by the host
+   card and driver.
+
+These requirements are usually satisfied by installing the NVIDIA
+drivers and CUDA packages directly from the NVIDIA website. Linux
+distributions may provide NVIDIA drivers and CUDA libraries, but they
+are often outdated which can lead to problems running applications
+compiled for the latest versions of CUDA.
+
+{Singularity} will find the NVIDIA/CUDA libraries on your host using the
+list of libraries in the configuration file
 ``etc/singularity/nvbliblist``, and resolving paths through the
 ``ldconfig`` cache. At time of release this list is approriate for the
 latest stable CUDA version. It can be modified by the administrator to
 add additional libraries if necessary. See the admin guide for more
 details.
 
-
 Example - tensorflow-gpu
 ========================
 
-Tensorflow is commonly used for machine learning projects but can be diffficult
-to install on older systems, and is updated frequently. Running tensorflow from
-a container removes installation problems and makes trying out new versions easy.
+Tensorflow is commonly used for machine learning projects but can be
+diffficult to install on older systems, and is updated frequently.
+Running tensorflow from a container removes installation problems and
+makes trying out new versions easy.
 
-The official tensorflow repository on Docker Hub contains NVIDA GPU supporting
-containers, that will use CUDA for processing. You can view the available
-versions on the `tags page on Docker Hub <https://hub.docker.com/r/tensorflow/tensorflow/tags>`__
+The official tensorflow repository on Docker Hub contains NVIDA GPU
+supporting containers, that will use CUDA for processing. You can view
+the available versions on the `tags page on Docker Hub
+<https://hub.docker.com/r/tensorflow/tensorflow/tags>`__
 
-The container is large, so it's best to build or pull the docker image to a SIF
-before you start working with it:
+The container is large, so it's best to build or pull the docker image
+to a SIF before you start working with it:
 
-.. code-block::
+.. code::
 
-    $ singularity pull docker://tensorflow/tensorflow:latest-gpu
-    ...
-    INFO:    Creating SIF file...
-    INFO:    Build complete: tensorflow_latest-gpu.sif
-
+   $ singularity pull docker://tensorflow/tensorflow:latest-gpu
+   ...
+   INFO:    Creating SIF file...
+   INFO:    Build complete: tensorflow_latest-gpu.sif
 
 Then run the container with GPU support:
 
-.. code-block::
+.. code::
 
-    $ singularity run --nv tensorflow_latest-gpu.sif
+   $ singularity run --nv tensorflow_latest-gpu.sif
 
-    ________                               _______________
-    ___  __/__________________________________  ____/__  /________      __
-    __  /  _  _ \_  __ \_  ___/  __ \_  ___/_  /_   __  /_  __ \_ | /| / /
-    _  /   /  __/  / / /(__  )/ /_/ /  /   _  __/   _  / / /_/ /_ |/ |/ /
-    /_/    \___//_/ /_//____/ \____//_/    /_/      /_/  \____/____/|__/
+   ________                               _______________
+   ___  __/__________________________________  ____/__  /________      __
+   __  /  _  _ \_  __ \_  ___/  __ \_  ___/_  /_   __  /_  __ \_ | /| / /
+   _  /   /  __/  / / /(__  )/ /_/ /  /   _  __/   _  / / /_/ /_ |/ |/ /
+   /_/    \___//_/ /_//____/ \____//_/    /_/      /_/  \____/____/|__/
 
 
-    You are running this container as user with ID 1000 and group 1000,
-    which should map to the ID and group for your user on the Docker host. Great!
+   You are running this container as user with ID 1000 and group 1000,
+   which should map to the ID and group for your user on the Docker host. Great!
 
-    Singularity>
+   Singularity>
 
 You can verify the GPU is available within the container by using the
 tensorflow ``list_local_devices()`` function:
 
-.. code-block::
+.. code::
 
-    Singularity> python
-    Python 2.7.15+ (default, Jul  9 2019, 16:51:35)
-    [GCC 7.4.0] on linux2
-    Type "help", "copyright", "credits" or "license" for more information.
-    >>> from tensorflow.python.client import device_lib
-    >>> print(device_lib.list_local_devices())
-    2019-11-14 15:32:09.743600: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
-    2019-11-14 15:32:09.784482: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 3292620000 Hz
-    2019-11-14 15:32:09.787911: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x565246634360 executing computations on platform Host. Devices:
-    2019-11-14 15:32:09.787939: I tensorflow/compiler/xla/service/service.cc:175]   StreamExecutor device (0): Host, Default Version
-    2019-11-14 15:32:09.798428: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libcuda.so.1
-    2019-11-14 15:32:09.842683: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:1006] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
-    2019-11-14 15:32:09.843252: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x5652469263d0 executing computations on platform CUDA. Devices:
-    2019-11-14 15:32:09.843265: I tensorflow/compiler/xla/service/service.cc:175]   StreamExecutor device (0): GeForce GT 730, Compute Capability 3.5
-    2019-11-14 15:32:09.843380: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:1006] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
-    2019-11-14 15:32:09.843984: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1618] Found device 0 with properties:
-    name: GeForce GT 730 major: 3 minor: 5 memoryClockRate(GHz): 0.9015
-    ...
-
+   Singularity> python
+   Python 2.7.15+ (default, Jul  9 2019, 16:51:35)
+   [GCC 7.4.0] on linux2
+   Type "help", "copyright", "credits" or "license" for more information.
+   >>> from tensorflow.python.client import device_lib
+   >>> print(device_lib.list_local_devices())
+   2019-11-14 15:32:09.743600: I tensorflow/core/platform/cpu_feature_guard.cc:142] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
+   2019-11-14 15:32:09.784482: I tensorflow/core/platform/profile_utils/cpu_utils.cc:94] CPU Frequency: 3292620000 Hz
+   2019-11-14 15:32:09.787911: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x565246634360 executing computations on platform Host. Devices:
+   2019-11-14 15:32:09.787939: I tensorflow/compiler/xla/service/service.cc:175]   StreamExecutor device (0): Host, Default Version
+   2019-11-14 15:32:09.798428: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libcuda.so.1
+   2019-11-14 15:32:09.842683: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:1006] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
+   2019-11-14 15:32:09.843252: I tensorflow/compiler/xla/service/service.cc:168] XLA service 0x5652469263d0 executing computations on platform CUDA. Devices:
+   2019-11-14 15:32:09.843265: I tensorflow/compiler/xla/service/service.cc:175]   StreamExecutor device (0): GeForce GT 730, Compute Capability 3.5
+   2019-11-14 15:32:09.843380: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:1006] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
+   2019-11-14 15:32:09.843984: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1618] Found device 0 with properties:
+   name: GeForce GT 730 major: 3 minor: 5 memoryClockRate(GHz): 0.9015
+   ...
 
 Multiple GPUs
 =============
 
-By default, {Singularity} makes all host devices available in the container. When
-the ``--contain`` option is used a minimal ``/dev`` tree is created in the
-container, but the ``--nv`` option will ensure that all nvidia devices on the
-host are present in the container.
+By default, {Singularity} makes all host devices available in the
+container. When the ``--contain`` option is used a minimal ``/dev`` tree
+is created in the container, but the ``--nv`` option will ensure that
+all nvidia devices on the host are present in the container.
 
-This behaviour is different to ``nvidia-docker`` where an ``NVIDIA_VISIBLE_DEVICES``
-environment variable is used to control whether some or all host GPUs are visible
-inside a container. The ``nvidia-container-runtime`` explicitly binds the devices
-into the container dependent on the value of ``NVIDIA_VISIBLE_DEVICES``.
+This behaviour is different to ``nvidia-docker`` where an
+``NVIDIA_VISIBLE_DEVICES`` environment variable is used to control
+whether some or all host GPUs are visible inside a container. The
+``nvidia-container-runtime`` explicitly binds the devices into the
+container dependent on the value of ``NVIDIA_VISIBLE_DEVICES``.
 
-To control which GPUs are used in a {Singularity} container that is run with
-``--nv`` you can set ``SINGULARITYENV_CUDA_VISIBLE_DEVICES`` before running the
-container, or ``CUDA_VISIBLE_DEVICES`` inside the container.  This variable will
-limit the GPU devices that CUDA programs see.
+To control which GPUs are used in a {Singularity} container that is run
+with ``--nv`` you can set ``SINGULARITYENV_CUDA_VISIBLE_DEVICES`` before
+running the container, or ``CUDA_VISIBLE_DEVICES`` inside the container.
+This variable will limit the GPU devices that CUDA programs see.
 
-E.g. to run the tensorflow container, but using only the first GPU in the host,
-we could do:
+E.g. to run the tensorflow container, but using only the first GPU in
+the host, we could do:
 
-.. code-block::
+.. code::
 
-    $ SINGULARITYENV_CUDA_VISIBLE_DEVICES=0 singularity run --nv tensorflow_latest-gpu.sif
+   $ SINGULARITYENV_CUDA_VISIBLE_DEVICES=0 singularity run --nv tensorflow_latest-gpu.sif
 
-    # or
+   # or
 
-    $ export SINGULARITYENV_CUDA_VISIBLE_DEVICES=0
-    $ singularity run tensorflow_latest-gpu.sif
-
+   $ export SINGULARITYENV_CUDA_VISIBLE_DEVICES=0
+   $ singularity run tensorflow_latest-gpu.sif
 
 Troubleshooting
 ===============
 
-If the host installation of the NVIDIA / CUDA driver and libraries is working
-and up-to-date there are rarely issues running CUDA programs inside of
-{Singularity} containers. The most common issue seen is:
+If the host installation of the NVIDIA / CUDA driver and libraries is
+working and up-to-date there are rarely issues running CUDA programs
+inside of {Singularity} containers. The most common issue seen is:
 
 CUDA_ERROR_UNKNOWN when everything seems to be correctly configured
 -------------------------------------------------------------------
 
-CUDA depends on multiple kernel modules being loaded. Not all of the modules are
-loaded at system startup. Some portions of the NVIDA driver stack are initialized
-when first needed. This is done using a setuid root binary, so initializing can
-be triggered by any user on the host. In {Singularity} containers, privilege
-escalation is blocked, so the setuid root binary cannot initialize the driver
-stack fully.
+CUDA depends on multiple kernel modules being loaded. Not all of the
+modules are loaded at system startup. Some portions of the NVIDA driver
+stack are initialized when first needed. This is done using a setuid
+root binary, so initializing can be triggered by any user on the host.
+In {Singularity} containers, privilege escalation is blocked, so the
+setuid root binary cannot initialize the driver stack fully.
 
-If you experience ``CUDA_ERROR_UNKNOWN`` in a container, initialize the driver
-stack on the host first, by running a CUDA program there or
-``modprobe nvidia_uvm`` as root, and using ``nvidia-persistenced`` to avoid
-driver unload.
+If you experience ``CUDA_ERROR_UNKNOWN`` in a container, initialize the
+driver stack on the host first, by running a CUDA program there or
+``modprobe nvidia_uvm`` as root, and using ``nvidia-persistenced`` to
+avoid driver unload.
 
-
------------------------------------------
-NVIDIA GPUs & CUDA (nvidia-container-cli)
------------------------------------------
+*******************************************
+ NVIDIA GPUs & CUDA (nvidia-container-cli)
+*******************************************
 
 {Singularity} 3.9 introduces the ``--nvccli`` option, which will
 instruct {Singularity} to perform GPU container setup using the
@@ -203,42 +210,35 @@ https://nvidia.github.io/libnvidia-container/
 Using ``nvidia-container-cli`` to configure a container for GPU
 operation has a number of advantages, including:
 
-* The tool is maintained by NVIDIA, and will track new features /
-  libraries in new CUDA releases closely.
-
-* Support for passing only specific GPUs / MIG devices into the
-  container.
-
-* Support for providing different classes of GPU cabability to the
-  container, e.g. compute, graphics, and display functionality.
-
-* Configuration via the same environment variables that are in use
-  with OCI containers.
-
+-  The tool is maintained by NVIDIA, and will track new features /
+   libraries in new CUDA releases closely.
+-  Support for passing only specific GPUs / MIG devices into the
+   container.
+-  Support for providing different classes of GPU cabability to the
+   container, e.g. compute, graphics, and display functionality.
+-  Configuration via the same environment variables that are in use with
+   OCI containers.
 
 Requirements & Limitations
 ==========================
 
-* ``nvidia-container-cli`` must be installed on your host.
-  Its path must be set in
-  ``singularity.conf``. This value will be set at build time if
-  ``nvidia-container-cli`` is found on the search ``$PATH``.
+-  ``nvidia-container-cli`` must be installed on your host. Its path must
+   be set in ``singularity.conf``. This value will be set at build time if
+   ``nvidia-container-cli`` is found on the search ``$PATH``.
 
-* For security reasons, ``--nvccli`` cannot be used with
-  privileged mode in a set-uid install of {Singularity}.
-  Use the traditional binding method with ``--nv`` only or use
-  ``--nvccli`` with the the ``--user`` (or ``-u``) option to run unprivileged.
-  The option also cannot be used with ``--fakeroot``.
-  Since unprivileged mode does not support SIF files, use sandbox mode.
-  ``nvidia-container-cli`` also requires writing to the image, and
-  since without set-uid there is no overlay available, the ``--writable``
-  (or ``-w``) option is also required.
+-  For security reasons, ``--nvccli`` cannot be used with
+   privileged mode in a set-uid install of {Singularity}.
+   Use the traditional binding method with ``--nv`` only or use
+   ``--nvccli`` with the the ``--user`` (or ``-u``) option to run unprivileged.
+   The option also cannot be used with ``--fakeroot``.
+   Since unprivileged mode does not support SIF files, use sandbox mode.
+   ``nvidia-container-cli`` also requires writing to the image, and
+   since without set-uid there is no overlay available, the ``--writable``
+   (or ``-w``) option is also required.
 
-* There are known problems with library discovery for the current
-  ``nvidia-container-cli`` in recent Debian distributions. See `this
-  GitHub issue
-  <https://github.com/NVIDIA/nvidia-docker/issues/1399>`__
-
+-  There are known problems with library discovery for the current
+   ``nvidia-container-cli`` in recent Debian distributions. See `this
+   GitHub issue <https://github.com/NVIDIA/nvidia-docker/issues/1399>`__
 
 Example - tensorflow-gpu
 ========================
@@ -247,103 +247,100 @@ Tensorflow can be run using ``--nvccli`` in a similar manner as the
 standard ``--nv`` binding approach when run unprivleged. Build the
 large container into a sandbox:
 
-.. code-block::
+.. code::
 
-    $ singularity build --sandbox tensorflow_latest-gpu docker://tensorflow/tensorflow:latest-gpu
-    INFO:    Starting build...
-    ...
-    INFO:    Creating sandbox directory...
-    INFO:    Build complete: tensorflow_latest-gpu
-
+   $ singularity build --sandbox tensorflow_latest-gpu docker://tensorflow/tensorflow:latest-gpu
+   INFO:    Starting build...
+   ...
+   INFO:    Creating sandbox directory...
+   INFO:    Build complete: tensorflow_latest-gpu
 
 Then run the container with ``nvidia-container-cli`` GPU support:
 
-.. code-block::
+.. code::
 
-    $ singularity run -uw --nv --nvccli tensorflow_latest-gpu
+   $ singularity run -uw --nv --nvccli tensorflow_latest-gpu
 
-    ________                               _______________
-    ___  __/__________________________________  ____/__  /________      __
-    __  /  _  _ \_  __ \_  ___/  __ \_  ___/_  /_   __  /_  __ \_ | /| / /
-    _  /   /  __/  / / /(__  )/ /_/ /  /   _  __/   _  / / /_/ /_ |/ |/ /
-    /_/    \___//_/ /_//____/ \____//_/    /_/      /_/  \____/____/|__/
+   ________                               _______________
+   ___  __/__________________________________  ____/__  /________      __
+   __  /  _  _ \_  __ \_  ___/  __ \_  ___/_  /_   __  /_  __ \_ | /| / /
+   _  /   /  __/  / / /(__  )/ /_/ /  /   _  __/   _  / / /_/ /_ |/ |/ /
+   /_/    \___//_/ /_//____/ \____//_/    /_/      /_/  \____/____/|__/
 
 
-    You are running this container as user with ID 1000 and group 1000,
-    which should map to the ID and group for your user on the Docker host. Great!
+   You are running this container as user with ID 1000 and group 1000,
+   which should map to the ID and group for your user on the Docker host. Great!
 
-    Singularity>
+   Singularity>
 
 You can verify the GPU is available within the container by using the
 tensorflow ``list_local_devices()`` function:
 
-.. code-block::
+.. code::
 
-    Singularity> python
-    Python 2.7.15+ (default, Jul  9 2019, 16:51:35)
-    [GCC 7.4.0] on linux2
-    Type "help", "copyright", "credits" or "license" for more information.
-    >>> from tensorflow.python.client import device_lib
-    >>> print(device_lib.list_local_devices())
-    ...
-    device_type: "GPU"
-    memory_limit: 14474280960
-    locality {
-      bus_id: 1
-      links {
-      }
-    }
-    incarnation: 13349913758992036690
-    physical_device_desc: "device: 0, name: Tesla T4, pci bus id: 0000:00:1e.0, compute capability: 7.5"
-    ...
-
+   Singularity> python
+   Python 2.7.15+ (default, Jul  9 2019, 16:51:35)
+   [GCC 7.4.0] on linux2
+   Type "help", "copyright", "credits" or "license" for more information.
+   >>> from tensorflow.python.client import device_lib
+   >>> print(device_lib.list_local_devices())
+   ...
+   device_type: "GPU"
+   memory_limit: 14474280960
+   locality {
+     bus_id: 1
+     links {
+     }
+   }
+   incarnation: 13349913758992036690
+   physical_device_desc: "device: 0, name: Tesla T4, pci bus id: 0000:00:1e.0, compute capability: 7.5"
+   ...
 
 GPU Selection
 =============
 
-When running with ``--nvccli``, by default {Singularity} will expose
-all GPUs on the host inside the container. This mirrors the
-functionality of the standard GPU support for the most common use-case.
+When running with ``--nvccli``, by default {Singularity} will expose all
+GPUs on the host inside the container. This mirrors the functionality of
+the standard GPU support for the most common use-case.
 
 Setting the ``SINGULARITY_CUDA_VISIBLE_DEVICES`` environment variable
-before running a container is still supported, to control which GPUs
-are used by CUDA programs that honor
-``CUDA_VISIBLE_DEVICES``. However, more powerful GPU isolation is
-possible using the ``--contain`` (or ``-c``) flag and ``NVIDIA_VISIBLE_DEVICES``
-environment variable. This controls which GPU devices are bound into
-the ``/dev`` tree in the container.
+before running a container is still supported, to control which GPUs are
+used by CUDA programs that honor ``CUDA_VISIBLE_DEVICES``. However, more
+powerful GPU isolation is possible using the ``--contain`` (or ``-c``) flag and
+``NVIDIA_VISIBLE_DEVICES`` environment variable. This controls which GPU
+devices are bound into the ``/dev`` tree in the container.
 
 For example, to pass only the 2nd and 3rd GPU into a container running
 on a system with 4 GPUs, run the following:
 
-.. code-block::
+.. code::
 
-    $ export NVIDIA_VISIBLE_DEVICES=1,2
-    $ singularity run -uwc --nv --nvccli tensorflow_latest-gpu
+   $ export NVIDIA_VISIBLE_DEVICES=1,2
+   $ singularity run -uwc --nv --nvccli tensorflow_latest-gpu
 
 Note that:
 
-* ``NVIDIA_VISIBLE_DEVICES`` is not prepended with ``SINGULARITY_`` as
-  this variable controls container setup, and is not passed into the
-  container.
+-  ``NVIDIA_VISIBLE_DEVICES`` is not prepended with ``SINGULARITY_`` as
+   this variable controls container setup, and is not passed into the
+   container.
 
-* The GPU device identifiers start at 0, so 1,2 refers to the 2nd and
-  3rd GPU.
+-  The GPU device identifiers start at 0, so 1,2 refers to the 2nd and
+   3rd GPU.
 
-* You can use GPU UUIDs in place of numeric identifiers. Use
-  ``nvidia-smi -L`` to list both numeric IDs and UUIDs available on
-  the system.
+-  You can use GPU UUIDs in place of numeric identifiers. Use
+   ``nvidia-smi -L`` to list both numeric IDs and UUIDs available on the
+   system.
 
-* ``all`` can be used to pass all available GPUs into the container.
+-  ``all`` can be used to pass all available GPUs into the container.
 
-If you use ``--contain`` without setting ``NVIDIA_VISIBLE_DEVICES``,
-no GPUs will be available in the container, and a warning will be shown:
+If you use ``--contain`` without setting ``NVIDIA_VISIBLE_DEVICES``, no
+GPUs will be available in the container, and a warning will be shown:
 
-.. code-block::
+.. code::
 
-    $ singularity run -uwc --nv --nvccli tensorflow_latest-gpu
-    WARNING: When using nvidia-container-cli with --contain NVIDIA_VISIBLE_DEVICES
-    must be set or no GPUs will be available in container.
+   $ singularity run -uwc --nv --nvccli tensorflow_latest-gpu
+   WARNING: When using nvidia-container-cli with --contain NVIDIA_VISIBLE_DEVICES
+   must be set or no GPUs will be available in container.
 
 To restore the behaviour of the standard GPU handling, set
 ``NVIDIA_VISIBLE_DEVICES=0`` when running with ``--contain``.
@@ -351,164 +348,170 @@ To restore the behaviour of the standard GPU handling, set
 If your system contains Ampere or newer GPUs that support virtual MIG
 devices, you can specify MIG identifiers / UUIDs.
 
-.. code-block::
+.. code::
 
-    $ export NVIDIA_VISIBLE_DEVICES=MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/7/0
+   $ export NVIDIA_VISIBLE_DEVICES=MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/7/0
 
 {Singularity} does not configure MIG partitions. It is expected that
 these would be statically configured by the system administrator, or
-setup dynamically by a job scheduler / workflow system according to
-the requirements of the job.
+setup dynamically by a job scheduler / workflow system according to the
+requirements of the job.
 
 Other GPU Options
 =================
 
-In ``--nvccli`` mode, {Singularity} understands the following
-additional environment variables. Note that these environment
-variables are read from the environment where ``singularity`` is
-run. {Singularity} does not currently read these settings from the
-container environment.
+In ``--nvccli`` mode, {Singularity} understands the following additional
+environment variables. Note that these environment variables are read
+from the environment where ``singularity`` is run. {Singularity} does
+not currently read these settings from the container environment.
 
-* ``NVIDIA_DRIVER_CAPABILITIES`` controls which libraries and
-  utilities are mounted in the container, to support different
-  requirements. The default value under {Singularity} is
-  ``compute,utility``, which will provide CUDA functionality and basic
-  utilities such as ``nvidia-smi``. Other options include ``graphics``
-  for OpenGL/Vulkan support, ``video`` for the codecs SDK, and
-  ``display`` to use X11 from a container.
+-  ``NVIDIA_DRIVER_CAPABILITIES`` controls which libraries and utilities
+   are mounted in the container, to support different requirements. The
+   default value under {Singularity} is ``compute,utility``, which will
+   provide CUDA functionality and basic utilities such as
+   ``nvidia-smi``. Other options include ``graphics`` for OpenGL/Vulkan
+   support, ``video`` for the codecs SDK, and ``display`` to use X11
+   from a container.
 
-* ``NVIDIA_REQUIRE_*`` variables allow specifying requirements, which
-  will be checked by ``nvidia-container-cli`` prior to starting the
-  container. Constraints can be set on ``cuda``, ``driver``, ``arch``,
-  and ``brand`` values. Docker/OCI images may set these variables
-  inside the container, to indicate runtime requirements. However,
-  these container variables are not yet interpreted by {Singularity}.
+-  ``NVIDIA_REQUIRE_*`` variables allow specifying requirements, which
+   will be checked by ``nvidia-container-cli`` prior to starting the
+   container. Constraints can be set on ``cuda``, ``driver``, ``arch``,
+   and ``brand`` values. Docker/OCI images may set these variables
+   inside the container, to indicate runtime requirements. However,
+   these container variables are not yet interpreted by {Singularity}.
 
-* ``NVIDIA_DISABLE_REQUIRE`` will disable the enforcement of any
-  ``NVIDIA_REQUIRE_*`` requirements that are set.
+-  ``NVIDIA_DISABLE_REQUIRE`` will disable the enforcement of any
+   ``NVIDIA_REQUIRE_*`` requirements that are set.
 
-Full details of the supported values for these environment variables
-can be found in the container-toolkit guide:
+Full details of the supported values for these environment variables can
+be found in the container-toolkit guide:
 
 https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#environment-variables-oci-spec
 
+*****************
+ AMD GPUs & ROCm
+*****************
 
----------------
-AMD GPUs & ROCm
----------------
+{Singularity} 3.5 adds a ``--rocm`` flag to support GPU compute with the
+ROCm framework using AMD Radeon GPU cards.
 
-{Singularity} 3.5 adds a ``--rocm`` flag to support GPU compute with the ROCm
-framework using AMD Radeon GPU cards.
+Commands that ``run``, or otherwise execute containers (``shell``,
+``exec``) can take an ``--rocm`` option, which will setup the
+container's environment to use a Radeon GPU and the basic ROCm libraries
+to run a ROCm enabled application. The ``--rocm`` flag will:
 
-Commands that ``run``, or otherwise execute containers (``shell``, ``exec``) can
-take an ``--rocm`` option, which will setup the container's environment to use a
-Radeon GPU and the basic ROCm libraries to run a ROCm enabled application.
-The ``--rocm`` flag will:
+-  Ensure that the ``/dev/dri/`` device entries are available inside the
+   container, so that the GPU cards in the host are accessible.
 
-* Ensure that the ``/dev/dri/`` device entries are available inside the
-  container, so that the GPU cards in the host are accessible.
-* Locate and bind the basic ROCm libraries from the host into the container, so
-  that they are available to the container, and match the kernel GPU driver on
-  the host.
-* Set the ``LD_LIBRARY_PATH`` inside the container so that the bound-in version
-  of the ROCm libraries are used by application run inside the container.
+-  Locate and bind the basic ROCm libraries from the host into the
+   container, so that they are available to the container, and match the
+   kernel GPU driver on the host.
+
+-  Set the ``LD_LIBRARY_PATH`` inside the container so that the bound-in
+   version of the ROCm libraries are used by application run inside the
+   container.
 
 Requirements
 ============
 
-To use the ``--rocm`` flag to run a CUDA application inside a container you must
-ensure that:
+To use the ``--rocm`` flag to run a CUDA application inside a container
+you must ensure that:
 
-* The host has a working installation of the ``amdgpu`` driver, and a compatible
-  version of the basic ROCm libraries. The host *does not* need to have an X
-  server running, unless you want to run graphical apps from the container.
-* The ROCm libraries are in the system's library search path.
-* The application inside your container was compiled for a ROCm version that is
-  compatible with the ROCm version on your host.
+-  The host has a working installation of the ``amdgpu`` driver, and a
+   compatible version of the basic ROCm libraries. The host *does not*
+   need to have an X server running, unless you want to run graphical
+   apps from the container.
+
+-  The ROCm libraries are in the system's library search path.
+
+-  The application inside your container was compiled for a ROCm version
+   that is compatible with the ROCm version on your host.
 
 These requirements can be satisfied by following the requirements on the
 `ROCm web site <https://rocm.github.io/ROCmInstall.html>`__
 
-At time of release, {Singularity} was tested successfully on Debian 10 with ROCm
-2.8/2.9 and the upstream kernel driver, and Ubuntu 18.04 with ROCm 2.9 and the
-DKMS driver.
-
+At time of release, {Singularity} was tested successfully on Debian 10
+with ROCm 2.8/2.9 and the upstream kernel driver, and Ubuntu 18.04 with
+ROCm 2.9 and the DKMS driver.
 
 Example - tensorflow-rocm
 =========================
 
-Tensorflow is commonly used for machine learning projects, but can be difficult
-to install on older systems, and is updated frequently. Running tensorflow from
-a container removes installation problems and makes trying out new versions easy.
+Tensorflow is commonly used for machine learning projects, but can be
+difficult to install on older systems, and is updated frequently.
+Running tensorflow from a container removes installation problems and
+makes trying out new versions easy.
 
-The rocm tensorflow repository on Docker Hub contains Radeon GPU supporting
-containers, that will use ROCm for processing. You can view the available
-versions on the `tags page on Docker Hub <https://hub.docker.com/r/rocm/tensorflow/tags>`__
+The rocm tensorflow repository on Docker Hub contains Radeon GPU
+supporting containers, that will use ROCm for processing. You can view
+the available versions on the `tags page on Docker Hub
+<https://hub.docker.com/r/rocm/tensorflow/tags>`__
 
-The container is large, so it's best to build or pull the docker image to a SIF
-before you start working with it:
+The container is large, so it's best to build or pull the docker image
+to a SIF before you start working with it:
 
-.. code-block::
+.. code::
 
-    $ singularity pull docker://rocm/tensorflow:latest
-    ...
-    INFO:    Creating SIF file...
-    INFO:    Build complete: tensorflow_latest.sif
-
+   $ singularity pull docker://rocm/tensorflow:latest
+   ...
+   INFO:    Creating SIF file...
+   INFO:    Build complete: tensorflow_latest.sif
 
 Then run the container with GPU support:
 
-.. code-block::
+.. code::
 
-    $ singularity run --rocm tensorflow_latest.sif
-
+   $ singularity run --rocm tensorflow_latest.sif
 
 You can verify the GPU is available within the container by using the
 tensorflow ``list_local_devices()`` function:
 
-.. code-block::
+.. code::
 
-    Singularity> ipython
-    Python 3.5.2 (default, Jul 10 2019, 11:58:48)
-    Type 'copyright', 'credits' or 'license' for more information
-    IPython 7.8.0 -- An enhanced Interactive Python. Type '?' for help.
-    >>> from tensorflow.python.client import device_lib
-    ...
-    >>> print(device_lib.list_local_devices())
-    ...
-    2019-11-14 16:33:42.750509: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1651] Found device 0 with properties:
-    name: Lexa PRO [Radeon RX 550/550X]
-    AMDGPU ISA: gfx803
-    memoryClockRate (GHz) 1.183
-    pciBusID 0000:09:00.0
-    ...
+   Singularity> ipython
+   Python 3.5.2 (default, Jul 10 2019, 11:58:48)
+   Type 'copyright', 'credits' or 'license' for more information
+   IPython 7.8.0 -- An enhanced Interactive Python. Type '?' for help.
+   >>> from tensorflow.python.client import device_lib
+   ...
+   >>> print(device_lib.list_local_devices())
+   ...
+   2019-11-14 16:33:42.750509: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1651] Found device 0 with properties:
+   name: Lexa PRO [Radeon RX 550/550X]
+   AMDGPU ISA: gfx803
+   memoryClockRate (GHz) 1.183
+   pciBusID 0000:09:00.0
+   ...
 
--------------------
-OpenCL Applications
--------------------
+*********************
+ OpenCL Applications
+*********************
 
-Both the ``--rocm`` and ``--nv`` flags will bind the vendor OpenCL implementation
-libraries into a container that is being run. However, these libraries will not
-be used by OpenCL applications unless a vendor icd file is available under
-``/etc/OpenCL/vendors`` that directs OpenCL to use the vendor library.
+Both the ``--rocm`` and ``--nv`` flags will bind the vendor OpenCL
+implementation libraries into a container that is being run. However,
+these libraries will not be used by OpenCL applications unless a vendor
+icd file is available under ``/etc/OpenCL/vendors`` that directs OpenCL
+to use the vendor library.
 
-The simplest way to use OpenCL in a container is to ``--bind /etc/OpenCL`` so
-that the icd files from the host (which match the bound-in libraries) are
-present in the container.
+The simplest way to use OpenCL in a container is to ``--bind
+/etc/OpenCL`` so that the icd files from the host (which match the
+bound-in libraries) are present in the container.
 
 Example - Blender OpenCL
 ========================
 
-The `Sylabs examples repository <https://github.com/sylabs/examples>`__ contains
-an example container definition for the 3D modelling application 'Blender'.
+The `Sylabs examples repository <https://github.com/sylabs/examples>`__
+contains an example container definition for the 3D modelling
+application 'Blender'.
 
-The latest versions of Blender supports OpenCL rendering. You can run Blender
-as a graphical application that will make use of a local Radeon GPU for OpenCL
-compute using the container that has been published to the Sylabs library:
+The latest versions of Blender supports OpenCL rendering. You can run
+Blender as a graphical application that will make use of a local Radeon
+GPU for OpenCL compute using the container that has been published to
+the Sylabs library:
 
-.. code-block::
+.. code::
 
-    $ singularity exec --rocm --bind /etc/OpenCL library://sylabs/examples/blender blender
+   $ singularity exec --rocm --bind /etc/OpenCL library://sylabs/examples/blender blender
 
-Note the *exec* used as the *runscript* for this container is setup for batch
-rendering (which can also use OpenCL).
+Note the *exec* used as the *runscript* for this container is setup for
+batch rendering (which can also use OpenCL).

--- a/index.rst
+++ b/index.rst
@@ -1,7 +1,6 @@
-========================
-{Singularity} User Guide
-========================
-
+##########################
+ {Singularity} User Guide
+##########################
 
 Welcome to the {Singularity} User Guide!
 
@@ -11,11 +10,11 @@ and running containers.
 
 For a detailed guide to installation and configuration, please see the
 separate Admin Guide for this version of {Singularity} at
-`<\{admindocs\}/>`__.
+{admindocs}.
 
-
-Getting Started & Background Information
-========================================
+******************************************
+ Getting Started & Background Information
+******************************************
 
 .. toctree::
    :maxdepth: 2
@@ -24,8 +23,9 @@ Getting Started & Background Information
    Quick Start <quick_start>
    Security in {Singularity} <security>
 
-Building Containers
-===================
+*********************
+ Building Containers
+*********************
 
 Learn how to write a definition file that can be used to build a
 container. Understand the environment within a build, how to perform
@@ -40,13 +40,14 @@ non-root user.
    Build Environment <build_env>
    Fakeroot feature <fakeroot>
 
-Container Signing & Encryption
-==============================
+********************************
+ Container Signing & Encryption
+********************************
 
 {Singularity} allows containers to be signed using a PGP key. The
-signature travels with the container image, allowing you to verify
-that the image is unmodified at any time. Encryption of containers
-using LUKS2 is also supported. Encrypted containers can be run without
+signature travels with the container image, allowing you to verify that
+the image is unmodified at any time. Encryption of containers using
+LUKS2 is also supported. Encrypted containers can be run without
 decrypting them to disk first.
 
 .. toctree::
@@ -56,8 +57,9 @@ decrypting them to disk first.
    Key management commands <key_commands>
    Encrypted Containers <encryption>
 
-Sharing & Online Services
-=========================
+***************************
+ Sharing & Online Services
+***************************
 
 .. toctree::
    :maxdepth: 1
@@ -65,8 +67,9 @@ Sharing & Online Services
    Remote Endpoints <endpoint>
    Sylabs Cloud Library <cloud_library>
 
-Advanced Usage
-==============
+****************
+ Advanced Usage
+****************
 
 Once you've understood the basics, explore all the options which
 {Singularity} provides for accessing data, running persistent services
@@ -85,14 +88,14 @@ networking and security configuration.
    Network Options <networking>
    Cgroups Support <cgroups>
 
-Compatibility
-=============
+***************
+ Compatibility
+***************
 
 {Singularity} has unique benefits and supports easy access to GPUs and
 other hardware. It also strives for compatibility with Docker/OCI
-container formats. Understand the differences between {Singularity}
-and Docker, as well as how to use containerized MPI and GPU
-applications.
+container formats. Understand the differences between {Singularity} and
+Docker, as well as how to use containerized MPI and GPU applications.
 
 .. toctree::
    :maxdepth: 1
@@ -102,20 +105,22 @@ applications.
    Singularity and MPI applications <mpi>
    GPU Support <gpu>
 
-Get Involved
-============
+**************
+ Get Involved
+**************
 
 We'd love you to get involved in the {Singularity} community! Whether
-through contributing feature and fixes, helping to answer questions
-from other users, or simply testing new releases.
+through contributing feature and fixes, helping to answer questions from
+other users, or simply testing new releases.
 
 .. toctree::
    :maxdepth: 1
 
    Contributing <contributing>
 
-Reference
-=========
+***********
+ Reference
+***********
 
 .. toctree::
    :maxdepth: 2

--- a/introduction.rst
+++ b/introduction.rst
@@ -1,21 +1,21 @@
 .. _introduction:
 
-=============================
-Introduction to {Singularity}
-=============================
+###############################
+ Introduction to {Singularity}
+###############################
 
 {Singularity} is a *container* platform. It allows you to create and run
-containers that package up pieces of software in a way that is
-portable and reproducible. You can build a container using {Singularity}
-on your laptop, and then run it on many of the largest HPC clusters in
-the world, local university or company clusters, a single server, in
-the cloud, or on a workstation down the hall. Your container is a
-single file, and you don't have to worry about how to install all the
-software you need on each different operating system.
+containers that package up pieces of software in a way that is portable
+and reproducible. You can build a container using {Singularity} on your
+laptop, and then run it on many of the largest HPC clusters in the
+world, local university or company clusters, a single server, in the
+cloud, or on a workstation down the hall. Your container is a single
+file, and you don't have to worry about how to install all the software
+you need on each different operating system.
 
-
-Why use {Singularity}?
-======================
+************************
+ Why use {Singularity}?
+************************
 
 {Singularity} was created to run complex applications on HPC clusters in
 a simple, portable, and reproducible way. First developed at Lawrence
@@ -27,76 +27,78 @@ and academia in many areas of work.
 
 Many container platforms are available, but {Singularity} is focused on:
 
-  - Verifiable reproducibility and security, using cryptographic
-    signatures, an immutable container image format, and in-memory
-    decryption.
-  - Integration over isolation by default. Easily make use of GPUs, high speed
-    networks, parallel filesystems on a cluster or server by default.
-  - Mobility of compute. The single file SIF container format is easy
-    to transport and share.
-  - A simple, effective security model. You are the same user inside a
-    container as outside, and cannot gain additional privilege on the
-    host system by default. Read more about :ref:`security`.
+   -  Verifiable reproducibility and security, using cryptographic
+      signatures, an immutable container image format, and in-memory
+      decryption.
 
-Why use containers?
-===================
+   -  Integration over isolation by default. Easily make use of GPUs,
+      high speed networks, parallel filesystems on a cluster or server
+      by default.
+
+   -  Mobility of compute. The single file SIF container format is easy
+      to transport and share.
+
+   -  A simple, effective security model. You are the same user inside a
+      container as outside, and cannot gain additional privilege on the
+      host system by default. Read more about :ref:`security`.
+
+*********************
+ Why use containers?
+*********************
 
 A Unix operating system is broken into two primary components, the
-kernel space, and the user space. The Kernel talks to the hardware,
-and provides core system features. The user space is the environment
-that most people are most familiar with. It is where applications,
-libraries and system services run.
+kernel space, and the user space. The Kernel talks to the hardware, and
+provides core system features. The user space is the environment that
+most people are most familiar with. It is where applications, libraries
+and system services run.
 
 Traditionally you use an operating system that has a fixed combination
-of kernel and user space. If you have access to a machine running
-CentOS then you cannot install software that was packaged for Ubuntu
-on it, because the user space of these distributions is not
-compatible. It can also be very difficult to install multiple versions
-of the same software, which might be needed to support reproducibility
-in different workflows over time.
+of kernel and user space. If you have access to a machine running CentOS
+then you cannot install software that was packaged for Ubuntu on it,
+because the user space of these distributions is not compatible. It can
+also be very difficult to install multiple versions of the same
+software, which might be needed to support reproducibility in different
+workflows over time.
 
-Containers change the user space into a swappable component. This
-means that the entire user space portion of a Linux operating system,
+Containers change the user space into a swappable component. This means
+that the entire user space portion of a Linux operating system,
 including programs, custom configurations, and environment can be
-independent of whether your system is running CentOS, Fedora
-etc., underneath. A {Singularity} container packages up whatever you need
-into a single, verifiable file.
+independent of whether your system is running CentOS, Fedora etc.,
+underneath. A {Singularity} container packages up whatever you need into
+a single, verifiable file.
 
 Software developers can now build their stack onto whatever operating
 system base fits their needs best, and create distributable runtime
-environments so that users never have to worry about dependencies and 
-requirements, that they might not be able to satisfy on their
-systems.
+environments so that users never have to worry about dependencies and
+requirements, that they might not be able to satisfy on their systems.
 
-Use Cases
-=========
+***********
+ Use Cases
+***********
 
----------------------------------
 BYOE: Bring Your Own Environment!
----------------------------------
+=================================
 
 Engineering work-flows for research computing can be a complicated and
-iterative process, and even more so on a shared and somewhat
-inflexible production environment. {Singularity} solves this problem by
-making the environment flexible.
+iterative process, and even more so on a shared and somewhat inflexible
+production environment. {Singularity} solves this problem by making the
+environment flexible.
 
 Additionally, it is common (especially in education) for schools to
-provide a standardized pre-configured Linux distribution to the
-students which includes all of the necessary tools, programs, and
-configurations so they can immediately follow along.
+provide a standardized pre-configured Linux distribution to the students
+which includes all of the necessary tools, programs, and configurations
+so they can immediately follow along.
 
---------------------
 Reproducible science
---------------------
+====================
 
 {Singularity} containers can be built to include all of the programs,
 libraries, data and scripts such that an entire demonstration can be
-contained and either archived or distributed for others to replicate
-no matter what version of Linux they are presently running.
+contained and either archived or distributed for others to replicate no
+matter what version of Linux they are presently running.
 
---------------------------------------------------------------
 Commercially supported code requiring a particular environment
---------------------------------------------------------------
+==============================================================
 
 Some commercial applications are only certified to run on particular
 versions of Linux. If that application was installed into a
@@ -107,48 +109,42 @@ continue to run exactly as it is intended.
 
 Additionally, {Singularity} blurs the line between container and host
 such that your home directory (and other directories) exist within the
-container. Applications within the container have full and direct
-access to all files you own thus you can easily incorporate the
-contained commercial application into your work and process flow on
-the host.
+container. Applications within the container have full and direct access
+to all files you own thus you can easily incorporate the contained
+commercial application into your work and process flow on the host.
 
------------------------------------------
 Static environments (software appliances)
------------------------------------------
+=========================================
 
 Fund once, update never software development model. While this is not
-ideal, it is a common scenario for research funding. A certain amount
-of money is granted for initial development, and once that has been
-done the interns, grad students, post-docs, or developers are
-reassigned to other projects. This leaves the software stack
-un-maintained, and even rebuilds for updated compilers or Linux
-distributions can not be done without unfunded effort.
+ideal, it is a common scenario for research funding. A certain amount of
+money is granted for initial development, and once that has been done
+the interns, grad students, post-docs, or developers are reassigned to
+other projects. This leaves the software stack un-maintained, and even
+rebuilds for updated compilers or Linux distributions can not be done
+without unfunded effort.
 
-------------------------------------
 Legacy code on old operating systems
-------------------------------------
+====================================
 
-Similar to the above example, while this is less than ideal it is a
-fact of the research ecosystem. As an example, I know of one Linux
+Similar to the above example, while this is less than ideal it is a fact
+of the research ecosystem. As an example, I know of one Linux
 distribution which has been end of life for 15 years which is still in
 production due to the software stack which is custom built for this
 environment. {Singularity} has no problem running that operating system
 and application stack on a current operating system and hardware.
 
--------------------------------------------------------
 Complicated software stacks that are very host specific
--------------------------------------------------------
+=======================================================
 
 There are various software packages which are so complicated that it
-takes much effort in order to port, update and qualify to new
-operating systems or compilers. The atmospheric and weather
-applications are a good example of this. Porting them to a contained
-operating system will prolong the use-fullness of the development
-effort considerably.
+takes much effort in order to port, update and qualify to new operating
+systems or compilers. The atmospheric and weather applications are a
+good example of this. Porting them to a contained operating system will
+prolong the use-fullness of the development effort considerably.
 
--------------------------------------------------------------------
 Complicated work-flows that require custom installation and/or data
--------------------------------------------------------------------
+===================================================================
 
 Consolidating a work-flow into a {Singularity} container simplifies
 distribution and replication of scientific results. Making containers

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -39,7 +39,7 @@ keystore.
 First we will check what's the status of the local keystore (which keys
 are stored by the moment before importing a new key).
 
-.. code:: Singularity
+.. code:: singularity
 
    $ singularity key list --secret
 
@@ -50,7 +50,7 @@ are stored by the moment before importing a new key).
 
 The output will look as it follows:
 
-.. code:: Singularity
+.. code:: singularity
 
    Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
 
@@ -76,7 +76,7 @@ location to the file, let's say you own a gpg key file named
 ``pinkie-pie.asc`` which is a secret GPG key you want to import. Then
 you will just need to run the following command to import your key:
 
-.. code:: Singularity
+.. code:: singularity
 
    $ singularity key import $HOME/pinkie-pie.asc
 
@@ -89,7 +89,7 @@ Since you're importing a private (secret) key, you will need to specify
 the passphrase related to it and then a new passphrase to be added on
 your local keystore.
 
-.. code:: Singularity
+.. code:: singularity
 
    Enter your old password :
    Enter a new password for this key :
@@ -99,7 +99,7 @@ your local keystore.
 After this you can see if that key was correctly added to your local
 keystore by running ``singularity key list -s`` command:
 
-.. code:: Singularity
+.. code:: singularity
 
    Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
 
@@ -143,7 +143,7 @@ import`` command.
 
 For example to export a public key in binary format you can run:
 
-.. code:: Singularity
+.. code:: singularity
 
    $ singularity key export 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
@@ -152,7 +152,7 @@ it under the home folder. If you would like to export the same public
 key but in an ``ASCII`` armored format, you would need to run the
 following command:
 
-.. code:: Singularity
+.. code:: singularity
 
    $ singularity key export --armor 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
@@ -160,13 +160,13 @@ And in the case in which you may need to export a secret key on
 ``ASCII`` armored format, you would need to specify from where to find
 the key, since the fingerprint is the same.
 
-.. code:: Singularity
+.. code:: singularity
 
    $ singularity key export --armor --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 and on binary format instead:
 
-.. code:: Singularity
+.. code:: singularity
 
    $ singularity key export --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
@@ -185,7 +185,7 @@ and on binary format instead:
 In case you would want to remove a public key from your public local
 keystore, you can do so by running the following command:
 
-.. code:: Singularity
+.. code:: singularity
 
    $ singularity key remove 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
 

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -28,7 +28,7 @@ To give a quick view on how it works, we will first consider the case in which a
 
 First we will check what's the status of the local keystore (which keys are stored by the moment before importing a new key).
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
   $ singularity key list --secret
 
@@ -38,7 +38,7 @@ First we will check what's the status of the local keystore (which keys are stor
 
 The output will look as it follows:
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
     Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
 
@@ -60,7 +60,7 @@ The output will look as it follows:
 After this, you can simply import the key you need by adding the exact location to the file, let's say you own a gpg key file named ``pinkie-pie.asc`` which is a secret GPG key you want to import.
 Then you will just need to run the following command to import your key:
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
   $ singularity key import $HOME/pinkie-pie.asc
 
@@ -69,7 +69,7 @@ Then you will just need to run the following command to import your key:
 
 Since you're importing a private (secret) key, you will need to specify the passphrase related to it and then a new passphrase to be added on your local keystore.
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
     Enter your old password :
     Enter a new password for this key :
@@ -79,7 +79,7 @@ Since you're importing a private (secret) key, you will need to specify the pass
 After this you can see if that key was correctly added to your local keystore by running ``singularity key list -s`` command:
 
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
     Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
 
@@ -116,25 +116,25 @@ Of course to identify the keystore and the format the syntax varies from the ``k
 
 For example to export a public key in binary format you can run:
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
     $ singularity key export 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 This will export a public binary key named ``mykey.asc`` and will save it under the home folder. If you would like to export the same public key but in an ``ASCII`` armored format, you would need to run the following command:
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
     $ singularity key export --armor 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 And in the case in which you may need to export a secret key on ``ASCII`` armored format, you would need to specify from where to find the key, since the fingerprint is the same.
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
     $ singularity key export --armor --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 and on binary format instead:
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
     $ singularity key export --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
@@ -150,7 +150,7 @@ Key remove command
 
 In case you would want to remove a public key from your public local keystore, you can do so by running the following command:
 
-.. code-block:: {Singularity}
+.. code-block:: Singularity
 
     $ singularity key remove 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
 

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -20,7 +20,7 @@ the local keyring and are not related to the cloud keystore.
 {Singularity} 3.7 introduces a global keyring which can be managed by
 administrators with the new ``--global`` option. This global keyring is
 used by ECL
-(\{admindocs\}/configfiles.html#ecl-toml)
+({admindocs}/configfiles.html#ecl-toml)
 and allows administrators to manage public keys used during ECL image
 verification.
 

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -1,159 +1,195 @@
 .. _key_commands:
 
-Key commands
-============
+##############
+ Key commands
+##############
 
 .. _sec:key_commands:
 
-{Singularity} 3.2 introduces the abilities to import, export and remove PGP keys following the OpenPGP standard via `GnuPGP (GPG) <https://www.gnupg.org/gph/en/manual.html>`_.
-These commands only modify the local keyring and are not related to the cloud keystore.
+{Singularity} 3.2 introduces the abilities to import, export and remove
+PGP keys following the OpenPGP standard via `GnuPGP (GPG)
+<https://www.gnupg.org/gph/en/manual.html>`_. These commands only modify
+the local keyring and are not related to the cloud keystore.
 
 .. _key_import:
 
-----------------------------
-Changes in {Singularity} 3.7
-----------------------------
+******************************
+ Changes in {Singularity} 3.7
+******************************
 
-{Singularity} 3.7 introduces a global keyring which can be managed by administrators with the new ``--global`` option.
-This global keyring is used by ECL (\{admindocs\}/configfiles.html#ecl-toml)
-and allows administrators to manage public keys used during ECL image verification.
+{Singularity} 3.7 introduces a global keyring which can be managed by
+administrators with the new ``--global`` option. This global keyring is
+used by ECL
+(\{admindocs\}/configfiles.html#ecl-toml)
+and allows administrators to manage public keys used during ECL image
+verification.
 
-------------------
-Key import command
-------------------
+********************
+ Key import command
+********************
 
-{Singularity} 3.2 allows you import keys reading either from binary or armored key format and automatically detect if it is a private or public key and add it to the correspondent local keystore.
+{Singularity} 3.2 allows you import keys reading either from binary or
+armored key format and automatically detect if it is a private or public
+key and add it to the correspondent local keystore.
 
-To give a quick view on how it works, we will first consider the case in which a user wants to import a secret (private) key to the local keystore.
+To give a quick view on how it works, we will first consider the case in
+which a user wants to import a secret (private) key to the local
+keystore.
 
-First we will check what's the status of the local keystore (which keys are stored by the moment before importing a new key).
+First we will check what's the status of the local keystore (which keys
+are stored by the moment before importing a new key).
 
-.. code-block:: Singularity
+.. code:: Singularity
 
-  $ singularity key list --secret
+   $ singularity key list --secret
 
 .. note::
 
-  Remember that using ``--secret`` flag or ``-s`` flag will return the secret or private local keyring as output.
+   Remember that using ``--secret`` flag or ``-s`` flag will return the
+   secret or private local keyring as output.
 
 The output will look as it follows:
 
-.. code-block:: Singularity
+.. code:: Singularity
 
-    Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
+   Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
 
-    0) U: Johnny Cash (none) <cash@sylabs.io>
-    C: 2019-04-11 22:22:28 +0200 CEST
-    F: 47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
-    L: 3072
-    --------
-    1) U: John Green (none) <john@sylabs.io>
-    C: 2019-04-11 13:08:45 +0200 CEST
-    F: 5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
-    L: 1024
-    --------
-
-.. note::
-
-    Remember that running that same command but with sudo privilege, will give you a totally different list since it will be the correspondent keystore from user ``root``
-
-After this, you can simply import the key you need by adding the exact location to the file, let's say you own a gpg key file named ``pinkie-pie.asc`` which is a secret GPG key you want to import.
-Then you will just need to run the following command to import your key:
-
-.. code-block:: Singularity
-
-  $ singularity key import $HOME/pinkie-pie.asc
-
-.. note::
-  This location is considering your key was located on the ``$HOME`` directory. You can specify any location to the file.
-
-Since you're importing a private (secret) key, you will need to specify the passphrase related to it and then a new passphrase to be added on your local keystore.
-
-.. code-block:: Singularity
-
-    Enter your old password :
-    Enter a new password for this key :
-    Retype your passphrase :
-    Key with fingerprint 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 successfully added to the keyring
-
-After this you can see if that key was correctly added to your local keystore by running ``singularity key list -s`` command:
-
-
-.. code-block:: Singularity
-
-    Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
-
-      0) U: Johnny Cash (none) <cash@sylabs.io>
-      C: 2019-04-11 22:22:28 +0200 CEST
-      F: 47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
-      L: 3072
-      --------
-      1) U: John Green (none) <john@sylabs.io>
-      C: 2019-04-11 13:08:45 +0200 CEST
-      F: 5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
-      L: 1024
-      --------
-      3) U: Pinkie Pie (Eternal chaos comes with chocolate rain!) <balloons@sylabs.io>
-      C: 2019-04-26 12:07:07 +0200 CEST
-      F: 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
-      L: 1024
-      --------
-
-You will see the imported key at the bottom of the list. Remember you can also import an ``ascii`` armored key and this will be automatically detected by the ``key import`` command (no need to specify the format).
+   0) U: Johnny Cash (none) <cash@sylabs.io>
+   C: 2019-04-11 22:22:28 +0200 CEST
+   F: 47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
+   L: 3072
+   --------
+   1) U: John Green (none) <john@sylabs.io>
+   C: 2019-04-11 13:08:45 +0200 CEST
+   F: 5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
+   L: 1024
+   --------
 
 .. note::
 
-  In case you would like to import a public key the process remains the same, as the import command will automatically detect whether this key to be imported is either public or private.
+   Remember that running that same command but with sudo privilege, will
+   give you a totally different list since it will be the correspondent
+   keystore from user ``root``
+
+After this, you can simply import the key you need by adding the exact
+location to the file, let's say you own a gpg key file named
+``pinkie-pie.asc`` which is a secret GPG key you want to import. Then
+you will just need to run the following command to import your key:
+
+.. code:: Singularity
+
+   $ singularity key import $HOME/pinkie-pie.asc
+
+.. note::
+
+   This location is considering your key was located on the ``$HOME``
+   directory. You can specify any location to the file.
+
+Since you're importing a private (secret) key, you will need to specify
+the passphrase related to it and then a new passphrase to be added on
+your local keystore.
+
+.. code:: Singularity
+
+   Enter your old password :
+   Enter a new password for this key :
+   Retype your passphrase :
+   Key with fingerprint 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 successfully added to the keyring
+
+After this you can see if that key was correctly added to your local
+keystore by running ``singularity key list -s`` command:
+
+.. code:: Singularity
+
+   Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
+
+     0) U: Johnny Cash (none) <cash@sylabs.io>
+     C: 2019-04-11 22:22:28 +0200 CEST
+     F: 47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
+     L: 3072
+     --------
+     1) U: John Green (none) <john@sylabs.io>
+     C: 2019-04-11 13:08:45 +0200 CEST
+     F: 5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
+     L: 1024
+     --------
+     3) U: Pinkie Pie (Eternal chaos comes with chocolate rain!) <balloons@sylabs.io>
+     C: 2019-04-26 12:07:07 +0200 CEST
+     F: 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
+     L: 1024
+     --------
+
+You will see the imported key at the bottom of the list. Remember you
+can also import an ``ascii`` armored key and this will be automatically
+detected by the ``key import`` command (no need to specify the format).
+
+.. note::
+
+   In case you would like to import a public key the process remains the
+   same, as the import command will automatically detect whether this
+   key to be imported is either public or private.
 
 .. _key_export:
 
-------------------
-Key export command
-------------------
+********************
+ Key export command
+********************
 
-The key export command allows you to export a key that is on your local keystore. This key could be either private or public, and the key can be exported on ``ASCII`` armored format or on binary format.
-Of course to identify the keystore and the format the syntax varies from the ``key import`` command.
+The key export command allows you to export a key that is on your local
+keystore. This key could be either private or public, and the key can be
+exported on ``ASCII`` armored format or on binary format. Of course to
+identify the keystore and the format the syntax varies from the ``key
+import`` command.
 
 For example to export a public key in binary format you can run:
 
-.. code-block:: Singularity
+.. code:: Singularity
 
-    $ singularity key export 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+   $ singularity key export 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
-This will export a public binary key named ``mykey.asc`` and will save it under the home folder. If you would like to export the same public key but in an ``ASCII`` armored format, you would need to run the following command:
+This will export a public binary key named ``mykey.asc`` and will save
+it under the home folder. If you would like to export the same public
+key but in an ``ASCII`` armored format, you would need to run the
+following command:
 
-.. code-block:: Singularity
+.. code:: Singularity
 
-    $ singularity key export --armor 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+   $ singularity key export --armor 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
-And in the case in which you may need to export a secret key on ``ASCII`` armored format, you would need to specify from where to find the key, since the fingerprint is the same.
+And in the case in which you may need to export a secret key on
+``ASCII`` armored format, you would need to specify from where to find
+the key, since the fingerprint is the same.
 
-.. code-block:: Singularity
+.. code:: Singularity
 
-    $ singularity key export --armor --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+   $ singularity key export --armor --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 and on binary format instead:
 
-.. code-block:: Singularity
+.. code:: Singularity
 
-    $ singularity key export --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+   $ singularity key export --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
 
 .. note::
 
-    Exporting keys will not change the status of your local keystore or keyring. This will just obtain the content of the keys and save it on a local file on your host.
+   Exporting keys will not change the status of your local keystore or
+   keyring. This will just obtain the content of the keys and save it on
+   a local file on your host.
 
 .. _key_remove:
 
-------------------
-Key remove command
-------------------
+********************
+ Key remove command
+********************
 
-In case you would want to remove a public key from your public local keystore, you can do so by running the following command:
+In case you would want to remove a public key from your public local
+keystore, you can do so by running the following command:
 
-.. code-block:: Singularity
+.. code:: Singularity
 
-    $ singularity key remove 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
+   $ singularity key remove 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
 
 .. note::
 
-    Remember that this will only delete the public key and not the private one with the same matching fingerprint.
+   Remember that this will only delete the public key and not the
+   private one with the same matching fingerprint.

--- a/license.rst
+++ b/license.rst
@@ -1,6 +1,6 @@
-=======
-License
-=======
+#########
+ License
+#########
 
 This documentation is subject to the following 3-clause BSD license:
 

--- a/mpi.rst
+++ b/mpi.rst
@@ -1,315 +1,335 @@
 .. _mpi:
 
-==================================
-{Singularity} and MPI applications
-==================================
+####################################
+ {Singularity} and MPI applications
+####################################
 
 .. _sec-mpi:
 
-The `Message Passing Interface (MPI) <https://mpi-forum.org>`_
-is a standard extensively used by HPC applications to implement various communication
-across compute nodes of a single system or across compute platforms.
-There are two main open-source implementations of MPI at the
-moment - `OpenMPI <https://www.open-mpi.org/>`_ and `MPICH <https://www.mpich.org/>`_,
-both of which are supported by {Singularity}. The goal of this page is to
-demonstrate the development and running of MPI programs using {Singularity} containers.
+The `Message Passing Interface (MPI) <https://mpi-forum.org>`_ is a
+standard extensively used by HPC applications to implement various
+communication across compute nodes of a single system or across compute
+platforms. There are two main open-source implementations of MPI at the
+moment - `OpenMPI <https://www.open-mpi.org/>`_ and `MPICH
+<https://www.mpich.org/>`_, both of which are supported by
+{Singularity}. The goal of this page is to demonstrate the development
+and running of MPI programs using {Singularity} containers.
 
 There are several ways of carrying this out, the most popular way of
-executing MPI applications installed in a {Singularity} container is to rely on the
-MPI implementation available on the host. This is called the *Host MPI* or
-the *Hybrid* model since both the MPI implementations provided by system
-administrators (on the host) and in the containers will be used.
+executing MPI applications installed in a {Singularity} container is to
+rely on the MPI implementation available on the host. This is called the
+*Host MPI* or the *Hybrid* model since both the MPI implementations
+provided by system administrators (on the host) and in the containers
+will be used.
 
-Another approach is to only use the MPI implementation available on the host and
-not include any MPI in the container. This is called the *Bind* model since it
-requires to bind/mount the MPI version available on the host into the container.
+Another approach is to only use the MPI implementation available on the
+host and not include any MPI in the container. This is called the *Bind*
+model since it requires to bind/mount the MPI version available on the
+host into the container.
 
 .. note::
 
-    The *bind* model requires users to be able to mount user-specified
-    files from the host into the container. This ability is sometimes
-    disabled by system administrators for operational reasons. If this
-    is the case on your system please follow the *hybrid* approach.
+   The *bind* model requires users to be able to mount user-specified
+   files from the host into the container. This ability is sometimes
+   disabled by system administrators for operational reasons. If this is
+   the case on your system please follow the *hybrid* approach.
 
-------------
-Hybrid model
-------------
+**************
+ Hybrid model
+**************
 
-The basic idea behind the *Hybrid Approach* is when you execute a {Singularity}
-container with MPI code, you will call ``mpiexec`` or a similar launcher on the
-``singularity`` command itself. The MPI process outside of the container will
-then work in tandem with MPI inside the container and the containerized MPI code
-to instantiate the job.
+The basic idea behind the *Hybrid Approach* is when you execute a
+{Singularity} container with MPI code, you will call ``mpiexec`` or a
+similar launcher on the ``singularity`` command itself. The MPI process
+outside of the container will then work in tandem with MPI inside the
+container and the containerized MPI code to instantiate the job.
 
 The Open MPI/{Singularity} workflow in detail:
 
-1. The MPI launcher (e.g., ``mpirun``, ``mpiexec``) is called by the resource manager or the user directly from a shell.
-2. Open MPI then calls the process management daemon (ORTED).
-3. The ORTED process launches the {Singularity} container requested by the launcher command.
-4. {Singularity} instantiates the container and namespace environment.
-5. {Singularity} then launches the MPI application within the container.
-6. The MPI application launches and loads the Open MPI libraries.
-7. The Open MPI libraries connect back to the ORTED process via the Process Management Interface (PMI).
+#. The MPI launcher (e.g., ``mpirun``, ``mpiexec``) is called by the
+   resource manager or the user directly from a shell.
+#. Open MPI then calls the process management daemon (ORTED).
+#. The ORTED process launches the {Singularity} container requested by
+   the launcher command.
+#. {Singularity} instantiates the container and namespace environment.
+#. {Singularity} then launches the MPI application within the container.
+#. The MPI application launches and loads the Open MPI libraries.
+#. The Open MPI libraries connect back to the ORTED process via the
+   Process Management Interface (PMI).
 
-At this point the processes within the container run as they would normally directly on the host.
+At this point the processes within the container run as they would
+normally directly on the host.
 
 The advantages of this approach are:
-  - Integration with resource managers such as Slurm.
-  - Simplicity since similar to natively running MPI applications.
+   -  Integration with resource managers such as Slurm.
+   -  Simplicity since similar to natively running MPI applications.
 
 The drawbacks are:
-  - The MPI in the container must be compatible with the version of MPI
-    available on the host.
-  - The MPI implementation in the container must be carefully
-    configured for optimal use of the hardware if performance is
-    critical.
+   -  The MPI in the container must be compatible with the version of
+      MPI available on the host.
 
-Since the MPI implementation in the container must be compliant with
-the version available on the host system, a standard approach is to
-build your own MPI container, including building the same MPI
-framework installed on the host from source.
+   -  The MPI implementation in the container must be carefully
+      configured for optimal use of the hardware if performance is
+      critical.
 
+Since the MPI implementation in the container must be compliant with the
+version available on the host system, a standard approach is to build
+your own MPI container, including building the same MPI framework
+installed on the host from source.
 
 Test Application
 ================
 
-To illustrate how {Singularity} can be used to execute MPI applications, we will
-assume for a moment that the application is ``mpitest.c``, a simple Hello World:
+To illustrate how {Singularity} can be used to execute MPI applications,
+we will assume for a moment that the application is ``mpitest.c``, a
+simple Hello World:
 
-.. code-block:: c
+.. code:: c
 
-	#include <mpi.h>
-	#include <stdio.h>
-	#include <stdlib.h>
+   #include <mpi.h>
+   #include <stdio.h>
+   #include <stdlib.h>
 
-	int main (int argc, char **argv) {
-		int rc;
-		int size;
-		int myrank;
+   int main (int argc, char **argv) {
+           int rc;
+           int size;
+           int myrank;
 
-		rc = MPI_Init (&argc, &argv);
-		if (rc != MPI_SUCCESS) {
-			fprintf (stderr, "MPI_Init() failed");
-			return EXIT_FAILURE;
-		}
+           rc = MPI_Init (&argc, &argv);
+           if (rc != MPI_SUCCESS) {
+                   fprintf (stderr, "MPI_Init() failed");
+                   return EXIT_FAILURE;
+           }
 
-		rc = MPI_Comm_size (MPI_COMM_WORLD, &size);
-		if (rc != MPI_SUCCESS) {
-			fprintf (stderr, "MPI_Comm_size() failed");
-			goto exit_with_error;
-		}
+           rc = MPI_Comm_size (MPI_COMM_WORLD, &size);
+           if (rc != MPI_SUCCESS) {
+                   fprintf (stderr, "MPI_Comm_size() failed");
+                   goto exit_with_error;
+           }
 
-		rc = MPI_Comm_rank (MPI_COMM_WORLD, &myrank);
-		if (rc != MPI_SUCCESS) {
-			fprintf (stderr, "MPI_Comm_rank() failed");
-			goto exit_with_error;
-		}
+           rc = MPI_Comm_rank (MPI_COMM_WORLD, &myrank);
+           if (rc != MPI_SUCCESS) {
+                   fprintf (stderr, "MPI_Comm_rank() failed");
+                   goto exit_with_error;
+           }
 
-		fprintf (stdout, "Hello, I am rank %d/%d\n", myrank, size);
+           fprintf (stdout, "Hello, I am rank %d/%d\n", myrank, size);
 
-		MPI_Finalize();
+           MPI_Finalize();
 
-		return EXIT_SUCCESS;
+           return EXIT_SUCCESS;
 
-	 exit_with_error:
-		MPI_Finalize();
-		return EXIT_FAILURE;
-	}
+    exit_with_error:
+           MPI_Finalize();
+           return EXIT_FAILURE;
+   }
 
 .. note::
-    MPI is an interface to a library, so it consists of function calls and
-    libraries that can be used by many programming languages. It comes with
-    standardized bindings for Fortran and C. However, it can support
-    applications in many languages like Python, R, etc.
+
+   MPI is an interface to a library, so it consists of function calls
+   and libraries that can be used by many programming languages. It
+   comes with standardized bindings for Fortran and C. However, it can
+   support applications in many languages like Python, R, etc.
 
 The next step is to create the definition file used to build the
-container, which will depend on the MPI implementation available on
-the host.
+container, which will depend on the MPI implementation available on the
+host.
 
 MPICH Hybrid Container
 ======================
 
-If the host MPI is MPICH, a definition file such as the following example can be used:
+If the host MPI is MPICH, a definition file such as the following
+example can be used:
 
-.. code-block::
+.. code::
 
-    Bootstrap: docker
-    From: ubuntu:18.04
+   Bootstrap: docker
+   From: ubuntu:18.04
 
-    %files
-        mpitest.c /opt
+   %files
+       mpitest.c /opt
 
-    %environment
-        # Point to MPICH binaries, libraries man pages
-        export MPICH_DIR=/opt/mpich-3.3.2
-        export PATH="$MPICH_DIR/bin:$PATH"
-        export LD_LIBRARY_PATH="$MPICH_DIR/lib:$LD_LIBRARY_PATH"
-        export MANPATH=$MPICH_DIR/share/man:$MANPATH
+   %environment
+       # Point to MPICH binaries, libraries man pages
+       export MPICH_DIR=/opt/mpich-3.3.2
+       export PATH="$MPICH_DIR/bin:$PATH"
+       export LD_LIBRARY_PATH="$MPICH_DIR/lib:$LD_LIBRARY_PATH"
+       export MANPATH=$MPICH_DIR/share/man:$MANPATH
 
-    %post
-        echo "Installing required packages..."
-        export DEBIAN_FRONTEND=noninteractive
-        apt-get update && apt-get install -y wget git bash gcc gfortran g++ make
+   %post
+       echo "Installing required packages..."
+       export DEBIAN_FRONTEND=noninteractive
+       apt-get update && apt-get install -y wget git bash gcc gfortran g++ make
 
-        # Information about the version of MPICH to use
-        export MPICH_VERSION=3.3.2
-        export MPICH_URL="http://www.mpich.org/static/downloads/$MPICH_VERSION/mpich-$MPICH_VERSION.tar.gz"
-        export MPICH_DIR=/opt/mpich
+       # Information about the version of MPICH to use
+       export MPICH_VERSION=3.3.2
+       export MPICH_URL="http://www.mpich.org/static/downloads/$MPICH_VERSION/mpich-$MPICH_VERSION.tar.gz"
+       export MPICH_DIR=/opt/mpich
 
-        echo "Installing MPICH..."
-        mkdir -p /tmp/mpich
-        mkdir -p /opt
-        # Download
-        cd /tmp/mpich && wget -O mpich-$MPICH_VERSION.tar.gz $MPICH_URL && tar xzf mpich-$MPICH_VERSION.tar.gz
-        # Compile and install
-        cd /tmp/mpich/mpich-$MPICH_VERSION && ./configure --prefix=$MPICH_DIR && make install
+       echo "Installing MPICH..."
+       mkdir -p /tmp/mpich
+       mkdir -p /opt
+       # Download
+       cd /tmp/mpich && wget -O mpich-$MPICH_VERSION.tar.gz $MPICH_URL && tar xzf mpich-$MPICH_VERSION.tar.gz
+       # Compile and install
+       cd /tmp/mpich/mpich-$MPICH_VERSION && ./configure --prefix=$MPICH_DIR && make install
 
-        # Set env variables so we can compile our application
-        export PATH=$MPICH_DIR/bin:$PATH
-        export LD_LIBRARY_PATH=$MPICH_DIR/lib:$LD_LIBRARY_PATH
+       # Set env variables so we can compile our application
+       export PATH=$MPICH_DIR/bin:$PATH
+       export LD_LIBRARY_PATH=$MPICH_DIR/lib:$LD_LIBRARY_PATH
 
-        echo "Compiling the MPI application..."
-        cd /opt && mpicc -o mpitest mpitest.c
+       echo "Compiling the MPI application..."
+       cd /opt && mpicc -o mpitest mpitest.c
 
 .. note::
 
-   The version of MPICH you install in the container must be
-   compatible with the version on the host. It should also be
-   configured to support the same process management mechanism and
-   version, e.g. PMI2 / PMIx, as used on the host.
+   The version of MPICH you install in the container must be compatible
+   with the version on the host. It should also be configured to support
+   the same process management mechanism and version, e.g. PMI2 / PMIx,
+   as used on the host.
 
-   There are wide variations in MPI configuration across HPC
-   systems. Consult your system documentation, or ask your support
-   staff for details.
-        
+   There are wide variations in MPI configuration across HPC systems.
+   Consult your system documentation, or ask your support staff for
+   details.
 
 Open MPI Hybrid Container
 =========================
 
 If the host MPI is Open MPI, the definition file looks like:
 
-.. code-block::
+.. code::
 
-    Bootstrap: docker
-    From: ubuntu:18.04
+   Bootstrap: docker
+   From: ubuntu:18.04
 
-    %files
-        mpitest.c /opt
+   %files
+       mpitest.c /opt
 
-    %environment
-        # Point to OMPI binaries, libraries, man pages
-        export OMPI_DIR=/opt/ompi
-        export PATH="$OMPI_DIR/bin:$PATH"
-        export LD_LIBRARY_PATH="$OMPI_DIR/lib:$LD_LIBRARY_PATH"
-        export MANPATH="$OMPI_DIR/share/man:$MANPATH"
+   %environment
+       # Point to OMPI binaries, libraries, man pages
+       export OMPI_DIR=/opt/ompi
+       export PATH="$OMPI_DIR/bin:$PATH"
+       export LD_LIBRARY_PATH="$OMPI_DIR/lib:$LD_LIBRARY_PATH"
+       export MANPATH="$OMPI_DIR/share/man:$MANPATH"
 
-    %post
-        echo "Installing required packages..."
-        apt-get update && apt-get install -y wget git bash gcc gfortran g++ make file
+   %post
+       echo "Installing required packages..."
+       apt-get update && apt-get install -y wget git bash gcc gfortran g++ make file
 
-        echo "Installing Open MPI"
-        export OMPI_DIR=/opt/ompi
-        export OMPI_VERSION=4.0.5
-        export OMPI_URL="https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-$OMPI_VERSION.tar.bz2"
-        mkdir -p /tmp/ompi
-        mkdir -p /opt
-        # Download
-        cd /tmp/ompi && wget -O openmpi-$OMPI_VERSION.tar.bz2 $OMPI_URL && tar -xjf openmpi-$OMPI_VERSION.tar.bz2
-        # Compile and install
-        cd /tmp/ompi/openmpi-$OMPI_VERSION && ./configure --prefix=$OMPI_DIR && make -j8 install
+       echo "Installing Open MPI"
+       export OMPI_DIR=/opt/ompi
+       export OMPI_VERSION=4.0.5
+       export OMPI_URL="https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-$OMPI_VERSION.tar.bz2"
+       mkdir -p /tmp/ompi
+       mkdir -p /opt
+       # Download
+       cd /tmp/ompi && wget -O openmpi-$OMPI_VERSION.tar.bz2 $OMPI_URL && tar -xjf openmpi-$OMPI_VERSION.tar.bz2
+       # Compile and install
+       cd /tmp/ompi/openmpi-$OMPI_VERSION && ./configure --prefix=$OMPI_DIR && make -j8 install
 
-        # Set env variables so we can compile our application
-        export PATH=$OMPI_DIR/bin:$PATH
-        export LD_LIBRARY_PATH=$OMPI_DIR/lib:$LD_LIBRARY_PATH
+       # Set env variables so we can compile our application
+       export PATH=$OMPI_DIR/bin:$PATH
+       export LD_LIBRARY_PATH=$OMPI_DIR/lib:$LD_LIBRARY_PATH
 
-        echo "Compiling the MPI application..."
-        cd /opt && mpicc -o mpitest mpitest.c
-                
+       echo "Compiling the MPI application..."
+       cd /opt && mpicc -o mpitest mpitest.c
+
 .. note::
-      
+
    The version of Open MPI you install in the container must be
-   compatible with the version on the host. It should also be
-   configured to support the same process management mechanism and
-   version, e.g. PMI2 / PMIx, as used on the host.
+   compatible with the version on the host. It should also be configured
+   to support the same process management mechanism and version, e.g.
+   PMI2 / PMIx, as used on the host.
 
-   There are wide variations in MPI configuration across HPC
-   systems. Consult your system documentation, or ask your support
-   staff for details.
+   There are wide variations in MPI configuration across HPC systems.
+   Consult your system documentation, or ask your support staff for
+   details.
 
-      
 Running an MPI Application
 ==========================
 
-The standard way to execute MPI applications with hybrid {Singularity} containers is to
-run the native ``mpirun`` command from the host, which will start {Singularity}
-containers and ultimately MPI ranks within the containers.
+The standard way to execute MPI applications with hybrid {Singularity}
+containers is to run the native ``mpirun`` command from the host, which
+will start {Singularity} containers and ultimately MPI ranks within the
+containers.
 
 Assuming your container with MPI and your application is already built,
-the ``mpirun`` command to start your application looks like when your container
-has been built based on the hybrid model:
+the ``mpirun`` command to start your application looks like when your
+container has been built based on the hybrid model:
 
-.. code-block::
+.. code::
 
-    $ mpirun -n <NUMBER_OF_RANKS> singularity exec <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
+   $ mpirun -n <NUMBER_OF_RANKS> singularity exec <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
 
-Practically, this command will first start a process instantiating ``mpirun``
-and then {Singularity} containers on compute nodes. Finally, when the containers
-start, the MPI binary is executed:
+Practically, this command will first start a process instantiating
+``mpirun`` and then {Singularity} containers on compute nodes. Finally,
+when the containers start, the MPI binary is executed:
 
-.. code-block::
+.. code::
 
-    $ mpirun -n 8 singularity run hybrid-mpich.sif /opt/mpitest
-    Hello, I am rank 3/8
-    Hello, I am rank 4/8
-    Hello, I am rank 6/8
-    Hello, I am rank 2/8
-    Hello, I am rank 0/8
-    Hello, I am rank 5/8
-    Hello, I am rank 1/8
-    Hello, I am rank 7/8
+   $ mpirun -n 8 singularity run hybrid-mpich.sif /opt/mpitest
+   Hello, I am rank 3/8
+   Hello, I am rank 4/8
+   Hello, I am rank 6/8
+   Hello, I am rank 2/8
+   Hello, I am rank 0/8
+   Hello, I am rank 5/8
+   Hello, I am rank 1/8
+   Hello, I am rank 7/8
 
-----------      
-Bind model
-----------
+************
+ Bind model
+************
 
-Similar to the *Hybrid Approach*, the basic idea behind the *Bind Approach* is to start the MPI
-application by calling the MPI launcher (e.g., `mpirun`) from the host. The main difference between
-the hybrid and bind approach is the fact that with the bind approach, the container usually does
-not include any MPI implementation. This means that {Singularity} needs to mount/bind the MPI
-available on the host into the container.
+Similar to the *Hybrid Approach*, the basic idea behind the *Bind
+Approach* is to start the MPI application by calling the MPI launcher
+(e.g., `mpirun`) from the host. The main difference between the hybrid
+and bind approach is the fact that with the bind approach, the container
+usually does not include any MPI implementation. This means that
+{Singularity} needs to mount/bind the MPI available on the host into the
+container.
 
 Technically this requires two steps:
 
-1. Know where the MPI implementation on the host is installed.
-2. Mount/bind it into the container in a location where the system will be able to find libraries and binaries.
+#. Know where the MPI implementation on the host is installed.
+#. Mount/bind it into the container in a location where the system will
+   be able to find libraries and binaries.
 
 The advantages of this approach are:
-  - Integration with resource managers such as Slurm.
-  - Container images are smaller since there is no need to add an MPI in the containers.
+   -  Integration with resource managers such as Slurm.
+   -  Container images are smaller since there is no need to add an MPI
+      in the containers.
 
 The drawbacks are:
-  - The MPI used to compile the application in the container must be compatible with
-    the version of MPI available on the host.
-  - The user must know where the host MPI is installed.
-  - The user must ensure that binding the directory where the host MPI is installed is
-    possible.
-  - The user must ensure that the host MPI is compatible with the MPI used to compile
-    and install the application in the container.
+   -  The MPI used to compile the application in the container must be
+      compatible with the version of MPI available on the host.
+   -  The user must know where the host MPI is installed.
+   -  The user must ensure that binding the directory where the host MPI
+      is installed is possible.
+   -  The user must ensure that the host MPI is compatible with the MPI
+      used to compile and install the application in the container.
 
-The creation of a {Singularity} container for the bind model is based on the following steps:
+The creation of a {Singularity} container for the bind model is based on
+the following steps:
 
-1. Compile your application on a system with the target MPI implementation, as you would do
-   to install your application on any system.
-2. Create a definition file that includes the copy of the application from the host to the container
-   image, as well as all required dependencies.
-3. Generate the container image.
+#. Compile your application on a system with the target MPI
+   implementation, as you would do to install your application on any
+   system.
 
-As already mentioned, the compilation of the application on the host is not different from
-the installation of your application on any system. Just make sure that the MPI on the system
-where you create your container is compatible with the MPI available on the platform(s) where
-you want to run your containers. For example, a container where the application has been compiled
-with MPICH will not be able to run on a system where only Open MPI is available, even if you mount
-the directory where Open MPI is installed.
+#. Create a definition file that includes the copy of the application
+   from the host to the container image, as well as all required
+   dependencies.
+
+#. Generate the container image.
+
+As already mentioned, the compilation of the application on the host is
+not different from the installation of your application on any system.
+Just make sure that the MPI on the system where you create your
+container is compatible with the MPI available on the platform(s) where
+you want to run your containers. For example, a container where the
+application has been compiled with MPICH will not be able to run on a
+system where only Open MPI is available, even if you mount the directory
+where Open MPI is installed.
 
 Bind Mode Definition File
 =========================
@@ -319,174 +339,170 @@ forward. The following example shows the definition file for the test
 program, which in this case has been compiled on the host to
 ``/tmp/mpitest``:
 
-.. code-block::
+.. code::
 
-  Bootstrap: docker
-  From: ubuntu:18.04
+   Bootstrap: docker
+   From: ubuntu:18.04
 
-  %files
-        /tmp/mpitest /opt/mpitest
+   %files
+         /tmp/mpitest /opt/mpitest
 
-  %environment
-        export PATH="$MPI_DIR/bin:$PATH"
-        export LD_LIBRARY_PATH="$MPI_DIR/lib:$LD_LIBRARY_PATH"
-
+   %environment
+         export PATH="$MPI_DIR/bin:$PATH"
+         export LD_LIBRARY_PATH="$MPI_DIR/lib:$LD_LIBRARY_PATH"
 
 In this example, the application ``mpitest`` is copied from the host
-into ``/opt``, so we will need to run it as ``/opt/mpitest`` inside
-our container.
+into ``/opt``, so we will need to run it as ``/opt/mpitest`` inside our
+container.
 
 The environment section adds paths for binaries and libraries under
 ``$MPI_DIR`` - which we will need to set when running the container.
-
 
 Running an MPI Application
 ==========================
 
 When running our bind mode container we need to ``--bind`` our host's
-MPI installation into the container. We also need to set the
-environment variable ``$MPI_DIR`` in the container to point to the
-location where the MPI installation is bound in.
+MPI installation into the container. We also need to set the environment
+variable ``$MPI_DIR`` in the container to point to the location where
+the MPI installation is bound in.
 
 Setting up the container in this way makes it semi-portable between
 systems that have a version-compatible MPI installation, but under
-different installation paths. You can also hard code the MPI path in
-the definition file if you wish.
+different installation paths. You can also hard code the MPI path in the
+definition file if you wish.
 
+.. code::
 
-.. code-block::
-
-    $ export MPI_DIR="<PATH/TO/HOST/MPI/DIRECTORY>"            
-    $ mpirun -n <NUMBER_OF_RANKS> singularity exec --bind "$MPI_DIR" <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
+   $ export MPI_DIR="<PATH/TO/HOST/MPI/DIRECTORY>"
+   $ mpirun -n <NUMBER_OF_RANKS> singularity exec --bind "$MPI_DIR" <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
 
 On an example system we may be using an Open MPI installation at
-``/cm/shared/apps/openmpi/gcc/64/4.0.5/``. This means that the
-commands to run the container in bind mode are:
+``/cm/shared/apps/openmpi/gcc/64/4.0.5/``. This means that the commands
+to run the container in bind mode are:
 
-    
-.. code-block::
+.. code::
 
-    $ export MPI_DIR="/cm/shared/apps/openmpi/gcc/64/4.0.5"
-    $ mpirun -n 8 singularity exec --bind "$MPI_DIR" bind.sif /opt/mpitest
-    Hello, I am rank 1/8
-    Hello, I am rank 2/8
-    Hello, I am rank 0/8
-    Hello, I am rank 7/8
-    Hello, I am rank 5/8
-    Hello, I am rank 3/8
-    Hello, I am rank 4/8
-    Hello, I am rank 6/8
+   $ export MPI_DIR="/cm/shared/apps/openmpi/gcc/64/4.0.5"
+   $ mpirun -n 8 singularity exec --bind "$MPI_DIR" bind.sif /opt/mpitest
+   Hello, I am rank 1/8
+   Hello, I am rank 2/8
+   Hello, I am rank 0/8
+   Hello, I am rank 7/8
+   Hello, I am rank 5/8
+   Hello, I am rank 3/8
+   Hello, I am rank 4/8
+   Hello, I am rank 6/8
 
+*************************
+ Batch Scheduler / Slurm
+*************************
 
------------------------
-Batch Scheduler / Slurm
------------------------
-    
-If your target system is setup with a batch system such as SLURM, a standard
-way to execute MPI applications is through a batch script. The following
-example illustrates the context of a batch script for Slurm that aims at
-starting a {Singularity} container on each node allocated to the execution of
-the job. It can easily be adapted for all major batch systems available.
+If your target system is setup with a batch system such as SLURM, a
+standard way to execute MPI applications is through a batch script. The
+following example illustrates the context of a batch script for Slurm
+that aims at starting a {Singularity} container on each node allocated
+to the execution of the job. It can easily be adapted for all major
+batch systems available.
 
-.. code-block::
+.. code::
 
-    $ cat my_job.sh
-    #!/bin/bash
-    #SBATCH --job-name singularity-mpi
-    #SBATCH -N $NNODES # total number of nodes
-    #SBATCH --time=00:05:00 # Max execution time
+   $ cat my_job.sh
+   #!/bin/bash
+   #SBATCH --job-name singularity-mpi
+   #SBATCH -N $NNODES # total number of nodes
+   #SBATCH --time=00:05:00 # Max execution time
 
-    mpirun -n $NP singularity exec /var/nfsshare/gvallee/mpich.sif /opt/mpitest
+   mpirun -n $NP singularity exec /var/nfsshare/gvallee/mpich.sif /opt/mpitest
 
-In fact, the example describes a job that requests the number of nodes specified
-by the ``NNODES`` environment variable and a total number of MPI processes specified
-by the ``NP`` environment variable. The example is also assuming that the container
-is based on the hybrid model; if it is based on the bind model, please add the
-appropriate bind options.
+In fact, the example describes a job that requests the number of nodes
+specified by the ``NNODES`` environment variable and a total number of
+MPI processes specified by the ``NP`` environment variable. The example
+is also assuming that the container is based on the hybrid model; if it
+is based on the bind model, please add the appropriate bind options.
 
 A user can then submit a job by executing the following SLURM command:
 
-.. code-block::
+.. code::
 
-    $ sbatch my_job.sh
+   $ sbatch my_job.sh
 
-    
----------------------
-Alternative Launchers
----------------------
+***********************
+ Alternative Launchers
+***********************
 
-On many systems it is common to use an alternative launcher to start
-MPI applications, e.g. Slurm's ``srun`` rather than the ``mpirun``
-provided by the MPI installation. This approach is supported with
-{Singularity} as long as the container MPI version supports the same
-process management interface (e.g. PMI2 / PMIx) and version as is used
-by the launcher.
+On many systems it is common to use an alternative launcher to start MPI
+applications, e.g. Slurm's ``srun`` rather than the ``mpirun`` provided
+by the MPI installation. This approach is supported with {Singularity}
+as long as the container MPI version supports the same process
+management interface (e.g. PMI2 / PMIx) and version as is used by the
+launcher.
 
 In the bind mode the host MPI is used in the container, and should
 interact correctly with the same launchers as it does on the host.
 
-
---------------------------
-Interconnects / Networking
---------------------------
+****************************
+ Interconnects / Networking
+****************************
 
 High performance interconnects such as Infiniband and Omnipath require
 that MPI implementations are built to support them. You may need to
-install or bind Infiniband/Omnipath libraries into your containers
-when using these interconnects.
+install or bind Infiniband/Omnipath libraries into your containers when
+using these interconnects.
 
 By default {Singularity} exposes every device in ``/dev`` to the
 container. If you run a container using the ``--contain`` or
-``--containall`` flags a minimal ``/dev`` is used instead. You may
-need to bind in additional ``/dev/`` entries manually to
-support the operation of your interconnect drivers in the container in
-this case.
+``--containall`` flags a minimal ``/dev`` is used instead. You may need
+to bind in additional ``/dev/`` entries manually to support the
+operation of your interconnect drivers in the container in this case.
 
---------------------
-Troubleshooting Tips
---------------------
+**********************
+ Troubleshooting Tips
+**********************
 
 If your containers run N rank 0 processes, instead of operating
-correctly as an MPI application, it is likely that the MPI stack used
-to launch the containerized application is not compatible with, or
-cannot communicate with, the MPI stack in the container.
+correctly as an MPI application, it is likely that the MPI stack used to
+launch the containerized application is not compatible with, or cannot
+communicate with, the MPI stack in the container.
 
 E.g. if we attempt to run the hybrid Open MPI container, but with
 ``mpirun`` from MPICH loaded on the host:
 
-.. code-block::
+.. code::
 
-    $ module add mpich
-    $ mpirun -n 8 singularity run hybrid-openmpi.sif /opt/mpitest
-    Hello, I am rank 0/1
-    Hello, I am rank 0/1
-    Hello, I am rank 0/1
-    Hello, I am rank 0/1
-    Hello, I am rank 0/1
-    Hello, I am rank 0/1
-    Hello, I am rank 0/1
-    Hello, I am rank 0/1
+   $ module add mpich
+   $ mpirun -n 8 singularity run hybrid-openmpi.sif /opt/mpitest
+   Hello, I am rank 0/1
+   Hello, I am rank 0/1
+   Hello, I am rank 0/1
+   Hello, I am rank 0/1
+   Hello, I am rank 0/1
+   Hello, I am rank 0/1
+   Hello, I am rank 0/1
+   Hello, I am rank 0/1
 
 If your container starts processes of different ranks, but fails with
 communications errors there may also be a version incompatibility, or
-interconnect libraries may not be available or configured properly
-with the MPI stack in the container.
+interconnect libraries may not be available or configured properly with
+the MPI stack in the container.
 
 Please check the following things carefully before asking questions in
 the {Singularity} community:
 
- - For the hybrid mode, is the MPI version on the host compatible with
-   the version in the container? Newer MPI versions can generally
-   tolerate some mismatch in the version number, but it is safest to
-   use identical versions.
- - Is the MPI stack in the container configured to support the process
-   management method used on the host? E.g. if you are launching tasks
-   with ``srun`` configured for PMIx only, then a containerized MPI
-   supporting PMI2 only will not operate as expected.
- - If you are using an interconnect other than standard Ethernet, are
-   any required libraries for it installed or bound into the
-   container? Is the MPI stack in the container configured correctly
-   to use them?
+   -  For the hybrid mode, is the MPI version on the host compatible
+      with the version in the container? Newer MPI versions can
+      generally tolerate some mismatch in the version number, but it is
+      safest to use identical versions.
+
+   -  Is the MPI stack in the container configured to support the
+      process management method used on the host? E.g. if you are
+      launching tasks with ``srun`` configured for PMIx only, then a
+      containerized MPI supporting PMI2 only will not operate as
+      expected.
+
+   -  If you are using an interconnect other than standard Ethernet, are
+      any required libraries for it installed or bound into the
+      container? Is the MPI stack in the container configured correctly
+      to use them?
 
 We recommend using the {Singularity} Google Group or Slack Channel to
 ask for MPI advice from the {Singularity} community. HPC cluster

--- a/mpi.rst
+++ b/mpi.rst
@@ -131,7 +131,7 @@ MPICH Hybrid Container
 
 If the host MPI is MPICH, a definition file such as the following example can be used:
 
-.. code-block:: none
+.. code-block::
 
     Bootstrap: docker
     From: ubuntu:18.04
@@ -188,7 +188,7 @@ Open MPI Hybrid Container
 
 If the host MPI is Open MPI, the definition file looks like:
 
-.. code-block:: none
+.. code-block::
 
     Bootstrap: docker
     From: ubuntu:18.04
@@ -248,7 +248,7 @@ Assuming your container with MPI and your application is already built,
 the ``mpirun`` command to start your application looks like when your container
 has been built based on the hybrid model:
 
-.. code-block:: none
+.. code-block::
 
     $ mpirun -n <NUMBER_OF_RANKS> singularity exec <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
 
@@ -256,7 +256,7 @@ Practically, this command will first start a process instantiating ``mpirun``
 and then {Singularity} containers on compute nodes. Finally, when the containers
 start, the MPI binary is executed:
 
-.. code-block:: none
+.. code-block::
 
     $ mpirun -n 8 singularity run hybrid-mpich.sif /opt/mpitest
     Hello, I am rank 3/8
@@ -319,7 +319,7 @@ forward. The following example shows the definition file for the test
 program, which in this case has been compiled on the host to
 ``/tmp/mpitest``:
 
-.. code-block:: none
+.. code-block::
 
   Bootstrap: docker
   From: ubuntu:18.04
@@ -354,7 +354,7 @@ different installation paths. You can also hard code the MPI path in
 the definition file if you wish.
 
 
-.. code-block:: none
+.. code-block::
 
     $ export MPI_DIR="<PATH/TO/HOST/MPI/DIRECTORY>"            
     $ mpirun -n <NUMBER_OF_RANKS> singularity exec --bind "$MPI_DIR" <PATH/TO/MY/IMAGE> </PATH/TO/BINARY/WITHIN/CONTAINER>
@@ -364,7 +364,7 @@ On an example system we may be using an Open MPI installation at
 commands to run the container in bind mode are:
 
     
-.. code-block:: none
+.. code-block::
 
     $ export MPI_DIR="/cm/shared/apps/openmpi/gcc/64/4.0.5"
     $ mpirun -n 8 singularity exec --bind "$MPI_DIR" bind.sif /opt/mpitest
@@ -388,7 +388,7 @@ example illustrates the context of a batch script for Slurm that aims at
 starting a {Singularity} container on each node allocated to the execution of
 the job. It can easily be adapted for all major batch systems available.
 
-.. code-block:: none
+.. code-block::
 
     $ cat my_job.sh
     #!/bin/bash
@@ -406,7 +406,7 @@ appropriate bind options.
 
 A user can then submit a job by executing the following SLURM command:
 
-.. code-block:: none
+.. code-block::
 
     $ sbatch my_job.sh
 

--- a/networking.rst
+++ b/networking.rst
@@ -32,7 +32,7 @@ configure a virtualized network for a container.
 The ``--dns`` option allows you to specify a comma separated list of DNS servers
 to add to the ``/etc/resolv.conf`` file.
 
-.. code-block:: none
+.. code-block::
 
     $ nslookup sylabs.io | grep Server
     Server:		127.0.0.53
@@ -50,7 +50,7 @@ to add to the ``/etc/resolv.conf`` file.
 The ``--hostname`` option accepts a string argument to change the hostname
 within the container.
 
-.. code-block:: none
+.. code-block::
 
     $ hostname
     ubuntu-bionic
@@ -65,7 +65,7 @@ Passing the ``--net`` flag will cause the container to join a new network
 namespace when it initiates.  New in {Singularity} 3.0, a bridge interface will
 also be set up by default.
 
-.. code-block:: none
+.. code-block::
 
     $ hostname -I
     10.0.2.15
@@ -81,7 +81,7 @@ The ``--network`` option can only be invoked in combination with the ``--net``
 flag.  It accepts a comma delimited string of network types. Each entry will
 bring up a dedicated interface inside container.
 
-.. code-block:: none
+.. code-block::
 
     $ hostname -I
     172.16.107.251 10.22.0.1
@@ -125,7 +125,7 @@ For instance, let's say you want to start an `NGINX <https://www.nginx.com/>`_
 server on port 80 inside of the container, but you want to map it to port 8080
 outside of the container:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity instance start --writable-tmpfs \
         --net --network-args "portmap=8080:80/tcp" docker://nginx web2
@@ -139,14 +139,14 @@ which will map port 80 inside of the container to 8080 on the host.
 
 Now we can start NGINX inside of the container:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity exec instance://web2 nginx
 
 And the ``curl`` command can be used to verify that NGINX is running on the host
 port 8080 as expected.
 
-.. code-block:: none
+.. code-block::
 
     $ curl localhost:8080
     10.22.0.1 - - [16/Oct/2018:09:34:25 -0400] "GET / HTTP/1.1" 200 612 "-" "curl/7.58.0" "-"

--- a/networking.rst
+++ b/networking.rst
@@ -1,9 +1,8 @@
 .. _networking:
 
-======================
-Network virtualization
-======================
-
+########################
+ Network virtualization
+########################
 
 .. _sec:networking:
 
@@ -16,165 +15,168 @@ configure a virtualized network for a container.
 .. note::
 
    Many of these options are available only to the ``root`` user by
-   default. Unrestricted ability to configure networking for
-   containers would allow users to affect networking on the host, or
-   in a cluster.
+   default. Unrestricted ability to configure networking for containers
+   would allow users to affect networking on the host, or in a cluster.
 
    {Singularity} 3.8 allows the administrator to permit a list of
    unprivileged users and/or groups to use specified network
    configurations. This is accomplished through settings in
    ``singularity.conf``. See the administrator guide for details.
 
+***********
+ ``--dns``
+***********
 
-``--dns``
-=========
+The ``--dns`` option allows you to specify a comma separated list of DNS
+servers to add to the ``/etc/resolv.conf`` file.
 
-The ``--dns`` option allows you to specify a comma separated list of DNS servers
-to add to the ``/etc/resolv.conf`` file.
+.. code::
 
-.. code-block::
+   $ nslookup sylabs.io | grep Server
+   Server:             127.0.0.53
 
-    $ nslookup sylabs.io | grep Server
-    Server:		127.0.0.53
+   $ sudo singularity exec --dns 8.8.8.8 ubuntu.sif nslookup sylabs.io | grep Server
+   Server:             8.8.8.8
 
-    $ sudo singularity exec --dns 8.8.8.8 ubuntu.sif nslookup sylabs.io | grep Server
-    Server:		8.8.8.8
+   $ sudo singularity exec --dns 8.8.8.8 ubuntu.sif cat /etc/resolv.conf
+   nameserver 8.8.8.8
 
-    $ sudo singularity exec --dns 8.8.8.8 ubuntu.sif cat /etc/resolv.conf
-    nameserver 8.8.8.8
+****************
+ ``--hostname``
+****************
 
+The ``--hostname`` option accepts a string argument to change the
+hostname within the container.
 
-``--hostname``
-==============
+.. code::
 
-The ``--hostname`` option accepts a string argument to change the hostname
-within the container.
+   $ hostname
+   ubuntu-bionic
 
-.. code-block::
+   $ sudo singularity exec --hostname hal-9000 my_container.sif hostname
+   hal-9000
 
-    $ hostname
-    ubuntu-bionic
+***********
+ ``--net``
+***********
 
-    $ sudo singularity exec --hostname hal-9000 my_container.sif hostname
-    hal-9000
+Passing the ``--net`` flag will cause the container to join a new
+network namespace when it initiates. New in {Singularity} 3.0, a bridge
+interface will also be set up by default.
 
-``--net``
-=========
+.. code::
 
-Passing the ``--net`` flag will cause the container to join a new network
-namespace when it initiates.  New in {Singularity} 3.0, a bridge interface will
-also be set up by default.
+   $ hostname -I
+   10.0.2.15
 
-.. code-block::
+   $ sudo singularity exec --net my_container.sif hostname -I
+   10.22.0.4
 
-    $ hostname -I
-    10.0.2.15
+***************
+ ``--network``
+***************
 
-    $ sudo singularity exec --net my_container.sif hostname -I
-    10.22.0.4
+The ``--network`` option can only be invoked in combination with the
+``--net`` flag. It accepts a comma delimited string of network types.
+Each entry will bring up a dedicated interface inside container.
 
+.. code::
 
-``--network``
-=============
+   $ hostname -I
+   172.16.107.251 10.22.0.1
 
-The ``--network`` option can only be invoked in combination with the ``--net``
-flag.  It accepts a comma delimited string of network types. Each entry will
-bring up a dedicated interface inside container.
+   $ sudo singularity exec --net --network ptp ubuntu.sif hostname -I
+   10.23.0.6
 
-.. code-block::
+   $ sudo singularity exec --net --network bridge,ptp ubuntu.sif hostname -I
+   10.22.0.14 10.23.0.7
 
-    $ hostname -I
-    172.16.107.251 10.22.0.1
+When invoked, the ``--network`` option searches the singularity
+configuration directory (commonly
+``/usr/local/etc/singularity/network/``) for the cni configuration file
+corresponding to the requested network type(s). Several configuration
+files are installed with {Singularity} by default corresponding to the
+following network types:
 
-    $ sudo singularity exec --net --network ptp ubuntu.sif hostname -I
-    10.23.0.6
+   -  bridge
+   -  ptp
+   -  ipvlan
+   -  macvlan
+   -  none (must be used alone)
 
-    $ sudo singularity exec --net --network bridge,ptp ubuntu.sif hostname -I
-    10.22.0.14 10.23.0.7
-
-When invoked, the ``--network`` option searches the singularity configuration
-directory (commonly ``/usr/local/etc/singularity/network/``) for the cni
-configuration file corresponding to the requested network type(s). Several
-configuration files are installed with {Singularity} by default corresponding to
-the following network types:
-
-    - bridge
-    - ptp
-    - ipvlan
-    - macvlan
-    - none (must be used alone)
-
-By default, ``none`` is the only network configuration that can be
-used by non-privileged users.  It isolates the container network from
-the host network with a loopback interface.
+By default, ``none`` is the only network configuration that can be used
+by non-privileged users. It isolates the container network from the host
+network with a loopback interface.
 
 Administrators can permit certain users or groups to request other
-network configurations through options in
-``singularity.conf``. Additional cni configuration files can be added
-to the ``network`` configuration directory as required, and
-{Singularity}'s provided configurations may also be modified.
+network configurations through options in ``singularity.conf``.
+Additional cni configuration files can be added to the ``network``
+configuration directory as required, and {Singularity}'s provided
+configurations may also be modified.
 
-``--network-args``
-==================
+********************
+ ``--network-args``
+********************
 
-The ``--network-args`` option provides a convenient way to specify arguments to
-pass directly to the cni plugins.  It must be used in conjunction with the
-``--net`` flag.
+The ``--network-args`` option provides a convenient way to specify
+arguments to pass directly to the cni plugins. It must be used in
+conjunction with the ``--net`` flag.
 
-For instance, let's say you want to start an `NGINX <https://www.nginx.com/>`_
-server on port 80 inside of the container, but you want to map it to port 8080
-outside of the container:
+For instance, let's say you want to start an `NGINX
+<https://www.nginx.com/>`_ server on port 80 inside of the container,
+but you want to map it to port 8080 outside of the container:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity instance start --writable-tmpfs \
-        --net --network-args "portmap=8080:80/tcp" docker://nginx web2
+   $ sudo singularity instance start --writable-tmpfs \
+       --net --network-args "portmap=8080:80/tcp" docker://nginx web2
 
-The above command will start the Docker Hub official NGINX image running in a
-background instance called ``web2``.  The NGINX instance will need to be able to
-write to disk, so we've used the ``--writable-tmpfs`` argument to allocate some
-space in memory.  The ``--net`` flag is necessary when using the
-``--network-args`` option, and specifying the ``portmap=8080:80/tcp`` argument
-which will map port 80 inside of the container to 8080 on the host.
+The above command will start the Docker Hub official NGINX image running
+in a background instance called ``web2``. The NGINX instance will need
+to be able to write to disk, so we've used the ``--writable-tmpfs``
+argument to allocate some space in memory. The ``--net`` flag is
+necessary when using the ``--network-args`` option, and specifying the
+``portmap=8080:80/tcp`` argument which will map port 80 inside of the
+container to 8080 on the host.
 
 Now we can start NGINX inside of the container:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity exec instance://web2 nginx
+   $ sudo singularity exec instance://web2 nginx
 
-And the ``curl`` command can be used to verify that NGINX is running on the host
-port 8080 as expected.
+And the ``curl`` command can be used to verify that NGINX is running on
+the host port 8080 as expected.
 
-.. code-block::
+.. code::
 
-    $ curl localhost:8080
-    10.22.0.1 - - [16/Oct/2018:09:34:25 -0400] "GET / HTTP/1.1" 200 612 "-" "curl/7.58.0" "-"
-    <!DOCTYPE html>
-    <html>
-    <head>
-    <title>Welcome to nginx!</title>
-    <style>
-        body {
-            width: 35em;
-            margin: 0 auto;
-            font-family: Tahoma, Verdana, Arial, sans-serif;
-        }
-    </style>
-    </head>
-    <body>
-    <h1>Welcome to nginx!</h1>
-    <p>If you see this page, the nginx web server is successfully installed and
-    working. Further configuration is required.</p>
+   $ curl localhost:8080
+   10.22.0.1 - - [16/Oct/2018:09:34:25 -0400] "GET / HTTP/1.1" 200 612 "-" "curl/7.58.0" "-"
+   <!DOCTYPE html>
+   <html>
+   <head>
+   <title>Welcome to nginx!</title>
+   <style>
+       body {
+           width: 35em;
+           margin: 0 auto;
+           font-family: Tahoma, Verdana, Arial, sans-serif;
+       }
+   </style>
+   </head>
+   <body>
+   <h1>Welcome to nginx!</h1>
+   <p>If you see this page, the nginx web server is successfully installed and
+   working. Further configuration is required.</p>
 
-    <p>For online documentation and support please refer to
-    <a href="http://nginx.org/">nginx.org</a>.<br/>
-    Commercial support is available at
-    <a href="http://nginx.com/">nginx.com</a>.</p>
+   <p>For online documentation and support please refer to
+   <a href="http://nginx.org/">nginx.org</a>.<br/>
+   Commercial support is available at
+   <a href="http://nginx.com/">nginx.com</a>.</p>
 
-    <p><em>Thank you for using nginx.</em></p>
-    </body>
-    </html>
+   <p><em>Thank you for using nginx.</em></p>
+   </body>
+   </html>
 
-For more information about cni, check the
-`cni specification <https://github.com/containernetworking/cni/blob/master/SPEC.md>`_.
+For more information about cni, check the `cni specification
+<https://github.com/containernetworking/cni/blob/master/SPEC.md>`_.

--- a/oci_runtime.rst
+++ b/oci_runtime.rst
@@ -46,7 +46,7 @@ Mounting an OCI Filesystem Bundle
 
 Suppose the Singularity Image Format (SIF) file ``busybox_latest.sif`` exists locally. (Recall: 
 
-.. code-block:: none
+.. code-block::
 
 	$ singularity pull docker://busybox
 	INFO:    Starting build...
@@ -64,13 +64,13 @@ This is one way to bootstrap creation of this image in SIF that *retains* a loca
 
 For the purpose of bootstrapping the creation of an OCI compliant container, this SIF file can be mounted as follows: 
 
-.. code-block:: none 
+.. code-block:: 
 
 	$ sudo singularity oci mount ./busybox_latest.sif /var/tmp/busybox
 
 By issuing the ``mount`` command, the root filesystem encapsulated in the SIF file ``busybox_latest.sif`` is mounted on ``/var/tmp/busybox`` as an ``overlay`` file system, 
 
-.. code-block:: none
+.. code-block::
 
 	$ sudo df -k
 	Filesystem                   1K-blocks    Used Available Use% Mounted on
@@ -85,7 +85,7 @@ By issuing the ``mount`` command, the root filesystem encapsulated in the SIF fi
 
 with permissions as follows:
 
-.. code-block:: none
+.. code-block::
 
 	$ sudo ls -ld /var/tmp/busybox
 	drwx------ 4 root root 4096 Apr  4 14:30 /var/tmp/busybox
@@ -96,7 +96,7 @@ Content of an OCI Compliant Filesystem Bundle
 
 The *expected* contents of the mounted filesystem are as follows:
 
-.. code-block:: none 
+.. code-block:: 
 
 	$ sudo ls -la /var/tmp/busybox
 	total 28
@@ -709,7 +709,7 @@ Furthermore, and through use of ``$ sudo cat /var/tmp/busybox/config.json | jq [
 
 identifies ``/var/tmp/busybox/rootfs`` as the container's root filesystem, as required by the standard; this filesystem has contents:
 
-.. code-block:: none
+.. code-block::
 
 	$ sudo ls /var/tmp/busybox/rootfs
 	bin  dev  environment  etc  home  proc	root  singularity  sys	tmp  usr  var
@@ -756,7 +756,7 @@ Creating OCI Compliant Container Instances
 
 SIF files encapsulate the OCI runtime. By 'OCI mounting' a SIF file (see above), this encapsulated runtime is revealed; please refer to the note below for additional details. Once revealed, the filesystem bundle can be used to bootstrap the creation of an OCI compliant container instance as follows: 
 
-.. code-block:: none
+.. code-block::
 
 	$ sudo singularity oci create -b /var/tmp/busybox busybox1
 
@@ -820,7 +820,7 @@ Unmounting OCI Filesystem Bundles
 
 To unmount a mounted OCI filesystem bundle, the following command should be issued:
 
-.. code-block:: none
+.. code-block::
 
 	$ sudo singularity oci umount /var/tmp/busybox
 

--- a/oci_runtime.rst
+++ b/oci_runtime.rst
@@ -1,877 +1,1049 @@
 .. _oci_runtime:
 
+..
+   TODO-MUST something with the long json snippet ...
 
-.. TODO-MUST something with the long json snippet ... 
-
-
-===================
-OCI Runtime Support 
-===================
+#####################
+ OCI Runtime Support
+#####################
 
 .. _sec:oci_runtime_overview:
 
---------
-Overview
---------
+**********
+ Overview
+**********
 
-OCI is an acronym for the `Open Containers Initiative <https://www.opencontainers.org/>`_ - an independent organization whose mandate is to develop open standards relating to containerization. To date, standardization efforts have focused on container formats and runtimes. {Singularity}'s compliance with respect to the OCI Image Specification is considered in detail :ref:`elsewhere <sec:oci_overview>`. It is {Singularity}'s compliance with the OCI Runtime Specification that is of concern here. 
+OCI is an acronym for the `Open Containers Initiative
+<https://www.opencontainers.org/>`_ - an independent organization whose
+mandate is to develop open standards relating to containerization. To
+date, standardization efforts have focused on container formats and
+runtimes. {Singularity}'s compliance with respect to the OCI Image
+Specification is considered in detail :ref:`elsewhere
+<sec:oci_overview>`. It is {Singularity}'s compliance with the OCI
+Runtime Specification that is of concern here.
 
-Briefly, compliance with respect to the OCI Runtime Specification is addressed in {Singularity} through the introduction of the ``oci`` command group. Although this command group can, in principle, be used to provide a runtime that supports end users, in this initial documentation effort, emphasis is placed upon interoperability with Kubernetes; more specifically, interoperability with Kubernetes via the `{Singularity} Container Runtime Interface <https://www.sylabs.io/guides/cri/1.0/user-guide/index.html>`_. 
+Briefly, compliance with respect to the OCI Runtime Specification is
+addressed in {Singularity} through the introduction of the ``oci``
+command group. Although this command group can, in principle, be used to
+provide a runtime that supports end users, in this initial documentation
+effort, emphasis is placed upon interoperability with Kubernetes; more
+specifically, interoperability with Kubernetes via the `{Singularity}
+Container Runtime Interface
+<https://www.sylabs.io/guides/cri/1.0/user-guide/index.html>`_.
 
-Owing to this restricted focus, a subset of the {Singularity} ``oci`` command group receives attention here; specifically:
+Owing to this restricted focus, a subset of the {Singularity} ``oci``
+command group receives attention here; specifically:
 
-	- Mounting and unmounting OCI filesystem bundles
-	- Creating OCI compliant container instances 
+   -  Mounting and unmounting OCI filesystem bundles
+   -  Creating OCI compliant container instances
 
-Some context for integration with Kubernetes via the {Singularity} CRI is provided at the end of the section.
+Some context for integration with Kubernetes via the {Singularity} CRI
+is provided at the end of the section.
 
-.. note:: 
+.. note::
 
-	All commands in the ``oci`` command group require ``root`` privileges. 
+   All commands in the ``oci`` command group require ``root``
+   privileges.
 
-.. TODO All commands require root access ... 
+..
+   TODO All commands require root access ...
 
-.. TODO Need to account for the diff bootstrap agents that could produce a SIF file for OCI runtime support ... 
+..
+   TODO Need to account for the diff bootstrap agents that could produce a SIF file for OCI runtime support ...
 
-.. TODO Compliance testing/validation  - need to document ... https://github.com/opencontainers/runtime-tools
+..
+   TODO Compliance testing/validation  - need to document ... https://github.com/opencontainers/runtime-tools
 
-------------------------------
-Mounted OCI Filesystem Bundles
-------------------------------
+********************************
+ Mounted OCI Filesystem Bundles
+********************************
 
 Mounting an OCI Filesystem Bundle
 =================================
 
-`BusyBox <https://busybox.net/about.html>`_ is used here for the purpose of illustration.
+`BusyBox <https://busybox.net/about.html>`_ is used here for the purpose
+of illustration.
 
-Suppose the Singularity Image Format (SIF) file ``busybox_latest.sif`` exists locally. (Recall: 
+Suppose the Singularity Image Format (SIF) file ``busybox_latest.sif``
+exists locally. (Recall:
 
-.. code-block::
+.. code::
 
-	$ singularity pull docker://busybox
-	INFO:    Starting build...
-	Getting image source signatures
-	Copying blob sha256:fc1a6b909f82ce4b72204198d49de3aaf757b3ab2bb823cb6e47c416b97c5985
-	 738.13 KiB / 738.13 KiB [==================================================] 0s
-	Copying config sha256:5fffaf1f2c1830a6a8cf90eb27c7a1a8476b8c49b4b6261a20d6257d031ce4f3
-	 575 B / 575 B [============================================================] 0s
-	Writing manifest to image destination
-	Storing signatures
-	INFO:    Creating SIF file...
-	INFO:    Build complete: busybox_latest.sif
+   $ singularity pull docker://busybox
+   INFO:    Starting build...
+   Getting image source signatures
+   Copying blob sha256:fc1a6b909f82ce4b72204198d49de3aaf757b3ab2bb823cb6e47c416b97c5985
+    738.13 KiB / 738.13 KiB [==================================================] 0s
+   Copying config sha256:5fffaf1f2c1830a6a8cf90eb27c7a1a8476b8c49b4b6261a20d6257d031ce4f3
+    575 B / 575 B [============================================================] 0s
+   Writing manifest to image destination
+   Storing signatures
+   INFO:    Creating SIF file...
+   INFO:    Build complete: busybox_latest.sif
 
-This is one way to bootstrap creation of this image in SIF that *retains* a local copy - i.e., a local copy of the SIF file *and* a cached copy of the OCI blobs. Additional approaches and details can be found in the section :ref:`Support for Docker and OCI <singularity-and-docker>`). 
+This is one way to bootstrap creation of this image in SIF that
+*retains* a local copy - i.e., a local copy of the SIF file *and* a
+cached copy of the OCI blobs. Additional approaches and details can be
+found in the section :ref:`Support for Docker and OCI
+<singularity-and-docker>`).
 
-For the purpose of bootstrapping the creation of an OCI compliant container, this SIF file can be mounted as follows: 
+For the purpose of bootstrapping the creation of an OCI compliant
+container, this SIF file can be mounted as follows:
 
-.. code-block:: 
+.. code::
 
-	$ sudo singularity oci mount ./busybox_latest.sif /var/tmp/busybox
+   $ sudo singularity oci mount ./busybox_latest.sif /var/tmp/busybox
 
-By issuing the ``mount`` command, the root filesystem encapsulated in the SIF file ``busybox_latest.sif`` is mounted on ``/var/tmp/busybox`` as an ``overlay`` file system, 
+By issuing the ``mount`` command, the root filesystem encapsulated in
+the SIF file ``busybox_latest.sif`` is mounted on ``/var/tmp/busybox``
+as an ``overlay`` file system,
 
-.. code-block::
+.. code::
 
-	$ sudo df -k
-	Filesystem                   1K-blocks    Used Available Use% Mounted on
-	udev                            475192       0    475192   0% /dev
-	tmpfs                           100916    1604     99312   2% /run
-	/dev/mapper/vagrant--vg-root  19519312 2620740  15883996  15% /
-	tmpfs                           504560       0    504560   0% /dev/shm
-	tmpfs                             5120       0      5120   0% /run/lock
-	tmpfs                           504560       0    504560   0% /sys/fs/cgroup
-	tmpfs                           100912       0    100912   0% /run/user/900
-	overlay                       19519312 2620740  15883996  15% /var/tmp/busybox/rootfs
+   $ sudo df -k
+   Filesystem                   1K-blocks    Used Available Use% Mounted on
+   udev                            475192       0    475192   0% /dev
+   tmpfs                           100916    1604     99312   2% /run
+   /dev/mapper/vagrant--vg-root  19519312 2620740  15883996  15% /
+   tmpfs                           504560       0    504560   0% /dev/shm
+   tmpfs                             5120       0      5120   0% /run/lock
+   tmpfs                           504560       0    504560   0% /sys/fs/cgroup
+   tmpfs                           100912       0    100912   0% /run/user/900
+   overlay                       19519312 2620740  15883996  15% /var/tmp/busybox/rootfs
 
 with permissions as follows:
 
-.. code-block::
+.. code::
 
-	$ sudo ls -ld /var/tmp/busybox
-	drwx------ 4 root root 4096 Apr  4 14:30 /var/tmp/busybox
-
+   $ sudo ls -ld /var/tmp/busybox
+   drwx------ 4 root root 4096 Apr  4 14:30 /var/tmp/busybox
 
 Content of an OCI Compliant Filesystem Bundle
 =============================================
 
 The *expected* contents of the mounted filesystem are as follows:
 
-.. code-block:: 
+.. code::
 
-	$ sudo ls -la /var/tmp/busybox
-	total 28
-	drwx------ 4 root root 4096 Apr  4 14:30 .
-	drwxrwxrwt 4 root root 4096 Apr  4 14:30 ..
-	-rw-rw-rw- 1 root root 9879 Apr  4 14:30 config.json
-	drwx------ 4 root root 4096 Apr  4 14:30 overlay
-	drwx------ 1 root root 4096 Apr  4 14:30 rootfs
+   $ sudo ls -la /var/tmp/busybox
+   total 28
+   drwx------ 4 root root 4096 Apr  4 14:30 .
+   drwxrwxrwt 4 root root 4096 Apr  4 14:30 ..
+   -rw-rw-rw- 1 root root 9879 Apr  4 14:30 config.json
+   drwx------ 4 root root 4096 Apr  4 14:30 overlay
+   drwx------ 1 root root 4096 Apr  4 14:30 rootfs
 
-From the perspective of the `OCI runtime specification <https://github.com/opencontainers/runtime-spec/blob/master/bundle.md>`_, this content is expected because it prescribes a 
+From the perspective of the `OCI runtime specification
+<https://github.com/opencontainers/runtime-spec/blob/master/bundle.md>`_,
+this content is expected because it prescribes a
 
-	"... a format for encoding a container as a **filesystem bundle** - a set of files organized in a certain way, and containing all the necessary data and metadata for any compliant runtime to perform all standard operations against it." 
+   "... a format for encoding a container as a **filesystem bundle** - a
+   set of files organized in a certain way, and containing all the
+   necessary data and metadata for any compliant runtime to perform all
+   standard operations against it."
 
-Critical to compliance with the specification is the presence of the following *mandatory* artifacts residing locally in a single directory:
+Critical to compliance with the specification is the presence of the
+following *mandatory* artifacts residing locally in a single directory:
 
-	1. The ``config.json`` file - a file of configuration data that must reside in the root of the bundle directory under this name 
-
-	2. The container's root filesystem - a referenced directory
-
-.. note::
-
-	Because the directory itself, i.e., ``/var/tmp/busybox`` is *not* part of the bundle, the mount point can be chosen arbitrarily. 
-
-The `filtered <https://github.com/stedolan/jq>`_ ``config.json`` file corresponding to the OCI mounted ``busybox_latest.sif`` container can be detailed as follows via ``$ sudo cat /var/tmp/busybox/config.json | jq``: 
-
-.. code-block:: json 
-
-	{
-	  "ociVersion": "1.0.1-dev",
-	  "process": {
-	    "user": {
-	      "uid": 0,
-	      "gid": 0
-	    },
-	    "args": [
-	      "/.singularity.d/actions/run"
-	    ],
-	    "env": [
-	      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-	      "TERM=xterm"
-	    ],
-	    "cwd": "/",
-	    "capabilities": {
-	      "bounding": [
-	        "CAP_CHOWN",
-	        "CAP_DAC_OVERRIDE",
-	        "CAP_FSETID",
-	        "CAP_FOWNER",
-	        "CAP_MKNOD",
-	        "CAP_NET_RAW",
-	        "CAP_SETGID",
-	        "CAP_SETUID",
-	        "CAP_SETFCAP",
-	        "CAP_SETPCAP",
-	        "CAP_NET_BIND_SERVICE",
-	        "CAP_SYS_CHROOT",
-	        "CAP_KILL",
-	        "CAP_AUDIT_WRITE"
-	      ],
-	      "effective": [
-	        "CAP_CHOWN",
-	        "CAP_DAC_OVERRIDE",
-	        "CAP_FSETID",
-	        "CAP_FOWNER",
-	        "CAP_MKNOD",
-	        "CAP_NET_RAW",
-	        "CAP_SETGID",
-	        "CAP_SETUID",
-	        "CAP_SETFCAP",
-	        "CAP_SETPCAP",
-	        "CAP_NET_BIND_SERVICE",
-	        "CAP_SYS_CHROOT",
-	        "CAP_KILL",
-	        "CAP_AUDIT_WRITE"
-	      ],
-	      "inheritable": [
-	        "CAP_CHOWN",
-	        "CAP_DAC_OVERRIDE",
-	        "CAP_FSETID",
-	        "CAP_FOWNER",
-	        "CAP_MKNOD",
-	        "CAP_NET_RAW",
-	        "CAP_SETGID",
-	        "CAP_SETUID",
-	        "CAP_SETFCAP",
-	        "CAP_SETPCAP",
-	        "CAP_NET_BIND_SERVICE",
-	        "CAP_SYS_CHROOT",
-	        "CAP_KILL",
-	        "CAP_AUDIT_WRITE"
-	      ],
-	      "permitted": [
-	        "CAP_CHOWN",
-	        "CAP_DAC_OVERRIDE",
-	        "CAP_FSETID",
-	        "CAP_FOWNER",
-	        "CAP_MKNOD",
-	        "CAP_NET_RAW",
-	        "CAP_SETGID",
-	        "CAP_SETUID",
-	        "CAP_SETFCAP",
-	        "CAP_SETPCAP",
-	        "CAP_NET_BIND_SERVICE",
-	        "CAP_SYS_CHROOT",
-	        "CAP_KILL",
-	        "CAP_AUDIT_WRITE"
-	      ],
-	      "ambient": [
-	        "CAP_CHOWN",
-	        "CAP_DAC_OVERRIDE",
-	        "CAP_FSETID",
-	        "CAP_FOWNER",
-	        "CAP_MKNOD",
-	        "CAP_NET_RAW",
-	        "CAP_SETGID",
-	        "CAP_SETUID",
-	        "CAP_SETFCAP",
-	        "CAP_SETPCAP",
-	        "CAP_NET_BIND_SERVICE",
-	        "CAP_SYS_CHROOT",
-	        "CAP_KILL",
-	        "CAP_AUDIT_WRITE"
-	      ]
-	    },
-	    "rlimits": [
-	      {
-	        "type": "RLIMIT_NOFILE",
-	        "hard": 1024,
-	        "soft": 1024
-	      }
-	    ]
-	  },
-	  "root": {
-	    "path": "/var/tmp/busybox/rootfs"
-	  },
-	  "hostname": "mrsdalloway",
-	  "mounts": [
-	    {
-	      "destination": "/proc",
-	      "type": "proc",
-	      "source": "proc"
-	    },
-	    {
-	      "destination": "/dev",
-	      "type": "tmpfs",
-	      "source": "tmpfs",
-	      "options": [
-	        "nosuid",
-	        "strictatime",
-	        "mode=755",
-	        "size=65536k"
-	      ]
-	    },
-	    {
-	      "destination": "/dev/pts",
-	      "type": "devpts",
-	      "source": "devpts",
-	      "options": [
-	        "nosuid",
-	        "noexec",
-	        "newinstance",
-	        "ptmxmode=0666",
-	        "mode=0620",
-	        "gid=5"
-	      ]
-	    },
-	    {
-	      "destination": "/dev/shm",
-	      "type": "tmpfs",
-	      "source": "shm",
-	      "options": [
-	        "nosuid",
-	        "noexec",
-	        "nodev",
-	        "mode=1777",
-	        "size=65536k"
-	      ]
-	    },
-	    {
-	      "destination": "/dev/mqueue",
-	      "type": "mqueue",
-	      "source": "mqueue",
-	      "options": [
-	        "nosuid",
-	        "noexec",
-	        "nodev"
-	      ]
-	    },
-	    {
-	      "destination": "/sys",
-	      "type": "sysfs",
-	      "source": "sysfs",
-	      "options": [
-	        "nosuid",
-	        "noexec",
-	        "nodev",
-	        "ro"
-	      ]
-	    }
-	  ],
-	  "linux": {
-	    "resources": {
-	      "devices": [
-	        {
-	          "allow": false,
-	          "access": "rwm"
-	        }
-	      ]
-	    },
-	    "namespaces": [
-	      {
-	        "type": "pid"
-	      },
-	      {
-	        "type": "network"
-	      },
-	      {
-	        "type": "ipc"
-	      },
-	      {
-	        "type": "uts"
-	      },
-	      {
-	        "type": "mount"
-	      }
-	    ],
-	    "seccomp": {
-	      "defaultAction": "SCMP_ACT_ERRNO",
-	      "architectures": [
-	        "SCMP_ARCH_X86_64",
-	        "SCMP_ARCH_X86",
-	        "SCMP_ARCH_X32"
-	      ],
-	      "syscalls": [
-	        {
-	          "names": [
-	            "accept",
-	            "accept4",
-	            "access",
-	            "alarm",
-	            "bind",
-	            "brk",
-	            "capget",
-	            "capset",
-	            "chdir",
-	            "chmod",
-	            "chown",
-	            "chown32",
-	            "clock_getres",
-	            "clock_gettime",
-	            "clock_nanosleep",
-	            "close",
-	            "connect",
-	            "copy_file_range",
-	            "creat",
-	            "dup",
-	            "dup2",
-	            "dup3",
-	            "epoll_create",
-	            "epoll_create1",
-	            "epoll_ctl",
-	            "epoll_ctl_old",
-	            "epoll_pwait",
-	            "epoll_wait",
-	            "epoll_wait_old",
-	            "eventfd",
-	            "eventfd2",
-	            "execve",
-	            "execveat",
-	            "exit",
-	            "exit_group",
-	            "faccessat",
-	            "fadvise64",
-	            "fadvise64_64",
-	            "fallocate",
-	            "fanotify_mark",
-	            "fchdir",
-	            "fchmod",
-	            "fchmodat",
-	            "fchown",
-	            "fchown32",
-	            "fchownat",
-	            "fcntl",
-	            "fcntl64",
-	            "fdatasync",
-	            "fgetxattr",
-	            "flistxattr",
-	            "flock",
-	            "fork",
-	            "fremovexattr",
-	            "fsetxattr",
-	            "fstat",
-	            "fstat64",
-	            "fstatat64",
-	            "fstatfs",
-	            "fstatfs64",
-	            "fsync",
-	            "ftruncate",
-	            "ftruncate64",
-	            "futex",
-	            "futimesat",
-	            "getcpu",
-	            "getcwd",
-	            "getdents",
-	            "getdents64",
-	            "getegid",
-	            "getegid32",
-	            "geteuid",
-	            "geteuid32",
-	            "getgid",
-	            "getgid32",
-	            "getgroups",
-	            "getgroups32",
-	            "getitimer",
-	            "getpeername",
-	            "getpgid",
-	            "getpgrp",
-	            "getpid",
-	            "getppid",
-	            "getpriority",
-	            "getrandom",
-	            "getresgid",
-	            "getresgid32",
-	            "getresuid",
-	            "getresuid32",
-	            "getrlimit",
-	            "get_robust_list",
-	            "getrusage",
-	            "getsid",
-	            "getsockname",
-	            "getsockopt",
-	            "get_thread_area",
-	            "gettid",
-	            "gettimeofday",
-	            "getuid",
-	            "getuid32",
-	            "getxattr",
-	            "inotify_add_watch",
-	            "inotify_init",
-	            "inotify_init1",
-	            "inotify_rm_watch",
-	            "io_cancel",
-	            "ioctl",
-	            "io_destroy",
-	            "io_getevents",
-	            "ioprio_get",
-	            "ioprio_set",
-	            "io_setup",
-	            "io_submit",
-	            "ipc",
-	            "kill",
-	            "lchown",
-	            "lchown32",
-	            "lgetxattr",
-	            "link",
-	            "linkat",
-	            "listen",
-	            "listxattr",
-	            "llistxattr",
-	            "_llseek",
-	            "lremovexattr",
-	            "lseek",
-	            "lsetxattr",
-	            "lstat",
-	            "lstat64",
-	            "madvise",
-	            "memfd_create",
-	            "mincore",
-	            "mkdir",
-	            "mkdirat",
-	            "mknod",
-	            "mknodat",
-	            "mlock",
-	            "mlock2",
-	            "mlockall",
-	            "mmap",
-	            "mmap2",
-	            "mprotect",
-	            "mq_getsetattr",
-	            "mq_notify",
-	            "mq_open",
-	            "mq_timedreceive",
-	            "mq_timedsend",
-	            "mq_unlink",
-	            "mremap",
-	            "msgctl",
-	            "msgget",
-	            "msgrcv",
-	            "msgsnd",
-	            "msync",
-	            "munlock",
-	            "munlockall",
-	            "munmap",
-	            "nanosleep",
-	            "newfstatat",
-	            "_newselect",
-	            "open",
-	            "openat",
-	            "pause",
-	            "pipe",
-	            "pipe2",
-	            "poll",
-	            "ppoll",
-	            "prctl",
-	            "pread64",
-	            "preadv",
-	            "prlimit64",
-	            "pselect6",
-	            "pwrite64",
-	            "pwritev",
-	            "read",
-	            "readahead",
-	            "readlink",
-	            "readlinkat",
-	            "readv",
-	            "recv",
-	            "recvfrom",
-	            "recvmmsg",
-	            "recvmsg",
-	            "remap_file_pages",
-	            "removexattr",
-	            "rename",
-	            "renameat",
-	            "renameat2",
-	            "restart_syscall",
-	            "rmdir",
-	            "rt_sigaction",
-	            "rt_sigpending",
-	            "rt_sigprocmask",
-	            "rt_sigqueueinfo",
-	            "rt_sigreturn",
-	            "rt_sigsuspend",
-	            "rt_sigtimedwait",
-	            "rt_tgsigqueueinfo",
-	            "sched_getaffinity",
-	            "sched_getattr",
-	            "sched_getparam",
-	            "sched_get_priority_max",
-	            "sched_get_priority_min",
-	            "sched_getscheduler",
-	            "sched_rr_get_interval",
-	            "sched_setaffinity",
-	            "sched_setattr",
-	            "sched_setparam",
-	            "sched_setscheduler",
-	            "sched_yield",
-	            "seccomp",
-	            "select",
-	            "semctl",
-	            "semget",
-	            "semop",
-	            "semtimedop",
-	            "send",
-	            "sendfile",
-	            "sendfile64",
-	            "sendmmsg",
-	            "sendmsg",
-	            "sendto",
-	            "setfsgid",
-	            "setfsgid32",
-	            "setfsuid",
-	            "setfsuid32",
-	            "setgid",
-	            "setgid32",
-	            "setgroups",
-	            "setgroups32",
-	            "setitimer",
-	            "setpgid",
-	            "setpriority",
-	            "setregid",
-	            "setregid32",
-	            "setresgid",
-	            "setresgid32",
-	            "setresuid",
-	            "setresuid32",
-	            "setreuid",
-	            "setreuid32",
-	            "setrlimit",
-	            "set_robust_list",
-	            "setsid",
-	            "setsockopt",
-	            "set_thread_area",
-	            "set_tid_address",
-	            "setuid",
-	            "setuid32",
-	            "setxattr",
-	            "shmat",
-	            "shmctl",
-	            "shmdt",
-	            "shmget",
-	            "shutdown",
-	            "sigaltstack",
-	            "signalfd",
-	            "signalfd4",
-	            "sigreturn",
-	            "socket",
-	            "socketcall",
-	            "socketpair",
-	            "splice",
-	            "stat",
-	            "stat64",
-	            "statfs",
-	            "statfs64",
-	            "symlink",
-	            "symlinkat",
-	            "sync",
-	            "sync_file_range",
-	            "syncfs",
-	            "sysinfo",
-	            "syslog",
-	            "tee",
-	            "tgkill",
-	            "time",
-	            "timer_create",
-	            "timer_delete",
-	            "timerfd_create",
-	            "timerfd_gettime",
-	            "timerfd_settime",
-	            "timer_getoverrun",
-	            "timer_gettime",
-	            "timer_settime",
-	            "times",
-	            "tkill",
-	            "truncate",
-	            "truncate64",
-	            "ugetrlimit",
-	            "umask",
-	            "uname",
-	            "unlink",
-	            "unlinkat",
-	            "utime",
-	            "utimensat",
-	            "utimes",
-	            "vfork",
-	            "vmsplice",
-	            "wait4",
-	            "waitid",
-	            "waitpid",
-	            "write",
-	            "writev"
-	          ],
-	          "action": "SCMP_ACT_ALLOW"
-	        },
-	        {
-	          "names": [
-	            "personality"
-	          ],
-	          "action": "SCMP_ACT_ALLOW",
-	          "args": [
-	            {
-	              "index": 0,
-	              "value": 0,
-	              "op": "SCMP_CMP_EQ"
-	            },
-	            {
-	              "index": 0,
-	              "value": 8,
-	              "op": "SCMP_CMP_EQ"
-	            },
-	            {
-	              "index": 0,
-	              "value": 4294967295,
-	              "op": "SCMP_CMP_EQ"
-	            }
-	          ]
-	        },
-	        {
-	          "names": [
-	            "chroot"
-	          ],
-	          "action": "SCMP_ACT_ALLOW"
-	        },
-	        {
-	          "names": [
-	            "clone"
-	          ],
-	          "action": "SCMP_ACT_ALLOW",
-	          "args": [
-	            {
-	              "index": 0,
-	              "value": 2080505856,
-	              "op": "SCMP_CMP_MASKED_EQ"
-	            }
-	          ]
-	        },
-	        {
-	          "names": [
-	            "arch_prctl"
-	          ],
-	          "action": "SCMP_ACT_ALLOW"
-	        },
-	        {
-	          "names": [
-	            "modify_ldt"
-	          ],
-	          "action": "SCMP_ACT_ALLOW"
-	        }
-	      ]
-	    }
-	  }
-	}
-
-Furthermore, and through use of ``$ sudo cat /var/tmp/busybox/config.json | jq [.root.path]``, the property
-
-.. code-block:: json
-
-	[
-  		"/var/tmp/busybox/rootfs"
-	]
-
-identifies ``/var/tmp/busybox/rootfs`` as the container's root filesystem, as required by the standard; this filesystem has contents:
-
-.. code-block::
-
-	$ sudo ls /var/tmp/busybox/rootfs
-	bin  dev  environment  etc  home  proc	root  singularity  sys	tmp  usr  var
+   #. The ``config.json`` file - a file of configuration data that must
+      reside in the root of the bundle directory under this name
+   #. The container's root filesystem - a referenced directory
 
 .. note::
 
-	``environment`` and ``singularity`` above are symbolic links to the ``.singularity.d`` directory. 
+   Because the directory itself, i.e., ``/var/tmp/busybox`` is *not*
+   part of the bundle, the mount point can be chosen arbitrarily.
 
-.. TODO Is the ``.singularity.d`` ignored in this case? Relates to the other quote I lifted ... 
+The `filtered <https://github.com/stedolan/jq>`_ ``config.json`` file
+corresponding to the OCI mounted ``busybox_latest.sif`` container can be
+detailed as follows via ``$ sudo cat /var/tmp/busybox/config.json |
+jq``:
 
-	"The definition of a bundle is only concerned with how a container, and its configuration data, are stored on a local filesystem so that it can be consumed by a compliant runtime."
+.. code:: json
 
-Beyond ``root.path``, the ``config.json`` file includes a multitude of additional properties - for example:
+   {
+     "ociVersion": "1.0.1-dev",
+     "process": {
+       "user": {
+         "uid": 0,
+         "gid": 0
+       },
+       "args": [
+         "/.singularity.d/actions/run"
+       ],
+       "env": [
+         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+         "TERM=xterm"
+       ],
+       "cwd": "/",
+       "capabilities": {
+         "bounding": [
+           "CAP_CHOWN",
+           "CAP_DAC_OVERRIDE",
+           "CAP_FSETID",
+           "CAP_FOWNER",
+           "CAP_MKNOD",
+           "CAP_NET_RAW",
+           "CAP_SETGID",
+           "CAP_SETUID",
+           "CAP_SETFCAP",
+           "CAP_SETPCAP",
+           "CAP_NET_BIND_SERVICE",
+           "CAP_SYS_CHROOT",
+           "CAP_KILL",
+           "CAP_AUDIT_WRITE"
+         ],
+         "effective": [
+           "CAP_CHOWN",
+           "CAP_DAC_OVERRIDE",
+           "CAP_FSETID",
+           "CAP_FOWNER",
+           "CAP_MKNOD",
+           "CAP_NET_RAW",
+           "CAP_SETGID",
+           "CAP_SETUID",
+           "CAP_SETFCAP",
+           "CAP_SETPCAP",
+           "CAP_NET_BIND_SERVICE",
+           "CAP_SYS_CHROOT",
+           "CAP_KILL",
+           "CAP_AUDIT_WRITE"
+         ],
+         "inheritable": [
+           "CAP_CHOWN",
+           "CAP_DAC_OVERRIDE",
+           "CAP_FSETID",
+           "CAP_FOWNER",
+           "CAP_MKNOD",
+           "CAP_NET_RAW",
+           "CAP_SETGID",
+           "CAP_SETUID",
+           "CAP_SETFCAP",
+           "CAP_SETPCAP",
+           "CAP_NET_BIND_SERVICE",
+           "CAP_SYS_CHROOT",
+           "CAP_KILL",
+           "CAP_AUDIT_WRITE"
+         ],
+         "permitted": [
+           "CAP_CHOWN",
+           "CAP_DAC_OVERRIDE",
+           "CAP_FSETID",
+           "CAP_FOWNER",
+           "CAP_MKNOD",
+           "CAP_NET_RAW",
+           "CAP_SETGID",
+           "CAP_SETUID",
+           "CAP_SETFCAP",
+           "CAP_SETPCAP",
+           "CAP_NET_BIND_SERVICE",
+           "CAP_SYS_CHROOT",
+           "CAP_KILL",
+           "CAP_AUDIT_WRITE"
+         ],
+         "ambient": [
+           "CAP_CHOWN",
+           "CAP_DAC_OVERRIDE",
+           "CAP_FSETID",
+           "CAP_FOWNER",
+           "CAP_MKNOD",
+           "CAP_NET_RAW",
+           "CAP_SETGID",
+           "CAP_SETUID",
+           "CAP_SETFCAP",
+           "CAP_SETPCAP",
+           "CAP_NET_BIND_SERVICE",
+           "CAP_SYS_CHROOT",
+           "CAP_KILL",
+           "CAP_AUDIT_WRITE"
+         ]
+       },
+       "rlimits": [
+         {
+           "type": "RLIMIT_NOFILE",
+           "hard": 1024,
+           "soft": 1024
+         }
+       ]
+     },
+     "root": {
+       "path": "/var/tmp/busybox/rootfs"
+     },
+     "hostname": "mrsdalloway",
+     "mounts": [
+       {
+         "destination": "/proc",
+         "type": "proc",
+         "source": "proc"
+       },
+       {
+         "destination": "/dev",
+         "type": "tmpfs",
+         "source": "tmpfs",
+         "options": [
+           "nosuid",
+           "strictatime",
+           "mode=755",
+           "size=65536k"
+         ]
+       },
+       {
+         "destination": "/dev/pts",
+         "type": "devpts",
+         "source": "devpts",
+         "options": [
+           "nosuid",
+           "noexec",
+           "newinstance",
+           "ptmxmode=0666",
+           "mode=0620",
+           "gid=5"
+         ]
+       },
+       {
+         "destination": "/dev/shm",
+         "type": "tmpfs",
+         "source": "shm",
+         "options": [
+           "nosuid",
+           "noexec",
+           "nodev",
+           "mode=1777",
+           "size=65536k"
+         ]
+       },
+       {
+         "destination": "/dev/mqueue",
+         "type": "mqueue",
+         "source": "mqueue",
+         "options": [
+           "nosuid",
+           "noexec",
+           "nodev"
+         ]
+       },
+       {
+         "destination": "/sys",
+         "type": "sysfs",
+         "source": "sysfs",
+         "options": [
+           "nosuid",
+           "noexec",
+           "nodev",
+           "ro"
+         ]
+       }
+     ],
+     "linux": {
+       "resources": {
+         "devices": [
+           {
+             "allow": false,
+             "access": "rwm"
+           }
+         ]
+       },
+       "namespaces": [
+         {
+           "type": "pid"
+         },
+         {
+           "type": "network"
+         },
+         {
+           "type": "ipc"
+         },
+         {
+           "type": "uts"
+         },
+         {
+           "type": "mount"
+         }
+       ],
+       "seccomp": {
+         "defaultAction": "SCMP_ACT_ERRNO",
+         "architectures": [
+           "SCMP_ARCH_X86_64",
+           "SCMP_ARCH_X86",
+           "SCMP_ARCH_X32"
+         ],
+         "syscalls": [
+           {
+             "names": [
+               "accept",
+               "accept4",
+               "access",
+               "alarm",
+               "bind",
+               "brk",
+               "capget",
+               "capset",
+               "chdir",
+               "chmod",
+               "chown",
+               "chown32",
+               "clock_getres",
+               "clock_gettime",
+               "clock_nanosleep",
+               "close",
+               "connect",
+               "copy_file_range",
+               "creat",
+               "dup",
+               "dup2",
+               "dup3",
+               "epoll_create",
+               "epoll_create1",
+               "epoll_ctl",
+               "epoll_ctl_old",
+               "epoll_pwait",
+               "epoll_wait",
+               "epoll_wait_old",
+               "eventfd",
+               "eventfd2",
+               "execve",
+               "execveat",
+               "exit",
+               "exit_group",
+               "faccessat",
+               "fadvise64",
+               "fadvise64_64",
+               "fallocate",
+               "fanotify_mark",
+               "fchdir",
+               "fchmod",
+               "fchmodat",
+               "fchown",
+               "fchown32",
+               "fchownat",
+               "fcntl",
+               "fcntl64",
+               "fdatasync",
+               "fgetxattr",
+               "flistxattr",
+               "flock",
+               "fork",
+               "fremovexattr",
+               "fsetxattr",
+               "fstat",
+               "fstat64",
+               "fstatat64",
+               "fstatfs",
+               "fstatfs64",
+               "fsync",
+               "ftruncate",
+               "ftruncate64",
+               "futex",
+               "futimesat",
+               "getcpu",
+               "getcwd",
+               "getdents",
+               "getdents64",
+               "getegid",
+               "getegid32",
+               "geteuid",
+               "geteuid32",
+               "getgid",
+               "getgid32",
+               "getgroups",
+               "getgroups32",
+               "getitimer",
+               "getpeername",
+               "getpgid",
+               "getpgrp",
+               "getpid",
+               "getppid",
+               "getpriority",
+               "getrandom",
+               "getresgid",
+               "getresgid32",
+               "getresuid",
+               "getresuid32",
+               "getrlimit",
+               "get_robust_list",
+               "getrusage",
+               "getsid",
+               "getsockname",
+               "getsockopt",
+               "get_thread_area",
+               "gettid",
+               "gettimeofday",
+               "getuid",
+               "getuid32",
+               "getxattr",
+               "inotify_add_watch",
+               "inotify_init",
+               "inotify_init1",
+               "inotify_rm_watch",
+               "io_cancel",
+               "ioctl",
+               "io_destroy",
+               "io_getevents",
+               "ioprio_get",
+               "ioprio_set",
+               "io_setup",
+               "io_submit",
+               "ipc",
+               "kill",
+               "lchown",
+               "lchown32",
+               "lgetxattr",
+               "link",
+               "linkat",
+               "listen",
+               "listxattr",
+               "llistxattr",
+               "_llseek",
+               "lremovexattr",
+               "lseek",
+               "lsetxattr",
+               "lstat",
+               "lstat64",
+               "madvise",
+               "memfd_create",
+               "mincore",
+               "mkdir",
+               "mkdirat",
+               "mknod",
+               "mknodat",
+               "mlock",
+               "mlock2",
+               "mlockall",
+               "mmap",
+               "mmap2",
+               "mprotect",
+               "mq_getsetattr",
+               "mq_notify",
+               "mq_open",
+               "mq_timedreceive",
+               "mq_timedsend",
+               "mq_unlink",
+               "mremap",
+               "msgctl",
+               "msgget",
+               "msgrcv",
+               "msgsnd",
+               "msync",
+               "munlock",
+               "munlockall",
+               "munmap",
+               "nanosleep",
+               "newfstatat",
+               "_newselect",
+               "open",
+               "openat",
+               "pause",
+               "pipe",
+               "pipe2",
+               "poll",
+               "ppoll",
+               "prctl",
+               "pread64",
+               "preadv",
+               "prlimit64",
+               "pselect6",
+               "pwrite64",
+               "pwritev",
+               "read",
+               "readahead",
+               "readlink",
+               "readlinkat",
+               "readv",
+               "recv",
+               "recvfrom",
+               "recvmmsg",
+               "recvmsg",
+               "remap_file_pages",
+               "removexattr",
+               "rename",
+               "renameat",
+               "renameat2",
+               "restart_syscall",
+               "rmdir",
+               "rt_sigaction",
+               "rt_sigpending",
+               "rt_sigprocmask",
+               "rt_sigqueueinfo",
+               "rt_sigreturn",
+               "rt_sigsuspend",
+               "rt_sigtimedwait",
+               "rt_tgsigqueueinfo",
+               "sched_getaffinity",
+               "sched_getattr",
+               "sched_getparam",
+               "sched_get_priority_max",
+               "sched_get_priority_min",
+               "sched_getscheduler",
+               "sched_rr_get_interval",
+               "sched_setaffinity",
+               "sched_setattr",
+               "sched_setparam",
+               "sched_setscheduler",
+               "sched_yield",
+               "seccomp",
+               "select",
+               "semctl",
+               "semget",
+               "semop",
+               "semtimedop",
+               "send",
+               "sendfile",
+               "sendfile64",
+               "sendmmsg",
+               "sendmsg",
+               "sendto",
+               "setfsgid",
+               "setfsgid32",
+               "setfsuid",
+               "setfsuid32",
+               "setgid",
+               "setgid32",
+               "setgroups",
+               "setgroups32",
+               "setitimer",
+               "setpgid",
+               "setpriority",
+               "setregid",
+               "setregid32",
+               "setresgid",
+               "setresgid32",
+               "setresuid",
+               "setresuid32",
+               "setreuid",
+               "setreuid32",
+               "setrlimit",
+               "set_robust_list",
+               "setsid",
+               "setsockopt",
+               "set_thread_area",
+               "set_tid_address",
+               "setuid",
+               "setuid32",
+               "setxattr",
+               "shmat",
+               "shmctl",
+               "shmdt",
+               "shmget",
+               "shutdown",
+               "sigaltstack",
+               "signalfd",
+               "signalfd4",
+               "sigreturn",
+               "socket",
+               "socketcall",
+               "socketpair",
+               "splice",
+               "stat",
+               "stat64",
+               "statfs",
+               "statfs64",
+               "symlink",
+               "symlinkat",
+               "sync",
+               "sync_file_range",
+               "syncfs",
+               "sysinfo",
+               "syslog",
+               "tee",
+               "tgkill",
+               "time",
+               "timer_create",
+               "timer_delete",
+               "timerfd_create",
+               "timerfd_gettime",
+               "timerfd_settime",
+               "timer_getoverrun",
+               "timer_gettime",
+               "timer_settime",
+               "times",
+               "tkill",
+               "truncate",
+               "truncate64",
+               "ugetrlimit",
+               "umask",
+               "uname",
+               "unlink",
+               "unlinkat",
+               "utime",
+               "utimensat",
+               "utimes",
+               "vfork",
+               "vmsplice",
+               "wait4",
+               "waitid",
+               "waitpid",
+               "write",
+               "writev"
+             ],
+             "action": "SCMP_ACT_ALLOW"
+           },
+           {
+             "names": [
+               "personality"
+             ],
+             "action": "SCMP_ACT_ALLOW",
+             "args": [
+               {
+                 "index": 0,
+                 "value": 0,
+                 "op": "SCMP_CMP_EQ"
+               },
+               {
+                 "index": 0,
+                 "value": 8,
+                 "op": "SCMP_CMP_EQ"
+               },
+               {
+                 "index": 0,
+                 "value": 4294967295,
+                 "op": "SCMP_CMP_EQ"
+               }
+             ]
+           },
+           {
+             "names": [
+               "chroot"
+             ],
+             "action": "SCMP_ACT_ALLOW"
+           },
+           {
+             "names": [
+               "clone"
+             ],
+             "action": "SCMP_ACT_ALLOW",
+             "args": [
+               {
+                 "index": 0,
+                 "value": 2080505856,
+                 "op": "SCMP_CMP_MASKED_EQ"
+               }
+             ]
+           },
+           {
+             "names": [
+               "arch_prctl"
+             ],
+             "action": "SCMP_ACT_ALLOW"
+           },
+           {
+             "names": [
+               "modify_ldt"
+             ],
+             "action": "SCMP_ACT_ALLOW"
+           }
+         ]
+       }
+     }
+   }
 
-	- ``ociVersion`` - a mandatory property that identifies the version of the OCI runtime specification that the bundle is compliant with 
+Furthermore, and through use of ``$ sudo cat
+/var/tmp/busybox/config.json | jq [.root.path]``, the property
 
-	- ``process`` - an optional property that specifies the container process. When invoked via {Singularity}, subproperties such as ``args`` are populated by making use of the contents of the ``.singularity.d`` directory, e.g. via ``$ sudo cat /var/tmp/busybox/config.json | jq [.process.args]``:
+.. code:: json
 
-	.. code-block:: json
+   [
+           "/var/tmp/busybox/rootfs"
+   ]
 
-		[
-		  [
-		    "/.singularity.d/actions/run"
-		  ]
-		]
+identifies ``/var/tmp/busybox/rootfs`` as the container's root
+filesystem, as required by the standard; this filesystem has contents:
 
-	where ``run`` equates to the :ref:`familiar runscript <sec:inspect_container_metadata>` for this container. If image creation is bootstrapped via a Docker or OCI agent, {Singularity} will make use of ``ENTRYPOINT`` or ``CMD`` (from the OCI image) to populate ``args``; for additional discussion, please refer to :ref:`Directing Execution <sec:def_files_execution>` in the section :ref:`Support for Docker and OCI <singularity-and-docker>`. 
+.. code::
 
-For a comprehensive discussion of all the ``config.json`` file properties, refer to the `implementation guide <https://github.com/opencontainers/runtime-spec/blob/master/config.md>`_. 
-
-Technically, the ``overlay`` directory was *not* content expected of an OCI compliant filesystem bundle. As detailed in the section dedicated to `Persistent Overlays <persistent_overlays.html>`_, these directories allow for the introduction of 
-a writable file system on an otherwise immutable read-only container; thus they permit the illusion of read-write access.
-
-.. TODO Need to ensure that what's written above is correct 
+   $ sudo ls /var/tmp/busybox/rootfs
+   bin  dev  environment  etc  home  proc  root  singularity  sys  tmp  usr  var
 
 .. note::
 
-	SIF is stated to be an extensible format; by encapsulating a filesystem bundle that conforms with the OCI runtime specification, this extensibility is evident.
+   ``environment`` and ``singularity`` above are symbolic links to the
+   ``.singularity.d`` directory.
 
+..
+   TODO Is the ``.singularity.d`` ignored in this case? Relates to the other quote I lifted ...
 
-------------------------------------------
-Creating OCI Compliant Container Instances 
-------------------------------------------
+   "The definition of a bundle is only concerned with how a container, and its configuration data, are stored on a local filesystem so that it can be consumed by a compliant runtime."
 
-SIF files encapsulate the OCI runtime. By 'OCI mounting' a SIF file (see above), this encapsulated runtime is revealed; please refer to the note below for additional details. Once revealed, the filesystem bundle can be used to bootstrap the creation of an OCI compliant container instance as follows: 
+Beyond ``root.path``, the ``config.json`` file includes a multitude of
+additional properties - for example:
 
-.. code-block::
+   -  ``ociVersion`` - a mandatory property that identifies the version
+      of the OCI runtime specification that the bundle is compliant with
 
-	$ sudo singularity oci create -b /var/tmp/busybox busybox1
+   -  ``process`` - an optional property that specifies the container
+      process. When invoked via {Singularity}, subproperties such as
+      ``args`` are populated by making use of the contents of the
+      ``.singularity.d`` directory, e.g. via ``$ sudo cat
+      /var/tmp/busybox/config.json | jq [.process.args]``:
+
+   .. code:: json
+
+      [
+        [
+          "/.singularity.d/actions/run"
+        ]
+      ]
+
+   where ``run`` equates to the :ref:`familiar runscript
+   <sec:inspect_container_metadata>` for this container. If image
+   creation is bootstrapped via a Docker or OCI agent, {Singularity}
+   will make use of ``ENTRYPOINT`` or ``CMD`` (from the OCI image) to
+   populate ``args``; for additional discussion, please refer to
+   :ref:`Directing Execution <sec:def_files_execution>` in the section
+   :ref:`Support for Docker and OCI <singularity-and-docker>`.
+
+For a comprehensive discussion of all the ``config.json`` file
+properties, refer to the `implementation guide
+<https://github.com/opencontainers/runtime-spec/blob/master/config.md>`_.
+
+Technically, the ``overlay`` directory was *not* content expected of an
+OCI compliant filesystem bundle. As detailed in the section dedicated to
+`Persistent Overlays
+<persistent_overlays.html>`_,
+these directories allow for the introduction of a writable file system
+on an otherwise immutable read-only container; thus they permit the
+illusion of read-write access.
+
+..
+   TODO Need to ensure that what's written above is correct
 
 .. note::
 
-	Data for the ``config.json`` file exists within the SIF file as a descriptor for images pulled or built from Docker/OCI registries. For images sourced elsewhere, a default ``config.json`` file is created when the ``singularity oci mount ...`` command is issued. 
+   SIF is stated to be an extensible format; by encapsulating a
+   filesystem bundle that conforms with the OCI runtime specification,
+   this extensibility is evident.
 
-	Upon invocation, ``singularity oci mount ...`` also mounts the root filesystem stored in the SIF file on ``/bundle/rootfs``, and establishes an overlay filesystem on the mount point ``/bundle/overlay``. 
+********************************************
+ Creating OCI Compliant Container Instances
+********************************************
 
-In this example, the filesystem bundle is located in the directory ``/var/tmp/busybox`` - i.e., the mount point identified above with respect to 'OCI mounting'. The ``config.json`` file, along with the ``rootfs`` and ``overlay`` filesystems, are all employed in the bootstrap process. The instance is named ``busybox1`` in this example. 
+SIF files encapsulate the OCI runtime. By 'OCI mounting' a SIF file (see
+above), this encapsulated runtime is revealed; please refer to the note
+below for additional details. Once revealed, the filesystem bundle can
+be used to bootstrap the creation of an OCI compliant container instance
+as follows:
+
+.. code::
+
+   $ sudo singularity oci create -b /var/tmp/busybox busybox1
 
 .. note::
 
-	The outcome of this creation request is truly a container **instance**. Multiple instances of the same container can easily be created by simply changing the name of the instance upon subsequent invocation requests. 
+   Data for the ``config.json`` file exists within the SIF file as a
+   descriptor for images pulled or built from Docker/OCI registries. For
+   images sourced elsewhere, a default ``config.json`` file is created
+   when the ``singularity oci mount ...`` command is issued.
 
-The ``state`` of the container instance can be determined via ``$ sudo singularity oci state busybox1``:
+   Upon invocation, ``singularity oci mount ...`` also mounts the root
+   filesystem stored in the SIF file on ``/bundle/rootfs``, and
+   establishes an overlay filesystem on the mount point
+   ``/bundle/overlay``.
 
-.. code-block:: json
+In this example, the filesystem bundle is located in the directory
+``/var/tmp/busybox`` - i.e., the mount point identified above with
+respect to 'OCI mounting'. The ``config.json`` file, along with the
+``rootfs`` and ``overlay`` filesystems, are all employed in the
+bootstrap process. The instance is named ``busybox1`` in this example.
 
-	{
-	"ociVersion": "1.0.1-dev",
-	"id": "busybox1",
-	"status": "created",
-	"pid": 6578,
-	"bundle": "/var/tmp/busybox",
-	"createdAt": 1554389921452964253,
-	"attachSocket": "/var/run/singularity/instances/root/busybox1/attach.sock",
-	"controlSocket": "/var/run/singularity/instances/root/busybox1/control.sock"
-	}
+.. note::
 
-Container state, as conveyed via these properties, is in compliance with the OCI runtime specification as detailed `here <https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#state>`_. 
+   The outcome of this creation request is truly a container
+   **instance**. Multiple instances of the same container can easily be
+   created by simply changing the name of the instance upon subsequent
+   invocation requests.
 
-The ``create`` command has a number of options available. Of these, real-time logging to a file is likely to be of particular value - e.g., in deployments where auditing requirements exist. 
+The ``state`` of the container instance can be determined via ``$ sudo
+singularity oci state busybox1``:
 
+.. code:: json
 
-.. TODO - illustrate use of cgroups 
+   {
+   "ociVersion": "1.0.1-dev",
+   "id": "busybox1",
+   "status": "created",
+   "pid": 6578,
+   "bundle": "/var/tmp/busybox",
+   "createdAt": 1554389921452964253,
+   "attachSocket": "/var/run/singularity/instances/root/busybox1/attach.sock",
+   "controlSocket": "/var/run/singularity/instances/root/busybox1/control.sock"
+   }
 
+Container state, as conveyed via these properties, is in compliance with
+the OCI runtime specification as detailed `here
+<https://github.com/opencontainers/runtime-spec/blob/master/runtime.md#state>`_.
 
-.. ------------------------------------------
-.. Starting OCI Compliant Container Instances 
-.. ------------------------------------------
+The ``create`` command has a number of options available. Of these,
+real-time logging to a file is likely to be of particular value - e.g.,
+in deployments where auditing requirements exist.
 
+..
+   TODO - illustrate use of cgroups
 
-.. $ sudo singularity oci start busybox
+..
+   ------------------------------------------
 
-.. ~$ sudo singularity oci state busybox
+..
+   Starting OCI Compliant Container Instances
 
-.. TODO Review CC's responses again ... see GDocs note on March 20, 2019
+..
+   ------------------------------------------
 
-.. TODO Highlight UID & GID ??? 
+..
+   $ sudo singularity oci start busybox
 
-.. TODO What is an overlay fs?  ^^^ https://www.datalight.com/blog/2016/01/27/explaining-overlayfs-%E2%80%93-what-it-does-and-how-it-works/ 
-.. Check again after I create a bundle and container ... 
+..
+   ~$ sudo singularity oci state busybox
 
-.. sandbox???
+..
+   TODO Review CC's responses again ... see GDocs note on March 20, 2019
 
+..
+   TODO Highlight UID & GID ???
 
----------------------------------
-Unmounting OCI Filesystem Bundles
----------------------------------
+..
+   TODO What is an overlay fs?  ^^^ https://www.datalight.com/blog/2016/01/27/explaining-overlayfs-%E2%80%93-what-it-does-and-how-it-works/
 
-To unmount a mounted OCI filesystem bundle, the following command should be issued:
+..
+   Check again after I create a bundle and container ...
 
-.. code-block::
+..
+   sandbox???
 
-	$ sudo singularity oci umount /var/tmp/busybox
+***********************************
+ Unmounting OCI Filesystem Bundles
+***********************************
 
-.. note:: 
+To unmount a mounted OCI filesystem bundle, the following command should
+be issued:
 
-	The argument provided to ``oci umount`` above is the name of the bundle path, ``/var/tmp/busybox``, as opposed to the mount point for the overlay filesystem, ``/var/tmp/busybox/rootfs``. 
+.. code::
 
-.. TODO Affect on running instances ... 
+   $ sudo singularity oci umount /var/tmp/busybox
 
+.. note::
 
+   The argument provided to ``oci umount`` above is the name of the
+   bundle path, ``/var/tmp/busybox``, as opposed to the mount point for
+   the overlay filesystem, ``/var/tmp/busybox/rootfs``.
 
-.. https://www.sylabs.io/guides/cri/1.0/user-guide/installation.html?highlight=oci#install-dependencies 
+..
+   TODO Affect on running instances ...
 
+..
+   https://www.sylabs.io/guides/cri/1.0/user-guide/installation.html?highlight=oci#install-dependencies
 
-----------------------
-Kubernetes Integration
-----------------------
+************************
+ Kubernetes Integration
+************************
 
-As noted at the :ref:`outset here <sec:oci_runtime_overview>`, in documenting support for an OCI runtime in {Singularity}, the impetus is initially derived from the requirement to integrate with `Kubernetes <https://kubernetes.io/>`_. Simply stated, Kubernetes is an open-source system for orchestrating containers; developed originally at Google, Kubernetes was contributed as seed technology to the `Cloud Native Compute Foundation <https://www.cncf.io/>`_ (CNCF). At this point, Kubernetes is regarded as a Graduated Project by CNCF, and is being used widely in production deployments. Even though Kubernetes emphasizes an orientation around services, it is appealing to those seeking to orchestrate containers having compute-driven requirements. Furthermore, emerging classes of workload in AI for example, appear to have requirements that are best addressed by a combination of service and traditional HPC infrastructures. Thus there is ample existing, as well as emerging, interest in integrating {Singularity} containers with Kubernetes. 
+As noted at the :ref:`outset here <sec:oci_runtime_overview>`, in
+documenting support for an OCI runtime in {Singularity}, the impetus is
+initially derived from the requirement to integrate with `Kubernetes
+<https://kubernetes.io/>`_. Simply stated, Kubernetes is an open-source
+system for orchestrating containers; developed originally at Google,
+Kubernetes was contributed as seed technology to the `Cloud Native
+Compute Foundation <https://www.cncf.io/>`_ (CNCF). At this point,
+Kubernetes is regarded as a Graduated Project by CNCF, and is being used
+widely in production deployments. Even though Kubernetes emphasizes an
+orientation around services, it is appealing to those seeking to
+orchestrate containers having compute-driven requirements. Furthermore,
+emerging classes of workload in AI for example, appear to have
+requirements that are best addressed by a combination of service and
+traditional HPC infrastructures. Thus there is ample existing, as well
+as emerging, interest in integrating {Singularity} containers with
+Kubernetes.
 
-The connection with support for the OCI runtime documented here, within the context of a {Singularity}-Kubernetes integration, can be best established through an architectural schematic. Dating back to the introduction of a Container Runtime Interface (CRI) for Kubernetes in late 2016, the schematic below is a modified version of the original presented in `a Kubernetes blog post <https://kubernetes.io/blog/2016/12/container-runtime-interface-cri-in-kubernetes/>`_. The lower branch of this schematic is essentially a reproduction of the original; it does however, place emphasis on OCI compliance in terms of the CRI and containers (the runtime as well as their instances). 
+The connection with support for the OCI runtime documented here, within
+the context of a {Singularity}-Kubernetes integration, can be best
+established through an architectural schematic. Dating back to the
+introduction of a Container Runtime Interface (CRI) for Kubernetes in
+late 2016, the schematic below is a modified version of the original
+presented in `a Kubernetes blog post
+<https://kubernetes.io/blog/2016/12/container-runtime-interface-cri-in-kubernetes/>`_.
+The lower branch of this schematic is essentially a reproduction of the
+original; it does however, place emphasis on OCI compliance in terms of
+the CRI and containers (the runtime as well as their instances).
 
 .. image:: sycri_ociruntime_implementation.png
 
-From this schematic it is evident that integrating {Singularity} containers with Kubernetes requires the following efforts:
+From this schematic it is evident that integrating {Singularity}
+containers with Kubernetes requires the following efforts:
 
-	1. Implementation of a CRI for {Singularity} 
-	
-	2. Implementation of an OCI runtime in {Singularity}
+   #. Implementation of a CRI for {Singularity}
+   #. Implementation of an OCI runtime in {Singularity}
 
-The implementation of a CRI for {Singularity} is the emphasis of a separate and distinct `open source project <https://github.com/sylabs/singularity-cri>`_; the implementation of this CRI is documented here. For the rationale conveyed through the architectural schematic, {Singularity} CRI's dependence upon {Singularity} with OCI runtime support is made clear as `an installation prerequisite <https://www.sylabs.io/guides/cri/1.0/user-guide/installation.html?highlight=oci#install-dependencies>`_. User-facing documentation for {Singularity} CRI details usage in a Kubernetes context - usage, of course, that involves orchestration of a {Singularity} container obtained from the `Sylabs Cloud Container Library <https://cloud.sylabs.io/library>`_. Because the entire Kubernetes-based deployment can exist within a single instance of a {Singularity} container, {Singularity} CRI can be easily evaluated via Sykube; inspired by `Minikube <https://kubernetes.io/docs/setup/minikube/>`_, `use of Sykube <https://www.sylabs.io/guides/cri/1.0/user-guide/sykube.html>`_ is included in the documentation for {Singularity} CRI.
+The implementation of a CRI for {Singularity} is the emphasis of a
+separate and distinct `open source project
+<https://github.com/sylabs/singularity-cri>`_; the implementation of
+this CRI is documented here. For the rationale conveyed through the
+architectural schematic, {Singularity} CRI's dependence upon
+{Singularity} with OCI runtime support is made clear as `an installation
+prerequisite
+<https://www.sylabs.io/guides/cri/1.0/user-guide/installation.html?highlight=oci#install-dependencies>`_.
+User-facing documentation for {Singularity} CRI details usage in a
+Kubernetes context - usage, of course, that involves orchestration of a
+{Singularity} container obtained from the `Sylabs Cloud Container
+Library <https://cloud.sylabs.io/library>`_. Because the entire
+Kubernetes-based deployment can exist within a single instance of a
+{Singularity} container, {Singularity} CRI can be easily evaluated via
+Sykube; inspired by `Minikube
+<https://kubernetes.io/docs/setup/minikube/>`_, `use of Sykube
+<https://www.sylabs.io/guides/cri/1.0/user-guide/sykube.html>`_ is
+included in the documentation for {Singularity} CRI.
 
-Documenting the implementation of an OCI-compliant runtime for {Singularity} has been the emphasis here. Although this standalone runtime can be used by end users independent of anything to do with {Singularity} and Kubernetes, the primary purpose here has been documenting it within this integrated context. In other words, by making use of the OCI runtime presented by {Singularity}, commands originating from Kubernetes (see, e.g., `Basic Usage <https://sylabs.io/guides/cri/1.0/user-guide/examples.html>`_ in the {Singularity} CRI documentation) have impact ultimately on {Singularity} containers via the CRI. {Singularity} CRI is implemented as a `gRPC <https://grpc.io/>`_ server - i.e., a persistent service available to `Kubelets <https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/>`_ (node agents). Taken together, this integration allows {Singularity} containers to be manipulated directly from Kubernetes.  
+Documenting the implementation of an OCI-compliant runtime for
+{Singularity} has been the emphasis here. Although this standalone
+runtime can be used by end users independent of anything to do with
+{Singularity} and Kubernetes, the primary purpose here has been
+documenting it within this integrated context. In other words, by making
+use of the OCI runtime presented by {Singularity}, commands originating
+from Kubernetes (see, e.g., `Basic Usage
+<https://sylabs.io/guides/cri/1.0/user-guide/examples.html>`_ in the
+{Singularity} CRI documentation) have impact ultimately on {Singularity}
+containers via the CRI. {Singularity} CRI is implemented as a `gRPC
+<https://grpc.io/>`_ server - i.e., a persistent service available to
+`Kubelets
+<https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/>`_
+(node agents). Taken together, this integration allows {Singularity}
+containers to be manipulated directly from Kubernetes.
 
+..
+   TODO Describe a workflow
 
-.. TODO Describe a workflow 
+..
+   ----------------------
 
-.. ----------------------
-.. Best Practices
-.. ----------------------
+..
+   Best Practices
 
-.. TODO - BP - umount ??? 
+..
+   ----------------------
 
+..
+   TODO - BP - umount ???
 
-.. CC's suggested workflow:
+..
+   CC's suggested workflow:
 
-.. singularity build /tmp/test.sif docker://busybox
-.. sudo singularity oci mount /tmp/test.sif /var/tmp/busy
-.. sudo singularity oci create -b /var/tmp/busy testing > /dev/null 2>&1
-.. sudo singularity oci start testing
-.. sudo singularity oci exec testing /bin/sh
-.. sudo singularity oci kill testing
-.. sudo singularity oci delete testing
-.. sudo singularity oci umount /var/tmp/busy
+..
+   singularity build /tmp/test.sif docker://busybox
+
+..
+   sudo singularity oci mount /tmp/test.sif /var/tmp/busy
+
+..
+   sudo singularity oci create -b /var/tmp/busy testing > /dev/null 2>&1
+
+..
+   sudo singularity oci start testing
+
+..
+   sudo singularity oci exec testing /bin/sh
+
+..
+   sudo singularity oci kill testing
+
+..
+   sudo singularity oci delete testing
+
+..
+   sudo singularity oci umount /var/tmp/busy

--- a/persistent_overlays.rst
+++ b/persistent_overlays.rst
@@ -41,7 +41,7 @@ Usage
 
 To use a persistent overlay, you must first have a container.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build ubuntu.sif library://ubuntu
 
@@ -60,13 +60,13 @@ or adding a EXT3 writable overlay partition to an existing SIF image.
 
 For example, to create a 1 GiB overlay image:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity overlay create --size 1024 /tmp/ext3_overlay.img
 
 To add a 1 GiB writable overlay partition to an existing SIF image:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity overlay create --size 1024 ubuntu.sif
 
@@ -82,7 +82,7 @@ need to make a directory writable by your user.
 
 So for example:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity build /tmp/nginx.sif docker://nginx
     $ singularity overlay create --size 1024 --create-dir /var/cache/nginx /tmp/nginx.sif
@@ -105,7 +105,7 @@ operations on the parallel filesystem.
 
 To create an overlay image file with 500MBs of empty space:
 
-.. code-block:: none
+.. code-block::
 
     $ dd if=/dev/zero of=overlay.img bs=1M count=500 && \
         mkfs.ext3 overlay.img
@@ -115,7 +115,7 @@ permissions still control where you can write, so ``sudo`` is needed
 to run the container as ``root`` if you need to write to ``/`` inside
 the container.
 
-.. code-block:: none
+.. code-block::
 
    $ sudo singularity shell --overlay overlay.img ubuntu.sif
 
@@ -124,7 +124,7 @@ unprivileged users you can create a directory structure on your host,
 set permissions on it as needed, and include it in the overlay with
 the ``-d`` option to ``mkfs.ext3``:
 
-.. code-block:: none
+.. code-block::
 
    $ mkdir -p overlay/upper overlay/work
    $ dd if=/dev/zero of=overlay.img bs=1M count=500 && \
@@ -134,7 +134,7 @@ Now the container will be writable as the unprivileged user who
 created the ``overlay/upper`` and ``overlay/work`` directories
 that were placed into ``overlay.img``.
 
-.. code-block:: none
+.. code-block::
 
    $ singularity shell --overlay overlay.img ubuntu.sif
    Singularity> echo $USER
@@ -167,14 +167,14 @@ transported or shared as easily as a single overlay file.
 
 Create a directory as usual:
 
-.. code-block:: none
+.. code-block::
 
     $ mkdir my_overlay
 
 
 The example below shows the directory overlay in action.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity shell --overlay my_overlay/ ubuntu.sif
 
@@ -199,7 +199,7 @@ container. This allows the read-only container image and your
 modifications to it to be managed as a single file.  In order to do
 this, you must first create a file system image:
 
-.. code-block:: none
+.. code-block::
 
     $ dd if=/dev/zero of=overlay.img bs=1M count=500 && \
         mkfs.ext3 overlay.img
@@ -207,7 +207,7 @@ this, you must first create a file system image:
 Then, you can add the overlay to the SIF image using the ``sif``
 functionality of {Singularity}.
 
-.. code-block:: none
+.. code-block::
 
    $ singularity sif add --datatype 4 --partfs 2 --parttype 4 --partarch 2 --groupid 1 ubuntu_latest.sif overlay.img
 
@@ -230,7 +230,7 @@ running ``singularity sif add --help``.
 After you've completed the steps above, you can shell into your
 container with the ``--writable`` option.
 
-.. code-block:: none
+.. code-block::
 
         $ sudo singularity shell --writable ubuntu_latest.sif
 
@@ -240,7 +240,7 @@ Final note
 You will find that your changes persist across sessions as though you
 were using a writable container.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity shell --overlay my_overlay/ ubuntu.sif
 
@@ -256,7 +256,7 @@ were using a writable container.
 If you mount your container without the ``--overlay`` directory, your changes
 will be gone.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity shell ubuntu.sif
 
@@ -272,7 +272,7 @@ images can be used.  For instance, to resize the 500MB file created
 above to 700MB one could use the ``e2fsck`` and ``resize2fs``
 utilities like so:
 
-.. code-block:: none
+.. code-block::
 
     $ e2fsck -f my_overlay && \
         resize2fs my_overlay 700M

--- a/persistent_overlays.rst
+++ b/persistent_overlays.rst
@@ -1,16 +1,15 @@
-===================
-Persistent Overlays
-===================
+#####################
+ Persistent Overlays
+#####################
 
 Persistent overlay directories allow you to overlay a writable file
 system on an immutable read-only container for the illusion of
 read-write access. You can run a container and make changes, and these
 changes are kept separately from the base container image.
 
-
---------
-Overview
---------
+**********
+ Overview
+**********
 
 A persistent overlay is a directory or file system image that “sits on
 top” of your immutable SIF container. When you install new software or
@@ -18,139 +17,141 @@ create and modify files the overlay will store the changes.
 
 If you want to use a SIF container as though it were writable, you can
 create a directory, an ext3 file system image, or embed an ext3 file
-system image in SIF to use as a persistent overlay. Then you can
-specify that you want to use the directory or image as an overlay at
-runtime with the ``--overlay`` option, or ``--writable`` if you want
-to use the overlay embedded in SIF.
+system image in SIF to use as a persistent overlay. Then you can specify
+that you want to use the directory or image as an overlay at runtime
+with the ``--overlay`` option, or ``--writable`` if you want to use the
+overlay embedded in SIF.
 
 If you want to make changes to the image, but do not want them to
-persist, use the ``--writable-tmpfs`` option. This stores all changes
-in an in-memory temporary filesystem which is discarded as soon as
-the container finishes executing.
+persist, use the ``--writable-tmpfs`` option. This stores all changes in
+an in-memory temporary filesystem which is discarded as soon as the
+container finishes executing.
 
 You can use persistent overlays with the following commands:
 
-- ``run``
-- ``exec``
-- ``shell``
-- ``instance.start``
+-  ``run``
+-  ``exec``
+-  ``shell``
+-  ``instance.start``
 
------
-Usage
------
+*******
+ Usage
+*******
 
 To use a persistent overlay, you must first have a container.
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build ubuntu.sif library://ubuntu
+   $ sudo singularity build ubuntu.sif library://ubuntu
 
 File system image overlay
 =========================
 
-Since 3.8, {Singularity} provides a command ``singularity overlay create`` to
-create persistent overlay images. You can create a single EXT3 overlay image
-or adding a EXT3 writable overlay partition to an existing SIF image.
+Since 3.8, {Singularity} provides a command ``singularity overlay
+create`` to create persistent overlay images. You can create a single
+EXT3 overlay image or adding a EXT3 writable overlay partition to an
+existing SIF image.
 
 .. note::
 
-    ``dd`` and ``mkfs.ext3`` must be installed on your system. Additionally
-    ``mkfs.ext3`` must support ``-d`` option in order to create an overlay
-    directory tree usable by a regular user.
+   ``dd`` and ``mkfs.ext3`` must be installed on your system.
+   Additionally ``mkfs.ext3`` must support ``-d`` option in order to
+   create an overlay directory tree usable by a regular user.
 
 For example, to create a 1 GiB overlay image:
 
-.. code-block::
+.. code::
 
-    $ singularity overlay create --size 1024 /tmp/ext3_overlay.img
+   $ singularity overlay create --size 1024 /tmp/ext3_overlay.img
 
 To add a 1 GiB writable overlay partition to an existing SIF image:
 
-.. code-block::
+.. code::
 
-    $ singularity overlay create --size 1024 ubuntu.sif
+   $ singularity overlay create --size 1024 ubuntu.sif
 
 .. warning::
 
-    It is not possible to add a writable overlay partition to a **signed**, **encrypted**
-    SIF image or if the SIF image already contain a writable overlay partition.
+   It is not possible to add a writable overlay partition to a
+   **signed**, **encrypted** SIF image or if the SIF image already
+   contain a writable overlay partition.
 
 ``singularity overlay create`` also provides an option ``--create-dir``
-to create additional directories owned by the calling user, it can be specified
-multiple times to create many directories. This is particularly useful when you
-need to make a directory writable by your user.
+to create additional directories owned by the calling user, it can be
+specified multiple times to create many directories. This is
+particularly useful when you need to make a directory writable by your
+user.
 
 So for example:
 
-.. code-block::
+.. code::
 
-    $ singularity build /tmp/nginx.sif docker://nginx
-    $ singularity overlay create --size 1024 --create-dir /var/cache/nginx /tmp/nginx.sif
-    $ echo "test" | singularity exec /tmp/nginx.sif sh -c "cat > /var/cache/nginx/test"
+   $ singularity build /tmp/nginx.sif docker://nginx
+   $ singularity overlay create --size 1024 --create-dir /var/cache/nginx /tmp/nginx.sif
+   $ echo "test" | singularity exec /tmp/nginx.sif sh -c "cat > /var/cache/nginx/test"
 
 Create an overlay image (< 3.8)
 -------------------------------
 
-You can use tools like ``dd`` and ``mkfs.ext3`` to create and format
-an empty ext3 file system image, which holds all changes made in your
+You can use tools like ``dd`` and ``mkfs.ext3`` to create and format an
+empty ext3 file system image, which holds all changes made in your
 container within a single file. Using an overlay image file makes it
 easy to transport your modifications as a single additional file
 alongside the original SIF container image.
 
-Workloads that write a very large number of small files into an
-overlay image, rather than a directory, are also faster on HPC
-parallel filesystems. Each write is a local operation within the
-single open image file, and does not cause additional metadata
-operations on the parallel filesystem.
+Workloads that write a very large number of small files into an overlay
+image, rather than a directory, are also faster on HPC parallel
+filesystems. Each write is a local operation within the single open
+image file, and does not cause additional metadata operations on the
+parallel filesystem.
 
 To create an overlay image file with 500MBs of empty space:
 
-.. code-block::
+.. code::
 
-    $ dd if=/dev/zero of=overlay.img bs=1M count=500 && \
-        mkfs.ext3 overlay.img
+   $ dd if=/dev/zero of=overlay.img bs=1M count=500 && \
+       mkfs.ext3 overlay.img
 
 Now you can use this overlay with your container, though filesystem
-permissions still control where you can write, so ``sudo`` is needed
-to run the container as ``root`` if you need to write to ``/`` inside
-the container.
+permissions still control where you can write, so ``sudo`` is needed to
+run the container as ``root`` if you need to write to ``/`` inside the
+container.
 
-.. code-block::
+.. code::
 
    $ sudo singularity shell --overlay overlay.img ubuntu.sif
 
 To manage permissions in the overlay, so the container is writable by
 unprivileged users you can create a directory structure on your host,
-set permissions on it as needed, and include it in the overlay with
-the ``-d`` option to ``mkfs.ext3``:
+set permissions on it as needed, and include it in the overlay with the
+``-d`` option to ``mkfs.ext3``:
 
-.. code-block::
+.. code::
 
    $ mkdir -p overlay/upper overlay/work
    $ dd if=/dev/zero of=overlay.img bs=1M count=500 && \
         mkfs.ext3 -d overlay overlay.img
 
-Now the container will be writable as the unprivileged user who
-created the ``overlay/upper`` and ``overlay/work`` directories
-that were placed into ``overlay.img``.
+Now the container will be writable as the unprivileged user who created
+the ``overlay/upper`` and ``overlay/work`` directories that were placed
+into ``overlay.img``.
 
-.. code-block::
+.. code::
 
    $ singularity shell --overlay overlay.img ubuntu.sif
    Singularity> echo $USER
    dtrudg
    Singularity> echo "Hello" > /hello
-                
+
 .. note::
 
    The ``-d`` option to ``mkfs.ext3`` does not support ``uid`` or
    ``gid`` values >65535. To allow writes from users with larger uids
    you can create the directories for your overlay with open
-   permissions, e.g. ``mkdir -p -m 777 overlay/upper overlay/work``. At runtime
-   files and directories created in the overlay will have the correct
-   ``uid`` and ``gid``, but it is not possible to lock down
+   permissions, e.g. ``mkdir -p -m 777 overlay/upper overlay/work``. At
+   runtime files and directories created in the overlay will have the
+   correct ``uid`` and ``gid``, but it is not possible to lock down
    permissions so that the overlay is only writable by certain users.
-   
 
 Directory overlay
 =================
@@ -161,68 +162,68 @@ transported or shared as easily as a single overlay file.
 
 .. note::
 
-    For security reasons, you must be root to use a bare directory as an
-    overlay. ext3 file system images can be used as overlays without root
-    privileges.
+   For security reasons, you must be root to use a bare directory as an
+   overlay. ext3 file system images can be used as overlays without root
+   privileges.
 
 Create a directory as usual:
 
-.. code-block::
+.. code::
 
-    $ mkdir my_overlay
-
+   $ mkdir my_overlay
 
 The example below shows the directory overlay in action.
 
-.. code-block::
+.. code::
 
-    $ sudo singularity shell --overlay my_overlay/ ubuntu.sif
+   $ sudo singularity shell --overlay my_overlay/ ubuntu.sif
 
-    {Singularity} ubuntu.sif:~> mkdir /data
+   {Singularity} ubuntu.sif:~> mkdir /data
 
-    {Singularity} ubuntu.sif:~> chown user /data
+   {Singularity} ubuntu.sif:~> chown user /data
 
-    {Singularity} ubuntu.sif:~> apt-get update && apt-get install -y vim
+   {Singularity} ubuntu.sif:~> apt-get update && apt-get install -y vim
 
-    {Singularity} ubuntu.sif:~> which vim
-    /usr/bin/vim
+   {Singularity} ubuntu.sif:~> which vim
+   /usr/bin/vim
 
-    {Singularity} ubuntu.sif:~> exit
+   {Singularity} ubuntu.sif:~> exit
 
 .. _overlay-sif:
-    
+
 Overlay embedded in SIF
 =======================
 
 It is possible to embed an overlay image in the SIF file that holds a
 container. This allows the read-only container image and your
-modifications to it to be managed as a single file.  In order to do
-this, you must first create a file system image:
+modifications to it to be managed as a single file. In order to do this,
+you must first create a file system image:
 
-.. code-block::
+.. code::
 
-    $ dd if=/dev/zero of=overlay.img bs=1M count=500 && \
-        mkfs.ext3 overlay.img
+   $ dd if=/dev/zero of=overlay.img bs=1M count=500 && \
+       mkfs.ext3 overlay.img
 
 Then, you can add the overlay to the SIF image using the ``sif``
 functionality of {Singularity}.
 
-.. code-block::
+.. code::
 
    $ singularity sif add --datatype 4 --partfs 2 --parttype 4 --partarch 2 --groupid 1 ubuntu_latest.sif overlay.img
 
-Below is the explanation what each parameter means, and how it can possibly affect the operation:
+Below is the explanation what each parameter means, and how it can
+possibly affect the operation:
 
-- ``datatype`` determines what kind of an object we attach, e.g. a
-  definition file, environment variable, signature.
-- ``partfs`` should be set according to the partition type,
-  e.g. SquashFS, ext3, raw.
-- ``parttype`` determines the type of partition. In our case it is
-  being set to overlay.
-- ``partarch`` must be set to the architecture against you're
-  building. In this case it's ``amd64``.
-- ``groupid`` is the ID of the container image group. In most cases
-  there's no more than one group, therefore we can assume it is 1.
+-  ``datatype`` determines what kind of an object we attach, e.g. a
+   definition file, environment variable, signature.
+-  ``partfs`` should be set according to the partition type, e.g.
+   SquashFS, ext3, raw.
+-  ``parttype`` determines the type of partition. In our case it is
+   being set to overlay.
+-  ``partarch`` must be set to the architecture against you're building.
+   In this case it's ``amd64``.
+-  ``groupid`` is the ID of the container image group. In most cases
+   there's no more than one group, therefore we can assume it is 1.
 
 All of these options are documented within the CLI help. Access it by
 running ``singularity sif add --help``.
@@ -230,9 +231,9 @@ running ``singularity sif add --help``.
 After you've completed the steps above, you can shell into your
 container with the ``--writable`` option.
 
-.. code-block::
+.. code::
 
-        $ sudo singularity shell --writable ubuntu_latest.sif
+   $ sudo singularity shell --writable ubuntu_latest.sif
 
 Final note
 ==========
@@ -240,43 +241,40 @@ Final note
 You will find that your changes persist across sessions as though you
 were using a writable container.
 
-.. code-block::
+.. code::
 
-    $ singularity shell --overlay my_overlay/ ubuntu.sif
+   $ singularity shell --overlay my_overlay/ ubuntu.sif
 
-    {Singularity} ubuntu.sif:~> ls -lasd /data
-    4 drwxr-xr-x 2 user root 4096 Apr  9 10:21 /data
+   {Singularity} ubuntu.sif:~> ls -lasd /data
+   4 drwxr-xr-x 2 user root 4096 Apr  9 10:21 /data
 
-    {Singularity} ubuntu.sif:~> which vim
-    /usr/bin/vim
+   {Singularity} ubuntu.sif:~> which vim
+   /usr/bin/vim
 
-    {Singularity} ubuntu.sif:~> exit
+   {Singularity} ubuntu.sif:~> exit
 
+If you mount your container without the ``--overlay`` directory, your
+changes will be gone.
 
-If you mount your container without the ``--overlay`` directory, your changes
-will be gone.
+.. code::
 
-.. code-block::
+   $ singularity shell ubuntu.sif
 
-    $ singularity shell ubuntu.sif
+   {Singularity} ubuntu.sif:~> ls /data
+   ls: cannot access 'data': No such file or directory
 
-    {Singularity} ubuntu.sif:~> ls /data
-    ls: cannot access 'data': No such file or directory
+   {Singularity} ubuntu.sif:~> which vim
 
-    {Singularity} ubuntu.sif:~> which vim
+   {Singularity} ubuntu.sif:~> exit
 
-    {Singularity} ubuntu.sif:~> exit
+To resize an overlay, standard Linux tools which manipulate ext3 images
+can be used. For instance, to resize the 500MB file created above to
+700MB one could use the ``e2fsck`` and ``resize2fs`` utilities like so:
 
-To resize an overlay, standard Linux tools which manipulate ext3
-images can be used.  For instance, to resize the 500MB file created
-above to 700MB one could use the ``e2fsck`` and ``resize2fs``
-utilities like so:
+.. code::
 
-.. code-block::
+   $ e2fsck -f my_overlay && \
+       resize2fs my_overlay 700M
 
-    $ e2fsck -f my_overlay && \
-        resize2fs my_overlay 700M
-
-Hints for creating and manipulating ext3 images on your distribution
-are readily available online and are not treated further in this
-manual.
+Hints for creating and manipulating ext3 images on your distribution are
+readily available online and are not treated further in this manual.

--- a/plugins.rst
+++ b/plugins.rst
@@ -20,7 +20,7 @@ Using Plugins
 
 The ``list`` command prints the currently installed plugins.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity plugin list
     There are no plugins installed.
@@ -31,14 +31,14 @@ source code of their plugins. A plugin can be compiled from its source code
 with the ``compile`` command. A sample plugin ``test-plugin`` is included with
 the {Singularity} source code.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity plugin compile examples/plugins/test-plugin/
 
 Upon successful compilation, a SIF file will appear in the directory of the
 plugin's source code.
 
-.. code-block:: none
+.. code-block::
 
     $ ls examples/plugins/test-plugin/ | grep sif
     test-plugin.sif
@@ -65,7 +65,7 @@ Every plugin encapsulates various information such as the plugin's author, the
 plugin's version, etc. To view this information about a plugin, use the
 ``inspect`` command.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity plugin inspect examples/plugins/test-plugin/test-plugin.sif
     Name: sylabs.io/test-plugin
@@ -76,7 +76,7 @@ plugin's version, etc. To view this information about a plugin, use the
 To install a plugin, use the ``install`` command. This operation requires root
 privilege.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity plugin install examples/plugins/test-plugin/test-plugin.sif
     $ singularity plugin list
@@ -87,7 +87,7 @@ After successful installation, the plugin will automatically be enabled. Any
 plugin can be disabled with the ``disable`` command and re-enabled with the
 ``enable`` command. Both of these operations require root privilege.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity plugin disable sylabs.io/test-plugin
     $ singularity plugin list
@@ -101,7 +101,7 @@ plugin can be disabled with the ``disable`` command and re-enabled with the
 Finally, to uninstall a plugin, use the ``uninstall`` command. This operation
 requires root privilege.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity plugin uninstall sylabs.io/test-plugin
     Uninstalled plugin "sylabs.io/test-plugin".

--- a/plugins.rst
+++ b/plugins.rst
@@ -1,122 +1,127 @@
 .. _plugins:
 
-=======
-Plugins
-=======
+#########
+ Plugins
+#########
 
---------
-Overview
---------
+**********
+ Overview
+**********
 
-A {Singularity} plugin is a package that can be dynamically loaded by the
-{Singularity} runtime, augmenting {Singularity} with experimental, non-standard
-and/or vendor-specific functionality. Currently, plugins are able to add
-commands and flags to {Singularity}. In the future, plugins will also be able to
-interface with more complex subsystems of the {Singularity} runtime.
+A {Singularity} plugin is a package that can be dynamically loaded by
+the {Singularity} runtime, augmenting {Singularity} with experimental,
+non-standard and/or vendor-specific functionality. Currently, plugins
+are able to add commands and flags to {Singularity}. In the future,
+plugins will also be able to interface with more complex subsystems of
+the {Singularity} runtime.
 
--------------
-Using Plugins
--------------
+***************
+ Using Plugins
+***************
 
 The ``list`` command prints the currently installed plugins.
 
-.. code-block::
+.. code::
 
-    $ singularity plugin list
-    There are no plugins installed.
+   $ singularity plugin list
+   There are no plugins installed.
 
-Plugins are packaged and distributed as binaries encoded with the versatile
-Singularity Image Format (SIF). However, plugin authors may also distribute the
-source code of their plugins. A plugin can be compiled from its source code
-with the ``compile`` command. A sample plugin ``test-plugin`` is included with
-the {Singularity} source code.
+Plugins are packaged and distributed as binaries encoded with the
+versatile Singularity Image Format (SIF). However, plugin authors may
+also distribute the source code of their plugins. A plugin can be
+compiled from its source code with the ``compile`` command. A sample
+plugin ``test-plugin`` is included with the {Singularity} source code.
 
-.. code-block::
+.. code::
 
-    $ singularity plugin compile examples/plugins/test-plugin/
+   $ singularity plugin compile examples/plugins/test-plugin/
 
-Upon successful compilation, a SIF file will appear in the directory of the
-plugin's source code.
+Upon successful compilation, a SIF file will appear in the directory of
+the plugin's source code.
 
-.. code-block::
+.. code::
 
-    $ ls examples/plugins/test-plugin/ | grep sif
-    test-plugin.sif
+   $ ls examples/plugins/test-plugin/ | grep sif
+   test-plugin.sif
 
 .. note::
 
-    Currently, **all** plugins must be compiled from the {Singularity} source
-    code tree.
+   Currently, **all** plugins must be compiled from the {Singularity}
+   source code tree.
 
-    Also, the plugins mechanism for the Go language that {Singularity} is written
-    in is quite restrictive - it requires extremely close version matching of
-    packages used in a plugin to the ones used in the program the plugin is
-    built for. Additionally {Singularity} is using build time config to get the
-    source tree location for ``singularity plugin compile`` so that you don't
-    need to export environment variables etc, and there isn't mismatch between
-    package path information that Go uses.  This means that at present you must:
+   Also, the plugins mechanism for the Go language that {Singularity} is
+   written in is quite restrictive - it requires extremely close version
+   matching of packages used in a plugin to the ones used in the program
+   the plugin is built for. Additionally {Singularity} is using build
+   time config to get the source tree location for ``singularity plugin
+   compile`` so that you don't need to export environment variables etc,
+   and there isn't mismatch between package path information that Go
+   uses. This means that at present you must:
 
-    * Build plugins using the exact same version of the source code, in the
-      same location, as was used to build the {Singularity} executable.
-    * Use the exact same version of Go that was used to build the executable
-      when compiling a plugin for it.
+   -  Build plugins using the exact same version of the source code, in
+      the same location, as was used to build the {Singularity}
+      executable.
 
-Every plugin encapsulates various information such as the plugin's author, the
-plugin's version, etc. To view this information about a plugin, use the
-``inspect`` command.
+   -  Use the exact same version of Go that was used to build the
+      executable when compiling a plugin for it.
 
-.. code-block::
+Every plugin encapsulates various information such as the plugin's
+author, the plugin's version, etc. To view this information about a
+plugin, use the ``inspect`` command.
 
-    $ singularity plugin inspect examples/plugins/test-plugin/test-plugin.sif
-    Name: sylabs.io/test-plugin
-    Description: This is a short test plugin for {Singularity}
-    Author: Michael Bauer
-    Version: 0.0.1
+.. code::
 
-To install a plugin, use the ``install`` command. This operation requires root
-privilege.
+   $ singularity plugin inspect examples/plugins/test-plugin/test-plugin.sif
+   Name: sylabs.io/test-plugin
+   Description: This is a short test plugin for {Singularity}
+   Author: Michael Bauer
+   Version: 0.0.1
 
-.. code-block::
-
-    $ sudo singularity plugin install examples/plugins/test-plugin/test-plugin.sif
-    $ singularity plugin list
-    ENABLED  NAME
-        yes  sylabs.io/test-plugin
-
-After successful installation, the plugin will automatically be enabled. Any
-plugin can be disabled with the ``disable`` command and re-enabled with the
-``enable`` command. Both of these operations require root privilege.
-
-.. code-block::
-
-    $ sudo singularity plugin disable sylabs.io/test-plugin
-    $ singularity plugin list
-    ENABLED  NAME
-         no  sylabs.io/test-plugin
-    $ sudo singularity plugin enable sylabs.io/test-plugin
-    $ singularity plugin list
-    ENABLED  NAME
-        yes  sylabs.io/test-plugin
-
-Finally, to uninstall a plugin, use the ``uninstall`` command. This operation
+To install a plugin, use the ``install`` command. This operation
 requires root privilege.
 
-.. code-block::
+.. code::
 
-    $ sudo singularity plugin uninstall sylabs.io/test-plugin
-    Uninstalled plugin "sylabs.io/test-plugin".
-    $ singularity plugin list
-    There are no plugins installed.
+   $ sudo singularity plugin install examples/plugins/test-plugin/test-plugin.sif
+   $ singularity plugin list
+   ENABLED  NAME
+       yes  sylabs.io/test-plugin
 
-----------------
-Writing a Plugin
-----------------
+After successful installation, the plugin will automatically be enabled.
+Any plugin can be disabled with the ``disable`` command and re-enabled
+with the ``enable`` command. Both of these operations require root
+privilege.
 
-Developers interested in writing {Singularity} plugins can get started by reading
-the `Go documentation
-<https://godoc.org/github.com/sylabs/singularity/pkg/plugin>`_ for the plugin
-package. Furthermore, reading through the `source code
+.. code::
+
+   $ sudo singularity plugin disable sylabs.io/test-plugin
+   $ singularity plugin list
+   ENABLED  NAME
+        no  sylabs.io/test-plugin
+   $ sudo singularity plugin enable sylabs.io/test-plugin
+   $ singularity plugin list
+   ENABLED  NAME
+       yes  sylabs.io/test-plugin
+
+Finally, to uninstall a plugin, use the ``uninstall`` command. This
+operation requires root privilege.
+
+.. code::
+
+   $ sudo singularity plugin uninstall sylabs.io/test-plugin
+   Uninstalled plugin "sylabs.io/test-plugin".
+   $ singularity plugin list
+   There are no plugins installed.
+
+******************
+ Writing a Plugin
+******************
+
+Developers interested in writing {Singularity} plugins can get started
+by reading the `Go documentation
+<https://godoc.org/github.com/sylabs/singularity/pkg/plugin>`_ for the
+plugin package. Furthermore, reading through the `source code
 <https://github.com/hpcng/singularity/tree/master/examples/plugins>`_
 for the example plugins will prove valuable. More detailed plugin
-development documentation is in the works and will be released at a future
-date.
+development documentation is in the works and will be released at a
+future date.

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -758,10 +758,10 @@ similar to this:
    learn more about {Singularity}, I thought these items might be of interest:
 
        - Security: A discussion of security concerns is discussed at
-       \{admindocs\}/admin_quickstart.html
+       {admindocs}/admin_quickstart.html
 
        - Installation:
-       \{admindocs\}/installation.html
+       {admindocs}/installation.html
 
    If you have questions about any of the above, you can contact one of the
    sources listed at https://singularity.hpcng.org/help. I can do my best

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -1,17 +1,17 @@
 .. _quick-start:
 
-===========
-Quick Start
-===========
+#############
+ Quick Start
+#############
 
 .. _sec:quickstart:
 
 This guide is intended for running {Singularity} on a computer where you
 have root (administrative) privileges, and will install {Singularity}
-from source code. Other installation options, including building an
-RPM package and installing {Singularity} without root privileges are
+from source code. Other installation options, including building an RPM
+package and installing {Singularity} without root privileges are
 discussed in the `installation section of the admin guide
-<\{admindocs\}/installation.html>`__.
+<{admindocs}/installation.html>`__.
 
 If you need to request an installation on your shared resource, see the
 :ref:`requesting an installation section <installation-request>` for
@@ -20,18 +20,17 @@ information to send to your system administrator.
 For any additional help or support contact the Singularity Community:
 https://singularity.hpcng.org/help
 
-
 .. _quick-installation:
 
-------------------------
-Quick Installation Steps
-------------------------
+**************************
+ Quick Installation Steps
+**************************
 
 You will need a Linux system to run {Singularity} natively. Options for
 using {Singularity} on Mac and Windows machines, along with alternate
-Linux installation options are discussed in the `installation section of the
-admin guide
-<\{admindocs\}/installation.html>`__.
+Linux installation options are discussed in the `installation section of
+the admin guide
+<{admindocs}/installation.html>`__.
 
 Install system dependencies
 ===========================
@@ -69,9 +68,9 @@ On CentOS/RHEL:
 
 There are 3 broad steps to installing {Singularity}:
 
-1. :ref:`Installing Go <install>`
-2. :ref:`Downloading {Singularity} <download>`
-3. :ref:`Compiling {Singularity} Source Code <compile>`
+#. :ref:`Installing Go <install>`
+#. :ref:`Downloading {Singularity} <download>`
+#. :ref:`Compiling {Singularity} Source Code <compile>`
 
 .. _install:
 
@@ -102,653 +101,674 @@ binary copy of Go as follows.
    If you have previously installed Go from a download, rather than an
    operating system package, you should remove your ``go`` directory,
    e.g. ``rm -r /usr/local/go`` before installing a newer version.
-   Extracting a new version of Go over an existing installation can
-   lead to errors when building Go programs, as it may leave old
-   files, which have been removed or replaced in newer versions.
+   Extracting a new version of Go over an existing installation can lead
+   to errors when building Go programs, as it may leave old files, which
+   have been removed or replaced in newer versions.
 
-Visit the `Go Downloads page <https://golang.org/dl/>`_ and pick a package
-archive suitable to the environment you are in. Once the Download is complete,
-extract the archive to ``/usr/local`` (or use other instructions on go installation
-page). Alternatively, follow the commands here:
+Visit the `Go Downloads page <https://golang.org/dl/>`_ and pick a
+package archive suitable to the environment you are in. Once the
+Download is complete, extract the archive to ``/usr/local`` (or use
+other instructions on go installation page). Alternatively, follow the
+commands here:
 
-.. code-block::
+.. code::
 
-    $ export VERSION=1.17.5 OS=linux ARCH=amd64 && \  # Replace the values as needed
-      wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \ # Downloads the required Go package
-      sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \ # Extracts the archive
-      rm go$VERSION.$OS-$ARCH.tar.gz    # Deletes the ``tar`` file
+   $ export VERSION=1.17.5 OS=linux ARCH=amd64 && \  # Replace the values as needed
+     wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \ # Downloads the required Go package
+     sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \ # Extracts the archive
+     rm go$VERSION.$OS-$ARCH.tar.gz    # Deletes the ``tar`` file
 
 Set the Environment variable ``PATH`` to point to Go:
 
-.. code-block::
+.. code::
 
-    $ echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.bashrc && \
-      source ~/.bashrc
+   $ echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.bashrc && \
+     source ~/.bashrc
 
 .. _download:
 
 Download {Singularity} from a release
 =====================================
 
-You can download {Singularity} from one of the releases. To see a full list, visit
-`the GitHub release page <https://github.com/hpcng/singularity/releases>`_.
-After deciding on a release to install, you can run the following commands to
-proceed with the installation.
+You can download {Singularity} from one of the releases. To see a full
+list, visit `the GitHub release page
+<https://github.com/hpcng/singularity/releases>`_. After deciding on a
+release to install, you can run the following commands to proceed with
+the installation.
 
-.. code-block::
+.. code::
 
-    $ export VERSION={InstallationVersion} && # adjust this as necessary \
-        wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
-        tar -xzf singularity-${VERSION}.tar.gz && \
-        cd singularity-${VERSION}
+   $ export VERSION={InstallationVersion} && # adjust this as necessary \
+       wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
+       tar -xzf singularity-${VERSION}.tar.gz && \
+       cd singularity-${VERSION}
 
 .. _compile:
 
 Compile the {Singularity} source code
 =====================================
 
-Now you are ready to build {Singularity}. Dependencies will be automatically
-downloaded. You can build {Singularity} using the following commands:
+Now you are ready to build {Singularity}. Dependencies will be
+automatically downloaded. You can build {Singularity} using the
+following commands:
 
-.. code-block::
+.. code::
 
-    $ ./mconfig && \
-        make -C builddir && \
-        sudo make -C builddir install
+   $ ./mconfig && \
+       make -C builddir && \
+       sudo make -C builddir install
 
 {Singularity} must be installed as root to function properly.
 
----------------------------------------
-Overview of the {Singularity} Interface
----------------------------------------
+*****************************************
+ Overview of the {Singularity} Interface
+*****************************************
 
 {Singularity}’s :ref:`command line interface <cli>` allows you to build
-and interact with containers transparently. You can run programs inside a
-container as if they were running on your host system. You can easily redirect
-IO, use pipes, pass arguments, and access files, sockets, and ports on the host
-system from within a container.
+and interact with containers transparently. You can run programs inside
+a container as if they were running on your host system. You can easily
+redirect IO, use pipes, pass arguments, and access files, sockets, and
+ports on the host system from within a container.
 
-The ``help`` command gives an overview of {Singularity} options and subcommands as
-follows:
+The ``help`` command gives an overview of {Singularity} options and
+subcommands as follows:
 
-.. code-block::
+.. code::
 
-    $ singularity help
+   $ singularity help
 
-    Linux container platform optimized for High Performance Computing (HPC) and
-    Enterprise Performance Computing (EPC)
+   Linux container platform optimized for High Performance Computing (HPC) and
+   Enterprise Performance Computing (EPC)
 
-    Usage:
-      singularity [global options...]
+   Usage:
+     singularity [global options...]
 
-    Description:
-      {Singularity} containers provide an application virtualization layer enabling
-      mobility of compute via both application and environment portability. With
-      {Singularity} one is capable of building a root file system that runs on any
-      other Linux system where {Singularity} is installed.
+   Description:
+     {Singularity} containers provide an application virtualization layer enabling
+     mobility of compute via both application and environment portability. With
+     {Singularity} one is capable of building a root file system that runs on any
+     other Linux system where {Singularity} is installed.
 
-    Options:
-      -d, --debug     print debugging information (highest verbosity)
-      -h, --help      help for singularity
-          --nocolor   print without color output (default False)
-      -q, --quiet     suppress normal output
-      -s, --silent    only print errors
-      -v, --verbose   print additional information
+   Options:
+     -d, --debug     print debugging information (highest verbosity)
+     -h, --help      help for singularity
+         --nocolor   print without color output (default False)
+     -q, --quiet     suppress normal output
+     -s, --silent    only print errors
+     -v, --verbose   print additional information
 
-    Available Commands:
-      build       Build a {Singularity} image
-      cache       Manage the local cache
-      capability  Manage Linux capabilities for users and groups
-      exec        Run a command within a container
-      help        Help about any command
-      inspect     Show metadata for an image
-      instance    Manage containers running as services
-      key         Manage OpenPGP keys
-      oci         Manage OCI containers
-      plugin      Manage singularity plugins
-      pull        Pull an image from a URI
-      push        Upload image to the provided library (default is "cloud.sylabs.io")
-      remote      Manage singularity remote endpoints
-      run         Run the user-defined default command within a container
-      run-help    Show the user-defined help for an image
-      search      Search a Container Library for images
-      shell       Run a shell within a container
-      sif         siftool is a program for Singularity Image Format (SIF) file manipulation
-      sign        Attach a cryptographic signature to an image
-      test        Run the user-defined tests within a container
-      verify      Verify cryptographic signatures attached to an image
-      version     Show the version for {Singularity}
+   Available Commands:
+     build       Build a {Singularity} image
+     cache       Manage the local cache
+     capability  Manage Linux capabilities for users and groups
+     exec        Run a command within a container
+     help        Help about any command
+     inspect     Show metadata for an image
+     instance    Manage containers running as services
+     key         Manage OpenPGP keys
+     oci         Manage OCI containers
+     plugin      Manage singularity plugins
+     pull        Pull an image from a URI
+     push        Upload image to the provided library (default is "cloud.sylabs.io")
+     remote      Manage singularity remote endpoints
+     run         Run the user-defined default command within a container
+     run-help    Show the user-defined help for an image
+     search      Search a Container Library for images
+     shell       Run a shell within a container
+     sif         siftool is a program for Singularity Image Format (SIF) file manipulation
+     sign        Attach a cryptographic signature to an image
+     test        Run the user-defined tests within a container
+     verify      Verify cryptographic signatures attached to an image
+     version     Show the version for {Singularity}
 
-    Examples:
-      $ singularity help <command> [<subcommand>]
-      $ singularity help build
-      $ singularity help instance start
-
-
-    For additional help or support, please visit https://www.sylabs.io/docs/
+   Examples:
+     $ singularity help <command> [<subcommand>]
+     $ singularity help build
+     $ singularity help instance start
 
 
-Information about subcommand can also be viewed with the ``help`` command.
+   For additional help or support, please visit https://www.sylabs.io/docs/
 
-.. code-block::
+Information about subcommand can also be viewed with the ``help``
+command.
 
-    $ singularity help verify
-    Verify cryptographic signatures attached to an image
+.. code::
 
-    Usage:
-      singularity verify [verify options...] <image path>
+   $ singularity help verify
+   Verify cryptographic signatures attached to an image
 
-    Description:
-      The verify command allows a user to verify cryptographic signatures on SIF 
-      container files. There may be multiple signatures for data objects and 
-      multiple data objects signed. By default the command searches for the primary 
-      partition signature. If found, a list of all verification blocks applied on 
-      the primary partition is gathered so that data integrity (hashing) and 
-      signature verification is done for all those blocks.
+   Usage:
+     singularity verify [verify options...] <image path>
 
-    Options:
-      -a, --all               verify all objects
-      -g, --group-id uint32   verify objects with the specified group ID
-      -h, --help              help for verify
-      -j, --json              output json
-          --legacy-insecure   enable verification of (insecure) legacy signatures
-      -l, --local             only verify with local keys
-      -i, --sif-id uint32     verify object with the specified ID
-      -u, --url string        key server URL (default "https://keys.sylabs.io")
+   Description:
+     The verify command allows a user to verify cryptographic signatures on SIF
+     container files. There may be multiple signatures for data objects and
+     multiple data objects signed. By default the command searches for the primary
+     partition signature. If found, a list of all verification blocks applied on
+     the primary partition is gathered so that data integrity (hashing) and
+     signature verification is done for all those blocks.
 
-
-    Examples:
-      $ singularity verify container.sif
-
-
-    For additional help or support, please visit https://www.sylabs.io/docs/
+   Options:
+     -a, --all               verify all objects
+     -g, --group-id uint32   verify objects with the specified group ID
+     -h, --help              help for verify
+     -j, --json              output json
+         --legacy-insecure   enable verification of (insecure) legacy signatures
+     -l, --local             only verify with local keys
+     -i, --sif-id uint32     verify object with the specified ID
+     -u, --url string        key server URL (default "https://keys.sylabs.io")
 
 
-{Singularity} uses positional syntax (i.e. the order of commands and options
-matters). Global options affecting the behavior of all commands follow the main
-``singularity`` command. Then sub commands are followed by their options
-and arguments.
+   Examples:
+     $ singularity verify container.sif
 
-For example, to pass the ``--debug`` option to the main ``singularity`` command
-and run {Singularity} with debugging messages on:
 
-.. code-block::
+   For additional help or support, please visit https://www.sylabs.io/docs/
 
-    $ singularity --debug run library://lolcow
+{Singularity} uses positional syntax (i.e. the order of commands and
+options matters). Global options affecting the behavior of all commands
+follow the main ``singularity`` command. Then sub commands are followed
+by their options and arguments.
+
+For example, to pass the ``--debug`` option to the main ``singularity``
+command and run {Singularity} with debugging messages on:
+
+.. code::
+
+   $ singularity --debug run library://lolcow
 
 To pass the ``--containall`` option to the ``run`` command and run a
 {Singularity} image in an isolated manner:
 
-.. code-block::
+.. code::
 
-    $ singularity run --containall library://lolcow
+   $ singularity run --containall library://lolcow
 
-{Singularity} 2.4 introduced the concept of command groups. For instance, to list
-Linux capabilities for a particular user, you would use the  ``list`` command in
-the ``capability`` command group like so:
+{Singularity} 2.4 introduced the concept of command groups. For
+instance, to list Linux capabilities for a particular user, you would
+use the ``list`` command in the ``capability`` command group like so:
 
-.. code-block::
+.. code::
 
-    $ singularity capability list dave
+   $ singularity capability list dave
 
-Container authors might also write help docs specific to a container or for an
-internal module called an ``app``. If those help docs exist for a particular
-container, you can view them like so.
+Container authors might also write help docs specific to a container or
+for an internal module called an ``app``. If those help docs exist for a
+particular container, you can view them like so.
 
-.. code-block::
+.. code::
 
-    $ singularity inspect --helpfile container.sif  # See the container's help, if provided
+   $ singularity inspect --helpfile container.sif  # See the container's help, if provided
 
-    $ singularity inspect --helpfile --app=foo foo.sif  # See the help for foo, if provided
+   $ singularity inspect --helpfile --app=foo foo.sif  # See the help for foo, if provided
 
--------------------------
-Download pre-built images
--------------------------
+***************************
+ Download pre-built images
+***************************
 
 You can use the ``search`` command to locate groups, collections, and
-containers of interest on the `Container Library <https://cloud.sylabs.io/library>`_ .
+containers of interest on the `Container Library
+<https://cloud.sylabs.io/library>`_ .
 
-.. code-block::
+.. code::
 
-    singularity search tensorflow
-    Found 22 container images for amd64 matching "tensorflow":
+   singularity search tensorflow
+   Found 22 container images for amd64 matching "tensorflow":
 
-	library://ajgreen/default/tensorflow2-gpu-py3-r-jupyter:latest
-		Current software: tensorflow2; py3.7; r; jupyterlab1.2.6
-		Signed by: 1B8565093D80FA393BC2BD73EA4711C01D881FCB
+       library://ajgreen/default/tensorflow2-gpu-py3-r-jupyter:latest
+               Current software: tensorflow2; py3.7; r; jupyterlab1.2.6
+               Signed by: 1B8565093D80FA393BC2BD73EA4711C01D881FCB
 
-	library://bensonyang/collection/tensorflow-rdma_v4.sif:latest
+       library://bensonyang/collection/tensorflow-rdma_v4.sif:latest
 
-	library://dxtr/default/hpc-tensorflow:0.1
+       library://dxtr/default/hpc-tensorflow:0.1
 
-	library://emmeff/tensorflow/tensorflow:latest
+       library://emmeff/tensorflow/tensorflow:latest
 
-	library://husi253/default/tensorflow:20.01-tf1-py3-mrcnn-2020.10.07
+       library://husi253/default/tensorflow:20.01-tf1-py3-mrcnn-2020.10.07
 
-	library://husi253/default/tensorflow:20.01-tf1-py3-mrcnn-20201014
+       library://husi253/default/tensorflow:20.01-tf1-py3-mrcnn-20201014
 
-	library://husi253/default/tensorflow:20.01-tf2-py3-lhx-20201007
+       library://husi253/default/tensorflow:20.01-tf2-py3-lhx-20201007
 
-	library://irinaespejo/default/tensorflow-gan:sha256.0c1b6026ba2d6989242f418835d76cd02fc4cfc8115682986395a71ef015af18
+       library://irinaespejo/default/tensorflow-gan:sha256.0c1b6026ba2d6989242f418835d76cd02fc4cfc8115682986395a71ef015af18
 
-	library://jon/default/tensorflow:1.12-gpu
-		Signed by: D0E30822F7F4B229B1454388597B8AFA69C8EE9F
+       library://jon/default/tensorflow:1.12-gpu
+               Signed by: D0E30822F7F4B229B1454388597B8AFA69C8EE9F
 
-        ...
+       ...
 
-You can use the `pull <cli/singularity_pull.html>`_
-and `build <cli/singularity_build.html>`_
+You can use the `pull
+<cli/singularity_pull.html>`_
+and `build
+<cli/singularity_build.html>`_
 commands to download pre-built images from an external resource like the
-`Container Library <https://cloud.sylabs.io/library>`_ or
-`Docker Hub <https://hub.docker.com/>`_.
+`Container Library <https://cloud.sylabs.io/library>`_ or `Docker Hub
+<https://hub.docker.com/>`_.
 
-When called on a native {Singularity} image like those provided on the Container Library, ``pull``
-simply downloads the image file to your system.
+When called on a native {Singularity} image like those provided on the
+Container Library, ``pull`` simply downloads the image file to your
+system.
 
-.. code-block::
+.. code::
 
-    $ singularity pull library://lolcow
+   $ singularity pull library://lolcow
 
-You can also use ``pull`` with the ``docker://`` uri to reference Docker images
-served from a registry. In this case ``pull`` does not just download an image
-file. Docker images are stored in layers, so ``pull`` must also combine those
-layers into a usable {Singularity} file.
+You can also use ``pull`` with the ``docker://`` uri to reference Docker
+images served from a registry. In this case ``pull`` does not just
+download an image file. Docker images are stored in layers, so ``pull``
+must also combine those layers into a usable {Singularity} file.
 
-.. code-block::
+.. code::
 
-    $ singularity pull docker://sylabsio/lolcow
+   $ singularity pull docker://sylabsio/lolcow
 
-Pulling Docker images reduces reproducibility. If you were to pull a Docker
-image today and then wait six months and pull again, you are not guaranteed to
-get the same image. If any of the source layers has changed the image will be
-altered. If reproducibility is a priority for you, try building your images from
-the Container Library.
+Pulling Docker images reduces reproducibility. If you were to pull a
+Docker image today and then wait six months and pull again, you are not
+guaranteed to get the same image. If any of the source layers has
+changed the image will be altered. If reproducibility is a priority for
+you, try building your images from the Container Library.
 
-You can also use the ``build`` command to download pre-built images from an
-external resource. When using ``build`` you must specify a name for your
-container like so:
+You can also use the ``build`` command to download pre-built images from
+an external resource. When using ``build`` you must specify a name for
+your container like so:
 
-.. code-block::
+.. code::
 
-    $ singularity build ubuntu.sif library://ubuntu
+   $ singularity build ubuntu.sif library://ubuntu
 
-    $ singularity build lolcow.sif docker://sylabsio/lolcow
+   $ singularity build lolcow.sif docker://sylabsio/lolcow
 
-Unlike ``pull``, ``build`` will convert your image to the latest {Singularity}
-image format after downloading it.
-``build`` is like a “Swiss Army knife” for container creation. In addition to
-downloading images, you can use ``build`` to create images from other images or
-from scratch using a :ref:`definition file <definition-files>`. You can also
-use ``build`` to convert an image between the container formats supported by
-{Singularity}. To see a comparison of {Singularity} definition file with Dockerfile,
-please see: :ref:`this section <sec:deffile-vs-dockerfile>`.
+Unlike ``pull``, ``build`` will convert your image to the latest
+{Singularity} image format after downloading it. ``build`` is like a
+“Swiss Army knife” for container creation. In addition to downloading
+images, you can use ``build`` to create images from other images or from
+scratch using a :ref:`definition file <definition-files>`. You can also
+use ``build`` to convert an image between the container formats
+supported by {Singularity}. To see a comparison of {Singularity}
+definition file with Dockerfile, please see: :ref:`this section
+<sec:deffile-vs-dockerfile>`.
 
 .. _cowimage:
 
---------------------
-Interact with images
---------------------
+**********************
+ Interact with images
+**********************
 
-You can interact with images in several ways, each of which can accept image URIs
-in addition to a local image path.
+You can interact with images in several ways, each of which can accept
+image URIs in addition to a local image path.
 
-For demonstration, we will use a ``lolcow_latest.sif`` image that can be pulled
-from the Container Library:
+For demonstration, we will use a ``lolcow_latest.sif`` image that can be
+pulled from the Container Library:
 
-.. code-block::
+.. code::
 
-    $ singularity pull library://lolcow
+   $ singularity pull library://lolcow
 
 Shell
 =====
 
-The `shell <cli/singularity_shell.html>`_
-command allows you to spawn a new shell within your container and interact with
-it as though it were a small virtual machine.
+The `shell
+<cli/singularity_shell.html>`_
+command allows you to spawn a new shell within your container and
+interact with it as though it were a small virtual machine.
 
-.. code-block::
+.. code::
 
-    $ singularity shell lolcow_latest.sif
+   $ singularity shell lolcow_latest.sif
 
-    {Singularity} lolcow_latest.sif:~>
+   {Singularity} lolcow_latest.sif:~>
 
+The change in prompt indicates that you have entered the container
+(though you should not rely on that to determine whether you are in
+container or not).
 
-The change in prompt indicates that you have entered the container (though you
-should not rely on that to determine whether you are in container or not).
+Once inside of a {Singularity} container, you are the same user as you
+are on the host system.
 
-Once inside of a {Singularity} container, you are the same user as you are on the
-host system.
+.. code::
 
-.. code-block::
+   {Singularity} lolcow_latest.sif:~> whoami
+   david
 
-    {Singularity} lolcow_latest.sif:~> whoami
-    david
+   {Singularity} lolcow_latest.sif:~> id
+   uid=1000(david) gid=1000(david) groups=1000(david),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),116(lpadmin),126(sambashare)
 
-    {Singularity} lolcow_latest.sif:~> id
-    uid=1000(david) gid=1000(david) groups=1000(david),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),116(lpadmin),126(sambashare)
+``shell`` also works with the ``library://``, ``docker://``, and
+``shub://`` URIs. This creates an ephemeral container that disappears
+when the shell is exited.
 
-``shell`` also works with the ``library://``, ``docker://``, and ``shub://``
-URIs. This creates an ephemeral container that disappears when the shell is
-exited.
+.. code::
 
-.. code-block::
-
-    $ singularity shell library://lolcow
+   $ singularity shell library://lolcow
 
 Executing Commands
 ==================
 
-The `exec <cli/singularity_exec.html>`_
-command allows you to execute a custom command within a container by specifying
-the image file. For instance, to execute the ``cowsay`` program within the
-``lolcow_latest.sif`` container:
+The `exec
+<cli/singularity_exec.html>`_
+command allows you to execute a custom command within a container by
+specifying the image file. For instance, to execute the ``cowsay``
+program within the ``lolcow_latest.sif`` container:
 
-.. code-block::
+.. code::
 
-    $ singularity exec lolcow_latest.sif cowsay moo
-     _____
-    < moo >
-     -----
-            \   ^__^
-             \  (oo)\_______
-                (__)\       )\/\
-                    ||----w |
-                    ||     ||
+   $ singularity exec lolcow_latest.sif cowsay moo
+    _____
+   < moo >
+    -----
+           \   ^__^
+            \  (oo)\_______
+               (__)\       )\/\
+                   ||----w |
+                   ||     ||
 
-``exec`` also works with the ``library://``, ``docker://``, and ``shub://``
-URIs. This creates an ephemeral container that executes a command and
-disappears.
+``exec`` also works with the ``library://``, ``docker://``, and
+``shub://`` URIs. This creates an ephemeral container that executes a
+command and disappears.
 
-.. code-block::
+.. code::
 
-    $ singularity exec library://lolcow cowsay "Fresh from the library!"
-     _________________________
-    < Fresh from the library! >
-     -------------------------
-            \   ^__^
-             \  (oo)\_______
-                (__)\       )\/\
-                    ||----w |
-                    ||     ||
+   $ singularity exec library://lolcow cowsay "Fresh from the library!"
+    _________________________
+   < Fresh from the library! >
+    -------------------------
+           \   ^__^
+            \  (oo)\_______
+               (__)\       )\/\
+                   ||----w |
+                   ||     ||
 
 .. _runcontainer:
 
 Running a container
 ===================
 
-{Singularity} containers contain :ref:`runscripts <runscript>`. These are user
-defined scripts that define the actions a container should perform when someone
-runs it. The runscript can be triggered with the `run <cli/singularity_run.html>`_
-command, or simply by calling the container as though it were an executable.
+{Singularity} containers contain :ref:`runscripts <runscript>`. These
+are user defined scripts that define the actions a container should
+perform when someone runs it. The runscript can be triggered with the
+`run
+<cli/singularity_run.html>`_
+command, or simply by calling the container as though it were an
+executable.
 
-.. code-block::
+.. code::
 
-    $ singularity run lolcow_latest.sif
-    ______________________________
-    < Mon Aug 16 13:01:55 CDT 2021 >
-     ------------------------------
-            \   ^__^
-             \  (oo)\_______
-                (__)\       )\/\
-                    ||----w |
-                    ||     ||
-    
-    $ ./lolcow_latest.sif
-    ______________________________
-    < Mon Aug 16 13:12:50 CDT 2021 >
-     ------------------------------
-            \   ^__^
-             \  (oo)\_______
-                (__)\       )\/\
-                    ||----w |
-                    ||     ||
-    
+   $ singularity run lolcow_latest.sif
+   ______________________________
+   < Mon Aug 16 13:01:55 CDT 2021 >
+    ------------------------------
+           \   ^__^
+            \  (oo)\_______
+               (__)\       )\/\
+                   ||----w |
+                   ||     ||
 
+   $ ./lolcow_latest.sif
+   ______________________________
+   < Mon Aug 16 13:12:50 CDT 2021 >
+    ------------------------------
+           \   ^__^
+            \  (oo)\_______
+               (__)\       )\/\
+                   ||----w |
+                   ||     ||
 
-``run`` also works with the ``library://``, ``docker://``, and ``shub://`` URIs.
-This creates an ephemeral container that runs and then disappears.
+``run`` also works with the ``library://``, ``docker://``, and
+``shub://`` URIs. This creates an ephemeral container that runs and then
+disappears.
 
-.. code-block::
+.. code::
 
-    $ singularity run library://lolcow
-    ______________________________
-    < Mon Aug 16 13:12:33 CDT 2021 >
-     ------------------------------
-            \   ^__^
-             \  (oo)\_______
-                (__)\       )\/\
-                    ||----w |
-                    ||     ||
+   $ singularity run library://lolcow
+   ______________________________
+   < Mon Aug 16 13:12:33 CDT 2021 >
+    ------------------------------
+           \   ^__^
+            \  (oo)\_______
+               (__)\       )\/\
+                   ||----w |
+                   ||     ||
 
--------------------
-Working with Files
--------------------
+********************
+ Working with Files
+********************
 
 Files on the host are reachable from within the container.
 
-.. code-block::
+.. code::
 
-    $ echo "Hello from inside the container" > $HOME/hostfile.txt
+   $ echo "Hello from inside the container" > $HOME/hostfile.txt
 
-    $ singularity exec lolcow_latest.sif cat $HOME/hostfile.txt
+   $ singularity exec lolcow_latest.sif cat $HOME/hostfile.txt
 
-    Hello from inside the container
+   Hello from inside the container
 
-This example works because ``hostfile.txt`` exists in the user’s home directory.
-By default {Singularity} bind mounts ``/home/$USER``, ``/tmp``, and ``$PWD`` into
-your container at runtime.
+This example works because ``hostfile.txt`` exists in the user’s home
+directory. By default {Singularity} bind mounts ``/home/$USER``,
+``/tmp``, and ``$PWD`` into your container at runtime.
 
-You can specify additional directories to bind mount into your container with
-the ``--bind`` option. In this example, the ``data`` directory on the host
-system is bind mounted to the ``/mnt`` directory inside the container.
+You can specify additional directories to bind mount into your container
+with the ``--bind`` option. In this example, the ``data`` directory on
+the host system is bind mounted to the ``/mnt`` directory inside the
+container.
 
-.. code-block::
+.. code::
 
-    $ echo "Drink milk (and never eat hamburgers)." > /data/cow_advice.txt
+   $ echo "Drink milk (and never eat hamburgers)." > /data/cow_advice.txt
 
-    $ singularity exec --bind /data:/mnt lolcow_latest.sif cat /mnt/cow_advice.txt
-    Drink milk (and never eat hamburgers).
+   $ singularity exec --bind /data:/mnt lolcow_latest.sif cat /mnt/cow_advice.txt
+   Drink milk (and never eat hamburgers).
 
-Pipes and redirects also work with {Singularity} commands just like they do with
-normal Linux commands.
+Pipes and redirects also work with {Singularity} commands just like they
+do with normal Linux commands.
 
-.. code-block::
+.. code::
 
-    $ cat /data/cow_advice.txt | singularity exec lolcow_latest.sif cowsay
-     ________________________________________
-    < Drink milk (and never eat hamburgers). >
-     ----------------------------------------
-            \   ^__^
-             \  (oo)\_______
-                (__)\       )\/\
-                    ||----w |
-                    ||     ||
+   $ cat /data/cow_advice.txt | singularity exec lolcow_latest.sif cowsay
+    ________________________________________
+   < Drink milk (and never eat hamburgers). >
+    ----------------------------------------
+           \   ^__^
+            \  (oo)\_______
+               (__)\       )\/\
+                   ||----w |
+                   ||     ||
 
 .. _build-images-from-scratch:
 
--------------------------
-Build images from scratch
--------------------------
+***************************
+ Build images from scratch
+***************************
 
 .. _sec:buildimagesfromscratch:
 
-{Singularity} v3.0 and above produces immutable images in the Singularity Image File (SIF)
-format. This ensures reproducible and verifiable images and allows for many
-extra benefits such as the ability to sign and verify your containers.
+{Singularity} v3.0 and above produces immutable images in the
+Singularity Image File (SIF) format. This ensures reproducible and
+verifiable images and allows for many extra benefits such as the ability
+to sign and verify your containers.
 
-However, during testing and debugging you may want an image format that is
-writable. This way you can ``shell`` into the image and install software and
-dependencies until you are satisfied that your container will fulfill your
-needs. For these scenarios, {Singularity} also supports the ``sandbox`` format
-(which is really just a directory).
+However, during testing and debugging you may want an image format that
+is writable. This way you can ``shell`` into the image and install
+software and dependencies until you are satisfied that your container
+will fulfill your needs. For these scenarios, {Singularity} also
+supports the ``sandbox`` format (which is really just a directory).
 
 Sandbox Directories
 ===================
 
-To build into a ``sandbox`` (container in a directory) use the
-``build --sandbox`` command and option:
+To build into a ``sandbox`` (container in a directory) use the ``build
+--sandbox`` command and option:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build --sandbox ubuntu/ library://ubuntu
+   $ sudo singularity build --sandbox ubuntu/ library://ubuntu
 
-This command creates a directory called ``ubuntu/`` with an entire Ubuntu
-Operating System and some {Singularity} metadata in your current working
-directory.
+This command creates a directory called ``ubuntu/`` with an entire
+Ubuntu Operating System and some {Singularity} metadata in your current
+working directory.
 
-You can use commands like ``shell``, ``exec`` , and ``run`` with this directory
-just as you would with a {Singularity} image. If you pass the ``--writable``
-option when you use your container you can also write files within the sandbox
-directory (provided you have the permissions to do so).
+You can use commands like ``shell``, ``exec`` , and ``run`` with this
+directory just as you would with a {Singularity} image. If you pass the
+``--writable`` option when you use your container you can also write
+files within the sandbox directory (provided you have the permissions to
+do so).
 
-.. code-block::
+.. code::
 
-    $ sudo singularity exec --writable ubuntu touch /foo
+   $ sudo singularity exec --writable ubuntu touch /foo
 
-    $ singularity exec ubuntu/ ls /foo
-    /foo
+   $ singularity exec ubuntu/ ls /foo
+   /foo
 
 Converting images from one format to another
 ============================================
 
 The ``build`` command allows you to build a container from an existing
-container. This means that you can use it to convert a container from one format
-to another. For instance, if you have already created a sandbox (directory) and
-want to convert it to the default immutable image format (squashfs) you can do
-so:
+container. This means that you can use it to convert a container from
+one format to another. For instance, if you have already created a
+sandbox (directory) and want to convert it to the default immutable
+image format (squashfs) you can do so:
 
-.. code-block::
+.. code::
 
-    $ singularity build new-sif sandbox
+   $ singularity build new-sif sandbox
 
-Doing so may break reproducibility if you have altered your sandbox outside of
-the context of a definition file, so you are advised to exercise care.
+Doing so may break reproducibility if you have altered your sandbox
+outside of the context of a definition file, so you are advised to
+exercise care.
 
 {Singularity} Definition Files
 ==============================
 
-For a reproducible, verifiable and production-quality container you should
-build a SIF file using a {Singularity} definition file. This also makes it easy to
-add files, environment variables, and install custom software, and still start
-from your base of choice (e.g., the Container Library).
+For a reproducible, verifiable and production-quality container you
+should build a SIF file using a {Singularity} definition file. This also
+makes it easy to add files, environment variables, and install custom
+software, and still start from your base of choice (e.g., the Container
+Library).
 
-A definition file has a header and a body. The header determines the base
-container to begin with, and the body is further divided into sections that
-perform things like software installation, environment setup, and copying files
-into the container from host system, etc.
+A definition file has a header and a body. The header determines the
+base container to begin with, and the body is further divided into
+sections that perform things like software installation, environment
+setup, and copying files into the container from host system, etc.
 
 Here is an example of a definition file:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    BootStrap: library
-    From: ubuntu:16.04
+   BootStrap: library
+   From: ubuntu:16.04
 
-    %post
-        apt-get -y update
-        apt-get -y install date cowsay lolcat
+   %post
+       apt-get -y update
+       apt-get -y install date cowsay lolcat
 
-    %environment
-        export LC_ALL=C
-        export PATH=/usr/games:$PATH
+   %environment
+       export LC_ALL=C
+       export PATH=/usr/games:$PATH
 
-    %runscript
-        date | cowsay | lolcat
+   %runscript
+       date | cowsay | lolcat
 
-    %labels
-        Author Sylabs
-
+   %labels
+       Author Sylabs
 
 To build a container from this definition file (assuming it is a file
 named lolcow.def), you would call build like so:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build lolcow.sif lolcow.def
+   $ sudo singularity build lolcow.sif lolcow.def
 
-In this example, the header tells {Singularity} to use a base Ubuntu 16.04 image
-from the Container Library.
+In this example, the header tells {Singularity} to use a base Ubuntu
+16.04 image from the Container Library.
 
-- The ``%post`` section executes within the container at build time after the base OS has been installed. The ``%post`` section is therefore the place to perform installations of new applications.
+-  The ``%post`` section executes within the container at build time
+   after the base OS has been installed. The ``%post`` section is
+   therefore the place to perform installations of new applications.
 
-- The ``%environment`` section defines some environment variables that will be available to the container at runtime.
+-  The ``%environment`` section defines some environment variables that
+   will be available to the container at runtime.
 
-- The ``%runscript`` section defines actions for the container to take when it is executed.
+-  The ``%runscript`` section defines actions for the container to take
+   when it is executed.
 
-- And finally, the ``%labels`` section allows for custom metadata to be added to the container.
+-  And finally, the ``%labels`` section allows for custom metadata to be
+   added to the container.
 
-This is a very small example of the things that you can do with a :ref:`definition file <definition-files>`.
-In addition to building a container from the Container Library, you can start
-with base images from Docker Hub and use images directly from official
-repositories such as Ubuntu, Debian, CentOS, Arch, and BusyBox.  You can also
-use an existing container on your host system as a base.
+This is a very small example of the things that you can do with a
+:ref:`definition file <definition-files>`. In addition to building a
+container from the Container Library, you can start with base images
+from Docker Hub and use images directly from official repositories such
+as Ubuntu, Debian, CentOS, Arch, and BusyBox. You can also use an
+existing container on your host system as a base.
 
-If you want to build {Singularity} images but you don't have administrative (root)
-access on your build system, you can build images using the `Remote Builder <https://cloud.sylabs.io/builder>`_.
+If you want to build {Singularity} images but you don't have
+administrative (root) access on your build system, you can build images
+using the `Remote Builder <https://cloud.sylabs.io/builder>`_.
 
-This quickstart document just scratches the surface of all of the things you can
-do with {Singularity}!
+This quickstart document just scratches the surface of all of the things
+you can do with {Singularity}!
 
 If you need additional help or support, see https://singularity.hpcng.org/help.
-
 
 .. _installation-request:
 
 {Singularity} on a shared resource
 ----------------------------------
 
-Perhaps you are a user who wants a few talking points and background to share
-with your administrator.  Or maybe you are an administrator who needs to decide
-whether to install {Singularity}.
+Perhaps you are a user who wants a few talking points and background to
+share with your administrator. Or maybe you are an administrator who
+needs to decide whether to install {Singularity}.
 
-This document, and the accompanying administrator documentation provides answers
-to many common questions.
+This document, and the accompanying administrator documentation provides
+answers to many common questions.
 
-If you need to request an installation you may decide to draft a message similar
-to this:
+If you need to request an installation you may decide to draft a message
+similar to this:
 
-.. code-block::
+.. code::
 
-    Dear shared resource administrator,
+   Dear shared resource administrator,
 
-    We are interested in having {Singularity} (https://singularity.hpcng.org)
-    installed on our shared resource. {Singularity} containers will allow us to
-    build encapsulated environments, meaning that our work is reproducible and
-    we are empowered to choose all dependencies including libraries, operating
-    system, and custom software. {Singularity} is already in use on many of the
-    top HPC centers around the world. Examples include:
+   We are interested in having {Singularity} (https://singularity.hpcng.org)
+   installed on our shared resource. {Singularity} containers will allow us to
+   build encapsulated environments, meaning that our work is reproducible and
+   we are empowered to choose all dependencies including libraries, operating
+   system, and custom software. {Singularity} is already in use on many of the
+   top HPC centers around the world. Examples include:
 
-        Texas Advanced Computing Center
-        GSI Helmholtz Center for Heavy Ion Research
-        Oak Ridge Leadership Computing Facility
-        Purdue University
-        National Institutes of Health HPC
-        UFIT Research Computing at the University of Florida
-        San Diego Supercomputing Center
-        Lawrence Berkeley National Laboratory
-        University of Chicago
-        McGill HPC Centre/Calcul Québec
-        Barcelona Supercomputing Center
-        Sandia National Lab
-        Argonne National Lab
+       Texas Advanced Computing Center
+       GSI Helmholtz Center for Heavy Ion Research
+       Oak Ridge Leadership Computing Facility
+       Purdue University
+       National Institutes of Health HPC
+       UFIT Research Computing at the University of Florida
+       San Diego Supercomputing Center
+       Lawrence Berkeley National Laboratory
+       University of Chicago
+       McGill HPC Centre/Calcul Québec
+       Barcelona Supercomputing Center
+       Sandia National Lab
+       Argonne National Lab
 
-    Importantly, it has a vibrant team of developers, scientists, and HPC
-    administrators that invest heavily in the security and development of the
-    software, and are quick to respond to the needs of the community. To help
-    learn more about {Singularity}, I thought these items might be of interest:
+   Importantly, it has a vibrant team of developers, scientists, and HPC
+   administrators that invest heavily in the security and development of the
+   software, and are quick to respond to the needs of the community. To help
+   learn more about {Singularity}, I thought these items might be of interest:
 
-        - Security: A discussion of security concerns is discussed at
-        \{admindocs\}/admin_quickstart.html
+       - Security: A discussion of security concerns is discussed at
+       \{admindocs\}/admin_quickstart.html
 
-        - Installation:
-        \{admindocs\}/installation.html
+       - Installation:
+       \{admindocs\}/installation.html
 
-    If you have questions about any of the above, you can contact one
-    of the sources listed at https://singularity.hpcng.org/help.  I can
-    do my best to facilitate this interaction if help is needed.
+   If you have questions about any of the above, you can contact one of the
+   sources listed at https://singularity.hpcng.org/help. I can do my best
+   to facilitate this interaction if help is needed.
 
-    Thank you kindly for considering this request!
+   Thank you kindly for considering this request!
 
-    Best,
+   Best,
 
-    User
+   User

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -111,7 +111,7 @@ archive suitable to the environment you are in. Once the Download is complete,
 extract the archive to ``/usr/local`` (or use other instructions on go installation
 page). Alternatively, follow the commands here:
 
-.. code-block:: none
+.. code-block::
 
     $ export VERSION=1.17.5 OS=linux ARCH=amd64 && \  # Replace the values as needed
       wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \ # Downloads the required Go package
@@ -120,7 +120,7 @@ page). Alternatively, follow the commands here:
 
 Set the Environment variable ``PATH`` to point to Go:
 
-.. code-block:: none
+.. code-block::
 
     $ echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.bashrc && \
       source ~/.bashrc
@@ -135,7 +135,7 @@ You can download {Singularity} from one of the releases. To see a full list, vis
 After deciding on a release to install, you can run the following commands to
 proceed with the installation.
 
-.. code-block:: none
+.. code-block::
 
     $ export VERSION={InstallationVersion} && # adjust this as necessary \
         wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
@@ -150,7 +150,7 @@ Compile the {Singularity} source code
 Now you are ready to build {Singularity}. Dependencies will be automatically
 downloaded. You can build {Singularity} using the following commands:
 
-.. code-block:: none
+.. code-block::
 
     $ ./mconfig && \
         make -C builddir && \
@@ -171,7 +171,7 @@ system from within a container.
 The ``help`` command gives an overview of {Singularity} options and subcommands as
 follows:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity help
 
@@ -230,7 +230,7 @@ follows:
 
 Information about subcommand can also be viewed with the ``help`` command.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity help verify
     Verify cryptographic signatures attached to an image
@@ -272,14 +272,14 @@ and arguments.
 For example, to pass the ``--debug`` option to the main ``singularity`` command
 and run {Singularity} with debugging messages on:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity --debug run library://lolcow
 
 To pass the ``--containall`` option to the ``run`` command and run a
 {Singularity} image in an isolated manner:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run --containall library://lolcow
 
@@ -287,7 +287,7 @@ To pass the ``--containall`` option to the ``run`` command and run a
 Linux capabilities for a particular user, you would use the  ``list`` command in
 the ``capability`` command group like so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity capability list dave
 
@@ -295,7 +295,7 @@ Container authors might also write help docs specific to a container or for an
 internal module called an ``app``. If those help docs exist for a particular
 container, you can view them like so.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity inspect --helpfile container.sif  # See the container's help, if provided
 
@@ -308,7 +308,7 @@ Download pre-built images
 You can use the ``search`` command to locate groups, collections, and
 containers of interest on the `Container Library <https://cloud.sylabs.io/library>`_ .
 
-.. code-block:: none
+.. code-block::
 
     singularity search tensorflow
     Found 22 container images for amd64 matching "tensorflow":
@@ -345,7 +345,7 @@ commands to download pre-built images from an external resource like the
 When called on a native {Singularity} image like those provided on the Container Library, ``pull``
 simply downloads the image file to your system.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull library://lolcow
 
@@ -354,7 +354,7 @@ served from a registry. In this case ``pull`` does not just download an image
 file. Docker images are stored in layers, so ``pull`` must also combine those
 layers into a usable {Singularity} file.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull docker://sylabsio/lolcow
 
@@ -368,7 +368,7 @@ You can also use the ``build`` command to download pre-built images from an
 external resource. When using ``build`` you must specify a name for your
 container like so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity build ubuntu.sif library://ubuntu
 
@@ -395,7 +395,7 @@ in addition to a local image path.
 For demonstration, we will use a ``lolcow_latest.sif`` image that can be pulled
 from the Container Library:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull library://lolcow
 
@@ -406,7 +406,7 @@ The `shell <cli/singularity_shell.html>`_
 command allows you to spawn a new shell within your container and interact with
 it as though it were a small virtual machine.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity shell lolcow_latest.sif
 
@@ -419,7 +419,7 @@ should not rely on that to determine whether you are in container or not).
 Once inside of a {Singularity} container, you are the same user as you are on the
 host system.
 
-.. code-block:: none
+.. code-block::
 
     {Singularity} lolcow_latest.sif:~> whoami
     david
@@ -431,7 +431,7 @@ host system.
 URIs. This creates an ephemeral container that disappears when the shell is
 exited.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity shell library://lolcow
 
@@ -443,7 +443,7 @@ command allows you to execute a custom command within a container by specifying
 the image file. For instance, to execute the ``cowsay`` program within the
 ``lolcow_latest.sif`` container:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity exec lolcow_latest.sif cowsay moo
      _____
@@ -459,7 +459,7 @@ the image file. For instance, to execute the ``cowsay`` program within the
 URIs. This creates an ephemeral container that executes a command and
 disappears.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity exec library://lolcow cowsay "Fresh from the library!"
      _________________________
@@ -481,7 +481,7 @@ defined scripts that define the actions a container should perform when someone
 runs it. The runscript can be triggered with the `run <cli/singularity_run.html>`_
 command, or simply by calling the container as though it were an executable.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run lolcow_latest.sif
     ______________________________
@@ -508,7 +508,7 @@ command, or simply by calling the container as though it were an executable.
 ``run`` also works with the ``library://``, ``docker://``, and ``shub://`` URIs.
 This creates an ephemeral container that runs and then disappears.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run library://lolcow
     ______________________________
@@ -526,7 +526,7 @@ Working with Files
 
 Files on the host are reachable from within the container.
 
-.. code-block:: none
+.. code-block::
 
     $ echo "Hello from inside the container" > $HOME/hostfile.txt
 
@@ -542,7 +542,7 @@ You can specify additional directories to bind mount into your container with
 the ``--bind`` option. In this example, the ``data`` directory on the host
 system is bind mounted to the ``/mnt`` directory inside the container.
 
-.. code-block:: none
+.. code-block::
 
     $ echo "Drink milk (and never eat hamburgers)." > /data/cow_advice.txt
 
@@ -552,7 +552,7 @@ system is bind mounted to the ``/mnt`` directory inside the container.
 Pipes and redirects also work with {Singularity} commands just like they do with
 normal Linux commands.
 
-.. code-block:: none
+.. code-block::
 
     $ cat /data/cow_advice.txt | singularity exec lolcow_latest.sif cowsay
      ________________________________________
@@ -588,7 +588,7 @@ Sandbox Directories
 To build into a ``sandbox`` (container in a directory) use the
 ``build --sandbox`` command and option:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build --sandbox ubuntu/ library://ubuntu
 
@@ -601,7 +601,7 @@ just as you would with a {Singularity} image. If you pass the ``--writable``
 option when you use your container you can also write files within the sandbox
 directory (provided you have the permissions to do so).
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity exec --writable ubuntu touch /foo
 
@@ -617,7 +617,7 @@ to another. For instance, if you have already created a sandbox (directory) and
 want to convert it to the default immutable image format (squashfs) you can do
 so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity build new-sif sandbox
 
@@ -662,7 +662,7 @@ Here is an example of a definition file:
 To build a container from this definition file (assuming it is a file
 named lolcow.def), you would call build like so:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build lolcow.sif lolcow.def
 
@@ -707,7 +707,7 @@ to many common questions.
 If you need to request an installation you may decide to draft a message similar
 to this:
 
-.. code-block:: none
+.. code-block::
 
     Dear shared resource administrator,
 

--- a/replacements.py
+++ b/replacements.py
@@ -13,9 +13,9 @@ def variableReplace(app, docname, source):
 # dictionary structure.
 variable_replacements = {
     "{InstallationVersion}" : "3.8.5",
-    "\{admindocs\}" : "https://singularity.hpcng.org/admin-docs/3.8",
-    "\{version\}": "3.8",
-    "\{adminversion\}": "3.8",
+    "{admindocs}" : "https://singularity.hpcng.org/admin-docs/3.8",
+    "{version}": "3.8",
+    "{adminversion}": "3.8",
     # The 'Singularity' noun is now a replacement so we can have
     # {Singularity}  rather than bare 'Singularity'... and HPCng can
     # replace to SingularityPRO so that it is clearer where docs

--- a/running_services.rst
+++ b/running_services.rst
@@ -30,7 +30,7 @@ instance of an API that converts URL to PDFs.
 To begin with, suppose you want to run an NGINX web server outside of a
 container. On Ubuntu, you can simply install NGINX and start the service by:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo apt-get update && sudo apt-get install -y nginx
 
@@ -51,7 +51,7 @@ For demonstration, let's use an easy (though somewhat useless) example of
 `alpine_latest.sif <https://cloud.sylabs.io/library/_container/5baba5e594feb900016ea41c>`_
 image from the `container library <https://cloud.sylabs.io/library/>`_:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull library://alpine
 
@@ -60,7 +60,7 @@ The above command will save the alpine image from the Container Library as
 
 To start an instance, you should follow this procedure :
 
-.. code-block:: none
+.. code-block::
 
     [command]                      [image]              [name of instance]
 
@@ -70,7 +70,7 @@ This command causes {Singularity} to create an isolated environment for the
 container services to live inside. One can confirm that an instance is running
 by using the ``instance list`` command like so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity instance list
 
@@ -87,7 +87,7 @@ If you want to run multiple instances from the same image, it’s as simple as
 running the command multiple times with different instance names. The instance
 name uniquely identify instances, so they cannot be repeated.
 
-.. code-block:: none
+.. code-block::
 
       $ singularity instance start alpine_latest.sif instance2
 
@@ -95,7 +95,7 @@ name uniquely identify instances, so they cannot be repeated.
 
 And again to confirm that the instances are running as we expected:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity instance list
 
@@ -106,7 +106,7 @@ And again to confirm that the instances are running as we expected:
 
 You can also filter the instance list by supplying a pattern:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity instance list '*2'
 
@@ -116,7 +116,7 @@ You can also filter the instance list by supplying a pattern:
 
 You can use the ``singularity run/exec`` commands on instances:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run instance://instance1
 
@@ -129,7 +129,7 @@ command in the instance.
 If you want to poke around inside of your instance, you can do a normal
 ``singularity shell`` command, but give it the instance URI:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity shell instance://instance3
 
@@ -138,7 +138,7 @@ If you want to poke around inside of your instance, you can do a normal
 When you are finished with your instance you can clean it up with the
 ``instance stop`` command as follows:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity instance stop instance1
 
@@ -146,7 +146,7 @@ If you have multiple instances running and you want to stop all of them, you can
 do so with a wildcard or the --all flag. The following three commands are all
 identical.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity instance stop \*
 
@@ -182,7 +182,7 @@ This downloads the official NGINX Docker container, converts it to a {Singularit
 image, and tells it to run NGINX when you start the instance. Since we’re
 running a web server, we’re going to run the following commands as root.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build nginx.sif nginx.def
 
@@ -196,7 +196,7 @@ running a web server, we’re going to run the following commands as root.
 Just like that we’ve downloaded, built, and run an NGINX {Singularity}
 image. And to confirm that it’s correctly running:
 
-.. code-block:: none
+.. code-block::
 
     $ curl localhost
 
@@ -240,7 +240,7 @@ converts a web page into a PDF, and can be found `here
 following the steps described below or you can just download the final image
 directly from Container Library, simply run:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull url-to-pdf.sif library://sylabs/doc-examples/url-to-pdf:latest
 
@@ -345,7 +345,7 @@ The complete definition file will look like this:
 
 The container can be built like so:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build url-to-pdf.sif url-to-pdf.def
 
@@ -355,7 +355,7 @@ Running the Service
 
 We can now start an instance and run the service:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity instance start url-to-pdf.sif pdf
 
@@ -368,7 +368,7 @@ We can now start an instance and run the service:
 We can confirm it’s working by sending the server an http request using
 curl:
 
-.. code-block:: none
+.. code-block::
 
     $ curl -o sylabs.pdf localhost:9000/api/render?url=http://sylabs.io/docs
 
@@ -385,7 +385,7 @@ You should see a PDF file being generated like the one shown below:
 
 If you shell into the instance, you can see the running processes:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity shell instance://pdf
     {Singularity}: Invoking an interactive shell within container...
@@ -516,7 +516,7 @@ The full def file will look like this:
 Create the container as before. The ``--force`` option will overwrite the old
 container:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity build --force url-to-pdf.sif url-to-pdf.def
 
@@ -524,26 +524,26 @@ Now that we have an output directory in the container, we need to expose it to
 the host using a bind mount. Once we’ve rebuilt the container, make a new
 directory called ``/tmp/out`` for the generated PDFs to go.
 
-.. code-block:: none
+.. code-block::
 
     $ mkdir /tmp/out
 
 After building the image from the edited definition file we simply start the
 instance:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity instance start --bind /tmp/out/:/output url-to-pdf.sif pdf
 
 To request a pdf simply do:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run --app pdf_client instance://pdf http://sylabs.io/docs sylabs.pdf
 
 To confirm that it worked:
 
-.. code-block:: none
+.. code-block::
 
     $ ls /tmp/out/
     sylabs.pdf
@@ -551,7 +551,7 @@ To confirm that it worked:
 When you are finished, use the instance stop command to close all running
 instances.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity instance stop --all
 
@@ -561,7 +561,7 @@ instances.
     For example, if you wish to capture the output of the ``web`` container
     instance which is placed at ``/output/`` inside the container you could do:
 
-    .. code-block:: none
+    .. code-block::
 
         $ singularity instance start --bind output/dir/outside/:/output/ nginx.sif  web
 
@@ -578,7 +578,7 @@ daemons support managing processes via pid files.
 You can specify a `--pid-file` option to `singularity instance start` to write
 the PID for an instance to the specified file, e.g.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity instance start --pid-file /home/dave/alpine.pid alpine_latest.sif instanceA
 
@@ -589,7 +589,7 @@ the PID for an instance to the specified file, e.g.
 An example service file for an instance controlled by systemd is below. This can be used as a
 template to setup containerized services under systemd.
 
-.. code-block:: none
+.. code-block::
 
     [Unit]
     Description=Web Instance

--- a/running_services.rst
+++ b/running_services.rst
@@ -1,610 +1,616 @@
 .. _running_services:
 
-================
-Running Services
-================
+##################
+ Running Services
+##################
 
-There are :ref:`different ways <runcontainer>`  in which you can run {Singularity}
-containers. If you use commands like ``run``, ``exec`` and ``shell`` to
-interact with processes in the container, you are running {Singularity} containers
-in the foreground. {Singularity}, also lets you run containers in a "detached" or
-"daemon" mode which can run different services in the background. A "service" is
-essentially a process running in the background that multiple different clients
-can use. For example, a web server or a database. To run services in a
-{Singularity} container one should use *instances*. A container instance is a
-persistent and isolated version of the container image that runs in the
-background.
+There are :ref:`different ways <runcontainer>` in which you can run
+{Singularity} containers. If you use commands like ``run``, ``exec`` and
+``shell`` to interact with processes in the container, you are running
+{Singularity} containers in the foreground. {Singularity}, also lets you
+run containers in a "detached" or "daemon" mode which can run different
+services in the background. A "service" is essentially a process running
+in the background that multiple different clients can use. For example,
+a web server or a database. To run services in a {Singularity} container
+one should use *instances*. A container instance is a persistent and
+isolated version of the container image that runs in the background.
 
-------------------------
-Overview
-------------------------
+**********
+ Overview
+**********
 
 .. _sec:instances:
 
-{Singularity} v2.4 introduced the concept of *instances* allowing users to run
-services in {Singularity}. This page will help you understand instances using an
-elementary example followed by a more useful example running an NGINX web server
-using instances. In the end, you will find a more detailed example of running an
-instance of an API that converts URL to PDFs.
+{Singularity} v2.4 introduced the concept of *instances* allowing users
+to run services in {Singularity}. This page will help you understand
+instances using an elementary example followed by a more useful example
+running an NGINX web server using instances. In the end, you will find a
+more detailed example of running an instance of an API that converts URL
+to PDFs.
 
 To begin with, suppose you want to run an NGINX web server outside of a
-container. On Ubuntu, you can simply install NGINX and start the service by:
+container. On Ubuntu, you can simply install NGINX and start the service
+by:
 
-.. code-block::
+.. code::
 
-    $ sudo apt-get update && sudo apt-get install -y nginx
+   $ sudo apt-get update && sudo apt-get install -y nginx
 
-    $ sudo service nginx start
+   $ sudo service nginx start
 
-If you were to do something like this from within a container you would also see
-the service start, and the web server running. But then if you were to exit the
-container, the process would continue to run within an unreachable mount
-namespace. The process would still be running, but you couldn't easily kill or
-interface with it. This is a called an orphan process. {Singularity} instances
-give you the ability to handle services properly.
+If you were to do something like this from within a container you would
+also see the service start, and the web server running. But then if you
+were to exit the container, the process would continue to run within an
+unreachable mount namespace. The process would still be running, but you
+couldn't easily kill or interface with it. This is a called an orphan
+process. {Singularity} instances give you the ability to handle services
+properly.
 
-------------------------------------
-Container Instances in {Singularity}
-------------------------------------
+**************************************
+ Container Instances in {Singularity}
+**************************************
 
-For demonstration, let's use an easy (though somewhat useless) example of
-`alpine_latest.sif <https://cloud.sylabs.io/library/_container/5baba5e594feb900016ea41c>`_
+For demonstration, let's use an easy (though somewhat useless) example
+of `alpine_latest.sif
+<https://cloud.sylabs.io/library/_container/5baba5e594feb900016ea41c>`_
 image from the `container library <https://cloud.sylabs.io/library/>`_:
 
-.. code-block::
+.. code::
 
-    $ singularity pull library://alpine
+   $ singularity pull library://alpine
 
-The above command will save the alpine image from the Container Library as
-``alpine_latest.sif``.
+The above command will save the alpine image from the Container Library
+as ``alpine_latest.sif``.
 
 To start an instance, you should follow this procedure :
 
-.. code-block::
+.. code::
 
-    [command]                      [image]              [name of instance]
+   [command]                      [image]              [name of instance]
 
-    $ singularity instance start   alpine_latest.sif     instance1
+   $ singularity instance start   alpine_latest.sif     instance1
 
-This command causes {Singularity} to create an isolated environment for the
-container services to live inside. One can confirm that an instance is running
-by using the ``instance list`` command like so:
+This command causes {Singularity} to create an isolated environment for
+the container services to live inside. One can confirm that an instance
+is running by using the ``instance list`` command like so:
 
-.. code-block::
+.. code::
 
-    $ singularity instance list
+   $ singularity instance list
 
-    INSTANCE NAME    PID      IP              IMAGE
-    instance1        22084                    /home/dave/instances/alpine_latest.sif
+   INSTANCE NAME    PID      IP              IMAGE
+   instance1        22084                    /home/dave/instances/alpine_latest.sif
 
 .. note::
-    The instances are linked with your user account. So make sure to run *all*
-    instance commands either with or without the ``sudo`` privilege. If you
-    ``start`` an instance with sudo then you must ``list`` it with sudo as
-    well, or you will not be able to locate the instance.
 
-If you want to run multiple instances from the same image, it’s as simple as
-running the command multiple times with different instance names. The instance
-name uniquely identify instances, so they cannot be repeated.
+   The instances are linked with your user account. So make sure to run
+   *all* instance commands either with or without the ``sudo``
+   privilege. If you ``start`` an instance with sudo then you must
+   ``list`` it with sudo as well, or you will not be able to locate the
+   instance.
 
-.. code-block::
+If you want to run multiple instances from the same image, it’s as
+simple as running the command multiple times with different instance
+names. The instance name uniquely identify instances, so they cannot be
+repeated.
 
-      $ singularity instance start alpine_latest.sif instance2
+.. code::
 
-      $ singularity instance start alpine_latest.sif instance3
+   $ singularity instance start alpine_latest.sif instance2
+
+   $ singularity instance start alpine_latest.sif instance3
 
 And again to confirm that the instances are running as we expected:
 
-.. code-block::
+.. code::
 
-    $ singularity instance list
+   $ singularity instance list
 
-    INSTANCE NAME    PID      IP              IMAGE
-    instance1        22084                    /home/dave/instances/alpine_latest.sif
-    instance2        22443                    /home/dave/instances/alpine_latest.sif
-    instance3        22493                    /home/dave/instances/alpine_latest.sif
+   INSTANCE NAME    PID      IP              IMAGE
+   instance1        22084                    /home/dave/instances/alpine_latest.sif
+   instance2        22443                    /home/dave/instances/alpine_latest.sif
+   instance3        22493                    /home/dave/instances/alpine_latest.sif
 
 You can also filter the instance list by supplying a pattern:
 
-.. code-block::
+.. code::
 
-    $ singularity instance list '*2'
+   $ singularity instance list '*2'
 
-    INSTANCE NAME    PID      IP              IMAGE
-    instance2        22443                    /home/dave/instances/alpine_latest.s
-
+   INSTANCE NAME    PID      IP              IMAGE
+   instance2        22443                    /home/dave/instances/alpine_latest.s
 
 You can use the ``singularity run/exec`` commands on instances:
 
-.. code-block::
+.. code::
 
-    $ singularity run instance://instance1
+   $ singularity run instance://instance1
 
-    $ singularity exec instance://instance2 cat /etc/os-release
+   $ singularity exec instance://instance2 cat /etc/os-release
 
-When using ``run`` with an instance URI, the ``runscript`` will be executed
-inside of the instance. Similarly with ``exec``, it will execute the given
-command in the instance.
+When using ``run`` with an instance URI, the ``runscript`` will be
+executed inside of the instance. Similarly with ``exec``, it will
+execute the given command in the instance.
 
 If you want to poke around inside of your instance, you can do a normal
 ``singularity shell`` command, but give it the instance URI:
 
-.. code-block::
+.. code::
 
-    $ singularity shell instance://instance3
+   $ singularity shell instance://instance3
 
-    Singularity>
+   Singularity>
 
 When you are finished with your instance you can clean it up with the
 ``instance stop`` command as follows:
 
-.. code-block::
+.. code::
 
-    $ singularity instance stop instance1
+   $ singularity instance stop instance1
 
-If you have multiple instances running and you want to stop all of them, you can
-do so with a wildcard or the --all flag. The following three commands are all
-identical.
+If you have multiple instances running and you want to stop all of them,
+you can do so with a wildcard or the --all flag. The following three
+commands are all identical.
 
-.. code-block::
+.. code::
 
-    $ singularity instance stop \*
+   $ singularity instance stop \*
 
-    $ singularity instance stop --all
+   $ singularity instance stop --all
 
-    $ singularity instance stop -a
-
-.. note::
-    Note that you must escape the wildcard with a backslash like this ``\*`` to
-    pass it properly.
-
-------------------------------------
-Nginx “Hello-world” in {Singularity}
-------------------------------------
-
-The above example, although not very useful, should serve as a fair introduction
-to the concept of {Singularity} instances and running services in the background.
-The following illustrates a more useful example of setting up a sample NGINX web
-server using instances. First we will create a basic
-:ref:`definition file <definition-files>` (let's call it nginx.def):
-
-.. code-block:: singularity
-
-    Bootstrap: docker
-    From: nginx
-    Includecmd: no
-
-    %startscript
-       nginx
-
-
-This downloads the official NGINX Docker container, converts it to a {Singularity}
-image, and tells it to run NGINX when you start the instance. Since we’re
-running a web server, we’re going to run the following commands as root.
-
-.. code-block::
-
-    $ sudo singularity build nginx.sif nginx.def
-
-    $ sudo singularity instance start --writable-tmpfs nginx.sif web
+   $ singularity instance stop -a
 
 .. note::
-    The above ``start`` command requires ``sudo`` because we are running a web
-    server. Also, to let the instance write temporary files during execution,
-    you should use ``--writable-tmpfs`` while starting the instance.
+
+   Note that you must escape the wildcard with a backslash like this
+   ``\*`` to pass it properly.
+
+**************************************
+ Nginx “Hello-world” in {Singularity}
+**************************************
+
+The above example, although not very useful, should serve as a fair
+introduction to the concept of {Singularity} instances and running
+services in the background. The following illustrates a more useful
+example of setting up a sample NGINX web server using instances. First
+we will create a basic :ref:`definition file <definition-files>` (let's
+call it nginx.def):
+
+.. code:: singularity
+
+   Bootstrap: docker
+   From: nginx
+   Includecmd: no
+
+   %startscript
+      nginx
+
+This downloads the official NGINX Docker container, converts it to a
+{Singularity} image, and tells it to run NGINX when you start the
+instance. Since we’re running a web server, we’re going to run the
+following commands as root.
+
+.. code::
+
+   $ sudo singularity build nginx.sif nginx.def
+
+   $ sudo singularity instance start --writable-tmpfs nginx.sif web
+
+.. note::
+
+   The above ``start`` command requires ``sudo`` because we are running
+   a web server. Also, to let the instance write temporary files during
+   execution, you should use ``--writable-tmpfs`` while starting the
+   instance.
 
 Just like that we’ve downloaded, built, and run an NGINX {Singularity}
 image. And to confirm that it’s correctly running:
 
-.. code-block::
+.. code::
 
-    $ curl localhost
+   $ curl localhost
 
-    <!DOCTYPE html>
-    <html>
-    <head>
-    <title>Welcome to nginx!</title>
-    <style>
-     body {
-         width: 35em;
-         margin: 0 auto;
-         font-family: Tahoma, Verdana, Arial, sans-serif;
-     }
-    </style>
-    </head>
-    <body>
-    <h1>Welcome to nginx!</h1>
-    <p>If you see this page, the nginx web server is successfully installed and
-    working. Further configuration is required.</p>
+   <!DOCTYPE html>
+   <html>
+   <head>
+   <title>Welcome to nginx!</title>
+   <style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+   </style>
+   </head>
+   <body>
+   <h1>Welcome to nginx!</h1>
+   <p>If you see this page, the nginx web server is successfully installed and
+   working. Further configuration is required.</p>
 
-    <p>For online documentation and support please refer to
-    <a href="http://nginx.org/">nginx.org</a>.<br/>
-    Commercial support is available at
-    <a href="http://nginx.com/">nginx.com</a>.</p>
+   <p>For online documentation and support please refer to
+   <a href="http://nginx.org/">nginx.org</a>.<br/>
+   Commercial support is available at
+   <a href="http://nginx.com/">nginx.com</a>.</p>
 
-    <p><em>Thank you for using nginx.</em></p>
-    </body>
-    </html>
-
+   <p><em>Thank you for using nginx.</em></p>
+   </body>
+   </html>
 
 Visit localhost on your browser, you should see a Welcome message!
 
---------------------
-Putting all together
---------------------
+**********************
+ Putting all together
+**********************
 
-In this section, we will demonstrate an example of packaging a service into a
-container and running it. The service we will be packaging is an API server that
-converts a web page into a PDF, and can be found `here
-<https://github.com/alvarcarto/url-to-pdf-api>`__. You can build the image by
-following the steps described below or you can just download the final image
-directly from Container Library, simply run:
+In this section, we will demonstrate an example of packaging a service
+into a container and running it. The service we will be packaging is an
+API server that converts a web page into a PDF, and can be found `here
+<https://github.com/alvarcarto/url-to-pdf-api>`__. You can build the
+image by following the steps described below or you can just download
+the final image directly from Container Library, simply run:
 
-.. code-block::
+.. code::
 
-    $ singularity pull url-to-pdf.sif library://sylabs/doc-examples/url-to-pdf:latest
+   $ singularity pull url-to-pdf.sif library://sylabs/doc-examples/url-to-pdf:latest
 
 Building the image
 ==================
 
-This section will describe the requirements for creating the definition file
-(url-to-pdf.def) that will be used to build the container image.
-``url-to-pdf-api`` is based on a Node 8 server that uses a headless version of
-Chromium called `Puppeteer <https://github.com/GoogleChrome/puppeteer>`_.
-Let’s first choose a base from which to build our container, in this case the
-docker image ``node:8`` which comes pre-installed with Node 8 has been used:
+This section will describe the requirements for creating the definition
+file (url-to-pdf.def) that will be used to build the container image.
+``url-to-pdf-api`` is based on a Node 8 server that uses a headless
+version of Chromium called `Puppeteer
+<https://github.com/GoogleChrome/puppeteer>`_. Let’s first choose a base
+from which to build our container, in this case the docker image
+``node:8`` which comes pre-installed with Node 8 has been used:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: docker
-    From: node:8
-    Includecmd: no
+   Bootstrap: docker
+   From: node:8
+   Includecmd: no
 
+Puppeteer also requires a slew of dependencies to be manually installed
+in addition to Node 8, so we can add those into the ``post`` section as
+well as the installation script for the ``url-to-pdf``:
 
-Puppeteer also requires a slew of dependencies to be manually installed in
-addition to Node 8, so we can add those into the ``post`` section as well as the
-installation script for the ``url-to-pdf``:
+.. code:: singularity
 
-.. code-block:: singularity
+   %post
 
-    %post
-
-        apt-get update && apt-get install -yq gconf-service libasound2 \
-            libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 \
-            libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
-            libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 \
-            libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
-            libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
-            libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
-            wget curl && rm -r /var/lib/apt/lists/*
-        git clone https://github.com/alvarcarto/url-to-pdf-api.git pdf_server
-        cd pdf_server
-        npm install
-        chmod -R 0755 .
+       apt-get update && apt-get install -yq gconf-service libasound2 \
+           libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 \
+           libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
+           libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 \
+           libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+           libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
+           libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+           fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
+           wget curl && rm -r /var/lib/apt/lists/*
+       git clone https://github.com/alvarcarto/url-to-pdf-api.git pdf_server
+       cd pdf_server
+       npm install
+       chmod -R 0755 .
 
 And now we need to define what happens when we start an instance of the
-container. In this situation, we want to run the commands that starts up the
-url-to-pdf service:
+container. In this situation, we want to run the commands that starts up
+the url-to-pdf service:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %startscript
-        cd /pdf_server
-        # Use nohup and /dev/null to completely detach server process from terminal
-        nohup npm start > /dev/null 2>&1 < /dev/null &
+   %startscript
+       cd /pdf_server
+       # Use nohup and /dev/null to completely detach server process from terminal
+       nohup npm start > /dev/null 2>&1 < /dev/null &
 
+Also, the ``url-to-pdf`` service requires some environment variables to
+be set, which we can do in the environment section:
 
-Also, the ``url-to-pdf`` service requires some environment variables to be set,
-which we can do in the environment section:
+.. code:: singularity
 
-.. code-block:: singularity
-
-    %environment
-        NODE_ENV=development
-        PORT=9000
-        ALLOW_HTTP=true
-        URL=localhost
-        export NODE_ENV PORT ALLOW_HTTP URL
+   %environment
+       NODE_ENV=development
+       PORT=9000
+       ALLOW_HTTP=true
+       URL=localhost
+       export NODE_ENV PORT ALLOW_HTTP URL
 
 The complete definition file will look like this:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: docker
-    From: node:8
-    Includecmd: no
+   Bootstrap: docker
+   From: node:8
+   Includecmd: no
 
-    %post
+   %post
 
-        apt-get update && apt-get install -yq gconf-service libasound2 \
-            libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 \
-            libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
-            libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 \
-            libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
-            libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
-            libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
-            wget curl && rm -r /var/lib/apt/lists/*
-        git clone https://github.com/alvarcarto/url-to-pdf-api.git pdf_server
-        cd pdf_server
-        npm install
-        chmod -R 0755 .
+       apt-get update && apt-get install -yq gconf-service libasound2 \
+           libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 \
+           libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
+           libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 \
+           libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+           libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
+           libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+           fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
+           wget curl && rm -r /var/lib/apt/lists/*
+       git clone https://github.com/alvarcarto/url-to-pdf-api.git pdf_server
+       cd pdf_server
+       npm install
+       chmod -R 0755 .
 
-    %startscript
-        cd /pdf_server
-        # Use nohup and /dev/null to completely detach server process from terminal
-        nohup npm start > /dev/null 2>&1 < /dev/null &
+   %startscript
+       cd /pdf_server
+       # Use nohup and /dev/null to completely detach server process from terminal
+       nohup npm start > /dev/null 2>&1 < /dev/null &
 
-    %environment
-        NODE_ENV=development
-        PORT=9000
-        ALLOW_HTTP=true
-        URL=localhost
-        export NODE_ENV PORT ALLOW_HTTP URL
+   %environment
+       NODE_ENV=development
+       PORT=9000
+       ALLOW_HTTP=true
+       URL=localhost
+       export NODE_ENV PORT ALLOW_HTTP URL
 
 The container can be built like so:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build url-to-pdf.sif url-to-pdf.def
-
+   $ sudo singularity build url-to-pdf.sif url-to-pdf.def
 
 Running the Service
 ===================
 
 We can now start an instance and run the service:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity instance start url-to-pdf.sif pdf
+   $ sudo singularity instance start url-to-pdf.sif pdf
 
 .. note::
-    If there occurs an error related to port connection being refused while
-    starting the instance or while using it later, you can try specifying
-    different port numbers in the ``%environment`` section of the definition
-    file above.
+
+   If there occurs an error related to port connection being refused
+   while starting the instance or while using it later, you can try
+   specifying different port numbers in the ``%environment`` section of
+   the definition file above.
 
 We can confirm it’s working by sending the server an http request using
 curl:
 
-.. code-block::
+.. code::
 
-    $ curl -o sylabs.pdf localhost:9000/api/render?url=http://sylabs.io/docs
+   $ curl -o sylabs.pdf localhost:9000/api/render?url=http://sylabs.io/docs
 
-    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                             Dload  Upload   Total   Spent    Left  Speed
+   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                            Dload  Upload   Total   Spent    Left  Speed
 
-    100 73750  100 73750    0     0  14583      0  0:00:05  0:00:05 --:--:-- 19130
+   100 73750  100 73750    0     0  14583      0  0:00:05  0:00:05 --:--:-- 19130
 
 You should see a PDF file being generated like the one shown below:
 
 .. image:: docpage.png
-    :alt: Screenshot of the PDF generated!
-
+   :alt: Screenshot of the PDF generated!
 
 If you shell into the instance, you can see the running processes:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity shell instance://pdf
-    {Singularity}: Invoking an interactive shell within container...
+   $ sudo singularity shell instance://pdf
+   {Singularity}: Invoking an interactive shell within container...
 
-    {Singularity} final.sif:/home/ysub> ps auxf
-    USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-    root       461  0.0  0.0  18204  3188 pts/1    S    17:58   0:00 /bin/bash --norc
-    root       468  0.0  0.0  36640  2880 pts/1    R+   17:59   0:00  \_ ps auxf
-    root         1  0.0  0.1 565392 12144 ?        Sl   15:10   0:00 sinit
-    root        16  0.0  0.4 1113904 39492 ?       Sl   15:10   0:00 npm
-    root        26  0.0  0.0   4296   752 ?        S    15:10   0:00  \_ sh -c nodemon --watch ./src -e js src/index.js
-    root        27  0.0  0.5 1179476 40312 ?       Sl   15:10   0:00      \_ node /pdf_server/node_modules/.bin/nodemon --watch ./src -e js src/index.js
-    root        39  0.0  0.7 936444 61220 ?        Sl   15:10   0:02          \_ /usr/local/bin/node src/index.js
+   {Singularity} final.sif:/home/ysub> ps auxf
+   USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+   root       461  0.0  0.0  18204  3188 pts/1    S    17:58   0:00 /bin/bash --norc
+   root       468  0.0  0.0  36640  2880 pts/1    R+   17:59   0:00  \_ ps auxf
+   root         1  0.0  0.1 565392 12144 ?        Sl   15:10   0:00 sinit
+   root        16  0.0  0.4 1113904 39492 ?       Sl   15:10   0:00 npm
+   root        26  0.0  0.0   4296   752 ?        S    15:10   0:00  \_ sh -c nodemon --watch ./src -e js src/index.js
+   root        27  0.0  0.5 1179476 40312 ?       Sl   15:10   0:00      \_ node /pdf_server/node_modules/.bin/nodemon --watch ./src -e js src/index.js
+   root        39  0.0  0.7 936444 61220 ?        Sl   15:10   0:02          \_ /usr/local/bin/node src/index.js
 
-    {Singularity} final.sif:/home/ysub> exit
-
+   {Singularity} final.sif:/home/ysub> exit
 
 Making it Fancy
 ===============
 
-Now that we have confirmation that the server is working, let’s make
-it a little cleaner. It’s difficult to remember the exact ``curl``
-command and URL syntax each time you want to request a PDF, so let’s
-automate it. Instead of creating completely separate containers for
-the server and our streamlined client, it'd be nice to have them both
-available in the same SIF file. To do that, we can use Scientific
-Filesystem (SCIF) apps.
+Now that we have confirmation that the server is working, let’s make it
+a little cleaner. It’s difficult to remember the exact ``curl`` command
+and URL syntax each time you want to request a PDF, so let’s automate
+it. Instead of creating completely separate containers for the server
+and our streamlined client, it'd be nice to have them both available in
+the same SIF file. To do that, we can use Scientific Filesystem (SCIF)
+apps.
 
 .. note::
 
-   SCIF is a standard for encapsulating multiple apps into a container. A
-   container with SCIF apps has multiple entry points, and you can choose
-   which to run easily. Each entry point can carry out a different task
-   with it's own environment, metadata etc., without the need for a
-   collection of different containers.
+   SCIF is a standard for encapsulating multiple apps into a container.
+   A container with SCIF apps has multiple entry points, and you can
+   choose which to run easily. Each entry point can carry out a
+   different task with it's own environment, metadata etc., without the
+   need for a collection of different containers.
 
-   {Singularity} implements SCIF, and you can read more about how to use it
-   :ref:`apps <in the SCIF Apps section>`.
+   {Singularity} implements SCIF, and you can read more about how to use
+   it :ref:`apps <in the SCIF Apps section>`.
 
-   SCIF is not specific to {Singularity}. You can learn more about it at the
-   project site: <https://sci-f.github.io/>`_.
+   SCIF is not specific to {Singularity}. You can learn more about it at
+   the project site: <https://sci-f.github.io/>`_.
 
+First off, we’re going to move the installation of the url-to-pdf into
+an app, so that there is a designated spot to place output files. To do
+that, we want to add a section to our definition file to build the
+server:
 
-First off, we’re going to move the installation of the url-to-pdf into an app,
-so that there is a designated spot to place output files. To do that, we want to
-add a section to our definition file to build the server:
+.. code:: singularity
 
-.. code-block:: singularity
-
-    %appinstall pdf_server
-        git clone https://github.com/alvarcarto/url-to-pdf-api.git pdf_server
-        cd pdf_server
-        npm install
-        chmod -R 0755 .
-
+   %appinstall pdf_server
+       git clone https://github.com/alvarcarto/url-to-pdf-api.git pdf_server
+       cd pdf_server
+       npm install
+       chmod -R 0755 .
 
 And update our ``startscript`` to point to the app location:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    %startscript
-        cd /scif/apps/pdf_server/scif/pdf_server
-        # Use nohup and /dev/null to completely detach server process from terminal
-        nohup npm start > /dev/null 2>&1 < /dev/null &
+   %startscript
+       cd /scif/apps/pdf_server/scif/pdf_server
+       # Use nohup and /dev/null to completely detach server process from terminal
+       nohup npm start > /dev/null 2>&1 < /dev/null &
 
+Now we want to define the pdf_client app, which we will run to send the
+requests to the server:
 
-Now we want to define the pdf_client app, which we will run to send the requests
-to the server:
+.. code:: singularity
 
-.. code-block:: singularity
-
-    %apprun pdf_client
-        if [ -z "${1:-}" ]; then
-            echo "Usage: singularity run --app pdf <instance://name> <URL> [output file]"
-            exit 1
-        fi
-        curl -o "${SINGULARITY_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
-
+   %apprun pdf_client
+       if [ -z "${1:-}" ]; then
+           echo "Usage: singularity run --app pdf <instance://name> <URL> [output file]"
+           exit 1
+       fi
+       curl -o "${SINGULARITY_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
 
 As you can see, the ``pdf_client`` app checks to make sure that the user
 provides at least one argument.
 
 The full def file will look like this:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: docker
-    From: node:8
-    Includecmd: no
+   Bootstrap: docker
+   From: node:8
+   Includecmd: no
 
-    %post
+   %post
 
-        apt-get update && apt-get install -yq gconf-service libasound2 \
-            libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 \
-            libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
-            libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 \
-            libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
-            libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
-            libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
-            wget curl && rm -r /var/lib/apt/lists/*
+       apt-get update && apt-get install -yq gconf-service libasound2 \
+           libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 \
+           libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
+           libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 \
+           libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+           libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
+           libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+           fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
+           wget curl && rm -r /var/lib/apt/lists/*
 
-    %appinstall pdf_server
-        git clone https://github.com/alvarcarto/url-to-pdf-api.git pdf_server
-        cd pdf_server
-        npm install
-        chmod -R 0755 .
+   %appinstall pdf_server
+       git clone https://github.com/alvarcarto/url-to-pdf-api.git pdf_server
+       cd pdf_server
+       npm install
+       chmod -R 0755 .
 
-    %startscript
-        cd /scif/apps/pdf_server/scif/pdf_server
-        # Use nohup and /dev/null to completely detach server process from terminal
-        nohup npm start > /dev/null 2>&1 < /dev/null &
+   %startscript
+       cd /scif/apps/pdf_server/scif/pdf_server
+       # Use nohup and /dev/null to completely detach server process from terminal
+       nohup npm start > /dev/null 2>&1 < /dev/null &
 
-    %environment
-        NODE_ENV=development
-        PORT=9000
-        ALLOW_HTTP=true
-        URL=localhost
-        export NODE_ENV PORT ALLOW_HTTP URL
+   %environment
+       NODE_ENV=development
+       PORT=9000
+       ALLOW_HTTP=true
+       URL=localhost
+       export NODE_ENV PORT ALLOW_HTTP URL
 
-    %apprun pdf_client
-        if [ -z "${1:-}" ]; then
-            echo "Usage: singularity run --app pdf <instance://name> <URL> [output file]"
-            exit 1
-        fi
-        curl -o "${SINGULARITY_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
+   %apprun pdf_client
+       if [ -z "${1:-}" ]; then
+           echo "Usage: singularity run --app pdf <instance://name> <URL> [output file]"
+           exit 1
+       fi
+       curl -o "${SINGULARITY_APPDATA}/output/${2:-output.pdf}" "${URL}:${PORT}/api/render?url=${1}"
 
-Create the container as before. The ``--force`` option will overwrite the old
-container:
+Create the container as before. The ``--force`` option will overwrite
+the old container:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity build --force url-to-pdf.sif url-to-pdf.def
+   $ sudo singularity build --force url-to-pdf.sif url-to-pdf.def
 
-Now that we have an output directory in the container, we need to expose it to
-the host using a bind mount. Once we’ve rebuilt the container, make a new
-directory called ``/tmp/out`` for the generated PDFs to go.
+Now that we have an output directory in the container, we need to expose
+it to the host using a bind mount. Once we’ve rebuilt the container,
+make a new directory called ``/tmp/out`` for the generated PDFs to go.
 
-.. code-block::
+.. code::
 
-    $ mkdir /tmp/out
+   $ mkdir /tmp/out
 
-After building the image from the edited definition file we simply start the
-instance:
+After building the image from the edited definition file we simply start
+the instance:
 
-.. code-block::
+.. code::
 
-    $ singularity instance start --bind /tmp/out/:/output url-to-pdf.sif pdf
+   $ singularity instance start --bind /tmp/out/:/output url-to-pdf.sif pdf
 
 To request a pdf simply do:
 
-.. code-block::
+.. code::
 
-    $ singularity run --app pdf_client instance://pdf http://sylabs.io/docs sylabs.pdf
+   $ singularity run --app pdf_client instance://pdf http://sylabs.io/docs sylabs.pdf
 
 To confirm that it worked:
 
-.. code-block::
+.. code::
 
-    $ ls /tmp/out/
-    sylabs.pdf
+   $ ls /tmp/out/
+   sylabs.pdf
 
-When you are finished, use the instance stop command to close all running
-instances.
+When you are finished, use the instance stop command to close all
+running instances.
 
-.. code-block::
+.. code::
 
-    $ singularity instance stop --all
+   $ singularity instance stop --all
 
 .. note::
-    If the service you want to run in your instance requires a bind mount,
-    then you must pass the ``--bind`` option when calling ``instance start``.
-    For example, if you wish to capture the output of the ``web`` container
-    instance which is placed at ``/output/`` inside the container you could do:
 
-    .. code-block::
+   If the service you want to run in your instance requires a bind
+   mount, then you must pass the ``--bind`` option when calling
+   ``instance start``. For example, if you wish to capture the output of
+   the ``web`` container instance which is placed at ``/output/`` inside
+   the container you could do:
 
-        $ singularity instance start --bind output/dir/outside/:/output/ nginx.sif  web
+   .. code::
 
+      $ singularity instance start --bind output/dir/outside/:/output/ nginx.sif  web
 
-------------------------------
-System integration / PID files
-------------------------------
+********************************
+ System integration / PID files
+********************************
 
-If you are running services in containers you may want them to be started on
-boot, and shutdown gracefully automatically. This is usually performed by an init process,
-or another supervisor daemon installed on your host. Many init and supervisor
-daemons support managing processes via pid files.
+If you are running services in containers you may want them to be
+started on boot, and shutdown gracefully automatically. This is usually
+performed by an init process, or another supervisor daemon installed on
+your host. Many init and supervisor daemons support managing processes
+via pid files.
 
-You can specify a `--pid-file` option to `singularity instance start` to write
-the PID for an instance to the specified file, e.g.
+You can specify a `--pid-file` option to `singularity instance start` to
+write the PID for an instance to the specified file, e.g.
 
-.. code-block::
+.. code::
 
-    $ singularity instance start --pid-file /home/dave/alpine.pid alpine_latest.sif instanceA
+   $ singularity instance start --pid-file /home/dave/alpine.pid alpine_latest.sif instanceA
 
-    $ cat /home/dave/alpine.pid
-    23727
+   $ cat /home/dave/alpine.pid
+   23727
 
+An example service file for an instance controlled by systemd is below.
+This can be used as a template to setup containerized services under
+systemd.
 
-An example service file for an instance controlled by systemd is below. This can be used as a
-template to setup containerized services under systemd.
+.. code::
 
-.. code-block::
+   [Unit]
+   Description=Web Instance
+   After=network.target
 
-    [Unit]
-    Description=Web Instance
-    After=network.target
+   [Service]
+   Type=forking
+   Restart=always
+   User=www-data
+   Group=www-data
+   PIDFile=/run/web-instance.pid
+   ExecStart=/usr/local/bin/singularity instance start --pid-file /run/web-instance.pid /data/containers/web.sif web-instance
+   ExecStop=/usr/local/bin/singularity instance stop web-instance
 
-    [Service]
-    Type=forking
-    Restart=always
-    User=www-data
-    Group=www-data
-    PIDFile=/run/web-instance.pid
-    ExecStart=/usr/local/bin/singularity instance start --pid-file /run/web-instance.pid /data/containers/web.sif web-instance
-    ExecStop=/usr/local/bin/singularity instance stop web-instance
+   [Install]
+   WantedBy=multi-user.target
 
-    [Install]
-    WantedBy=multi-user.target
-
-Note that ``Type=forking`` is required here, since ``instance start`` starts an instance and then exits.
+Note that ``Type=forking`` is required here, since ``instance start``
+starts an instance and then exits.

--- a/security.rst
+++ b/security.rst
@@ -1,17 +1,18 @@
 .. _security:
 
-*************************
-Security in {Singularity}
-*************************
+###########################
+ Security in {Singularity}
+###########################
 
-Security Policy
-###############
+*****************
+ Security Policy
+*****************
 
 If you suspect you have found a vulnerability in {Singularity} we want
-to work with you so that it can be investigated, fixed, and disclosed
-in a responsible manner. Please follow the steps in our published
-`Security Policy <https://singularity.hpcng.org/security-policy/>`__, which begins
-with contacting us privately via singularity‑security@hpcng.org
+to work with you so that it can be investigated, fixed, and disclosed in
+a responsible manner. Please follow the steps in our published `Security
+Policy <https://singularity.hpcng.org/security-policy/>`__, which begins with
+contacting us privately via singularity‑security@hpcng.org
 
 We disclose vulnerabilities found in {Singularity} through public
 CVE reports, and notifications on our community channels. We encourage
@@ -19,8 +20,9 @@ all users to monitor new releases of {Singularity} for security
 information. Security patches are applied to the latest open-source
 release.
 
-Background
-##########
+************
+ Background
+************
 
 {Singularity} grew out of the need to implement a container platform
 that was suitable for use on shared systems, such as HPC clusters. In
@@ -35,131 +37,130 @@ the Linux user namespace, only a privileged user could perform the
 operations which are needed to run a container. A default Docker
 installation uses a root-owned daemon to start containers. Users can
 request that the daemon starts a container on their behalf. However,
-co-ordinating a daemon with other schedulers is difficult and, since
-the daemon is privileged, users can ask it to carry out actions that
-they wouldn't normally have permission to do.
+co-ordinating a daemon with other schedulers is difficult and, since the
+daemon is privileged, users can ask it to carry out actions that they
+wouldn't normally have permission to do.
 
 When a user runs a container with {Singularity}, it is started as a
 normal process running under the user's account. Standard file
-permissions and other security controls based on user accounts,
-groups, and processes apply. In a default installation {Singularity}
-uses a setuid starter binary to perform only the specific tasks needed
-to setup the container.
+permissions and other security controls based on user accounts, groups,
+and processes apply. In a default installation {Singularity} uses a
+setuid starter binary to perform only the specific tasks needed to setup
+the container.
 
+**************************
+ Setuid & User Namespaces
+**************************
 
-Setuid & User Namespaces
-########################
-
-Using a setuid binary to run container setup operations is essential
-to support containers on older Linux distributions, such as CentOS 6,
-that were previously common in HPC and enterprise. Newer distributions
-have support for 'unprivileged user namespace creation'. This means a
-normal user can create a user namespace, in which most setup operations
-needed to run a container can be run, unprivileged.
+Using a setuid binary to run container setup operations is essential to
+support containers on older Linux distributions, such as CentOS 6, that
+were previously common in HPC and enterprise. Newer distributions have
+support for 'unprivileged user namespace creation'. This means a normal
+user can create a user namespace, in which most setup operations needed
+to run a container can be run, unprivileged.
 
 {Singularity} supports running containers without setuid, using user
-namespaces. It can be compiled with the ``--without-setuid`` option,
-or ``allow setuid = no`` can be set in ``singularity.conf`` to enable
-this. In this mode *all* operations run as the user who starts the
+namespaces. It can be compiled with the ``--without-setuid`` option, or
+``allow setuid = no`` can be set in ``singularity.conf`` to enable this.
+In this mode *all* operations run as the user who starts the
 ``singularity`` program. However, there are some disadvantages:
 
-* SIF and other single file container images cannot be mounted
-  directly. The container image must be extracted to a directory on
-  disk to run. This impact the speed of execution. Workloads accessing
-  large numbers of small files (such as python application startup) do
-  not benefit from the reduced metadata load on the filesystem an
-  image file provides.
+-  SIF and other single file container images cannot be mounted
+   directly. The container image must be extracted to a directory on
+   disk to run. This impact the speed of execution. Workloads accessing
+   large numbers of small files (such as python application startup) do
+   not benefit from the reduced metadata load on the filesystem an image
+   file provides.
 
-* Replacing direct kernel mounts with a FUSE approach is likely to
-  cause a significant reduction in perfomance.
+-  Replacing direct kernel mounts with a FUSE approach is likely to
+   cause a significant reduction in perfomance.
 
-* The effectiveness of signing and verifying container images is
-  reduced as, when extracted to a directory, modification is possible
-  and verification of the image's original signature cannot be
-  performed.
+-  The effectiveness of signing and verifying container images is
+   reduced as, when extracted to a directory, modification is possible
+   and verification of the image's original signature cannot be
+   performed.
 
-* Encryption is not supported. {Singularity} leverages kernel LUKS2
-  mounts to run encrypted containers without decrypting their content
-  to disk.
+-  Encryption is not supported. {Singularity} leverages kernel LUKS2
+   mounts to run encrypted containers without decrypting their content
+   to disk.
 
-* Some sites hold the opinion that vulnerabilities in kernel user
-  namespace code could have greater impact than vulnerabilities
-  confined to a single piece of setuid software. Therefore they are
-  reluctant to enable unprivileged user namespace creation.
+-  Some sites hold the opinion that vulnerabilities in kernel user
+   namespace code could have greater impact than vulnerabilities
+   confined to a single piece of setuid software. Therefore they are
+   reluctant to enable unprivileged user namespace creation.
 
 Because of the points above, the default mode of operation of
 {Singularity} uses a setuid binary. We aim to reduce the
 circumstances that require this as new functionality is developed and
 reaches commonly deployed Linux distributions.
 
-Runtime & User Privilege Model
-##############################
+********************************
+ Runtime & User Privilege Model
+********************************
 
 While other runtimes have aimed to safely sandbox containers executing
 as the ``root`` user, so that they cannot affect the host system,
 {Singularity} has adopted an alternative security model:
 
-* Containers should be run as an unprivileged user.
+-  Containers should be run as an unprivileged user.
 
-* The user should never be able to elevate their privileges inside the
-  container to gain control over the host.
+-  The user should never be able to elevate their privileges inside the
+   container to gain control over the host.
 
-* All permission restrictions on the user outside of a container
-  should apply inside the container.
+-  All permission restrictions on the user outside of a container should
+   apply inside the container.
 
-* Favor integration over isolation. Allow a user to use host resources
-  such as GPUs, network filesystems, high speed interconnects
-  easily. The process ID space, network etc. are not isolated in
-  separate namespaces by default.
+-  Favor integration over isolation. Allow a user to use host resources
+   such as GPUs, network filesystems, high speed interconnects easily.
+   The process ID space, network etc. are not isolated in separate
+   namespaces by default.
 
 To accomplish this, {Singularity} uses a number of Linux kernel
 features. The container file system is mounted using the ``nosuid``
-option, and processes are started with the ``PR_NO_NEW_PRIVS`` flag
-set. This means that even if you run ``sudo`` inside your container,
-you won't be able to change to another user, or gain root privileges
-by other means.
+option, and processes are started with the ``PR_NO_NEW_PRIVS`` flag set.
+This means that even if you run ``sudo`` inside your container, you
+won't be able to change to another user, or gain root privileges by
+other means.
 
-If you do require the additional isolation of the network, devices,
-PIDs etc. provided by other runtimes, {Singularity} can make use of
+If you do require the additional isolation of the network, devices, PIDs
+etc. provided by other runtimes, {Singularity} can make use of
 additional namespaces and functionality such as seccomp and cgroups.
 
+********************************
+ Singularity Image Format (SIF)
+********************************
 
-Singularity Image Format (SIF)
-##############################
+{Singularity} uses SIF as its default container format. A SIF container
+is a single file, which makes it easy to manage and distribute. Inside
+the SIF file, the container filesystem is held in a SquashFS object. By
+default, we mount the container filesystem directly using SquashFS. On a
+network filesytem this means that reads from the container are
+data-only. Metadata operations happen locally, speeding up workloads
+with many small files.
 
-{Singularity} uses SIF as its default container format. A SIF
-container is a single file, which makes it easy to manage and
-distribute. Inside the SIF file, the container filesystem is held in a
-SquashFS object. By default, we mount the container filesystem
-directly using SquashFS. On a network filesytem this means that reads
-from the container are data-only. Metadata operations happen locally,
-speeding up workloads with many small files.
+Holding the container image in a single file also enable unique security
+features. The container filesystem is immutable, and can be signed. The
+signature travels in the SIF image itself so that it is always possible
+to verify that the image has not been tampered with or corrupted.
 
-Holding the container image in a single file also enable unique
-security features. The container filesystem is immutable, and can be
-signed. The signature travels in the SIF image itself so that it is
-always possible to verify that the image has not been tampered with or
-corrupted.
+We use private PGP keys to create a container signature, and the public
+key in order to verify the container. Verification of signed containers
+happens automatically in ``singularity pull`` commands against the
+Sylabs Cloud Container Library. A Keystore in the Sylabs Cloud makes it
+easier to share and obtain public keys for container verification.
 
-We use private PGP keys to create a container signature, and the
-public key in order to verify the container. Verification of signed
-containers happens automatically in ``singularity pull`` commands
-against the Sylabs Cloud Container Library. A Keystore in the Sylabs
-Cloud makes it easier to share and obtain public keys for container
-verification.
-
-A container may be signed once, by a trusted individual who approves
-its use. It could also be signed with multiple keys to signify it has
-passed each step in a CI/CD QA & Security process. {Singularity} can
-be configured with an execution control list (ECL), which requires the
-presence of one or more valid signatures, to limit execution to
-approved containers.
+A container may be signed once, by a trusted individual who approves its
+use. It could also be signed with multiple keys to signify it has passed
+each step in a CI/CD QA & Security process. {Singularity} can be
+configured with an execution control list (ECL), which requires the
+presence of one or more valid signatures, to limit execution to approved
+containers.
 
 In {Singularity} 3.4 and above, the root filesystem of a container
-(stored in the squashFS partition of SIF) can be encrypted. As a
-result, everything inside the container becomes inaccessible without
-the correct key or passphrase. The content of the container is
-private, even if the SIF file is shared in public.
+(stored in the squashFS partition of SIF) can be encrypted. As a result,
+everything inside the container becomes inaccessible without the correct
+key or passphrase. The content of the container is private, even if the
+SIF file is shared in public.
 
 Encryption and decryption are performed using the Linux kernel's LUKS2
 feature. This is the same technology routinely used for full disk
@@ -167,22 +168,22 @@ encryption. The encrypted container is mounted directly through the
 kernel. Unlike other container formats, an encrypted container is not
 decrypted to disk in order to run it.
 
-
-Configuration & Runtime Options
-###############################
+*********************************
+ Configuration & Runtime Options
+*********************************
 
 System administrators who manage {Singularity} can use configuration
 files to set security restrictions, grant or revoke a user’s
 capabilities, manage resources and authorize containers etc.
 
 For example, the `ecl.toml
-<\{admindocs\}/configfiles.html#ecl-toml>`_
+<{admindocs}/configfiles.html#ecl-toml>`_
 file allows blacklisting and whitelisting of containers.
 
 Configuration files and their parameters are documented for
 administrators documented `here
-<\{admindocs\}/configfiles.html>`__.
+<{admindocs}/configfiles.html>`__.
 
-When running a container as root, Singularity can apply hardening
-rules using cgroups, seccomp, apparmor. See :ref:`details of these
-options here <security-options>`.
+When running a container as root, Singularity can apply hardening rules
+using cgroups, seccomp, apparmor. See :ref:`details of these options
+here <security-options>`.

--- a/security_options.rst
+++ b/security_options.rst
@@ -41,7 +41,7 @@ To take advantage of this granted capability as a user, ``pinger`` must also
 request the capability when executing a container with the ``--add-caps`` flag
 like so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
     PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
@@ -56,7 +56,7 @@ If the admin decides that it is no longer necessary to allow the user
 the appropriate Linux capability and ``pinger`` will not be able to add that
 capability to their containers anymore:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
     WARNING: not authorized to add capability: CAP_NET_RAW
@@ -76,7 +76,7 @@ Assuming the root user will execute containers with the ``CAP_NET_RAW``
 capability by default, executing the same container ``pinger`` executed above
 works without the need to grant capabilities:
 
-.. code-block:: none
+.. code-block::
 
     # singularity exec library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
     PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
@@ -88,7 +88,7 @@ works without the need to grant capabilities:
 
 Now we can manually drop the ``CAP_NET_RAW`` capability like so:
 
-.. code-block:: none
+.. code-block::
 
     # singularity exec --drop-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
     ping: socket: Operation not permitted
@@ -140,7 +140,7 @@ precaution.  But the root user can override this precaution and allow SetUID
 binaries to behave as expected within a {Singularity} container with the
 ``--allow-setuid`` option like so:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity shell --allow-setuid some_container.sif
 
@@ -155,7 +155,7 @@ default capabilities`` parameter in the ``singularity.conf`` file to ``file`` or
 the ``singularity.conf`` file and enter the container with full capabilities
 using the ``--keep-privs`` option.
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity exec --keep-privs library://centos ping -c 1 8.8.8.8
     PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
@@ -176,7 +176,7 @@ container as root to enhance security.
 For instance, to drop the ability for the root user to open a raw socket inside
 the container:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity exec --drop-caps CAP_NET_RAW library://centos ping -c 1 8.8.8.8
     ping: socket: Operation not permitted
@@ -194,7 +194,7 @@ also change the UID and GID of the user within the container at runtime.
 
 For instance:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo whoami
     root
@@ -213,7 +213,7 @@ with {Singularity}, normally at ``/usr/local/etc/singularity/seccomp-profiles/de
 For this example, we will use a much simpler configuration file to blacklist the
 ``mkdir`` command.
 
-.. code-block:: none
+.. code-block::
 
     {
         "defaultAction": "SCMP_ACT_ALLOW",
@@ -243,7 +243,7 @@ For this example, we will use a much simpler configuration file to blacklist the
 We'll save the file at ``/home/david/no_mkdir.json``. Then we can invoke the
 container like so:
 
-.. code-block:: none
+.. code-block::
 
     $ sudo singularity shell --security seccomp:/home/david/no_mkdir.json my_container.sif
 
@@ -255,7 +255,7 @@ core dump.
 
 The full list of arguments accepted by the ``--security`` option are as follows:
 
-.. code-block:: none
+.. code-block::
 
     --security="seccomp:/usr/local/etc/singularity/seccomp-profiles/default.json"
     --security="apparmor:/usr/bin/man"

--- a/security_options.rst
+++ b/security_options.rst
@@ -36,7 +36,7 @@ open raw sockets so that they can use ``ping`` in a container where the
 binary is controlled via capabilities. For information about how to
 manage capabilities as an admin please refer to the `capability admin
 docs
-<\{admindocs\}/configfiles.html#capability.json>`_.
+<{admindocs}/configfiles.html#capability.json>`_.
 
 To take advantage of this granted capability as a user, ``pinger`` must
 also request the capability when executing a container with the
@@ -69,9 +69,9 @@ spawning containers as the root user to help minimize attack surfaces.
 With a default installation of {Singularity}, containers created by the
 root user will maintain all capabilities. This behavior is configurable
 if desired. Check out the `capability configuration
-<\{admindocs\}/configfiles.html#capability.json>`_
+<{admindocs}/configfiles.html#capability.json>`_
 and `root default capabilities
-<\{admindocs\}/configfiles.html#setuid-and-capabilities>`_
+<{admindocs}/configfiles.html#setuid-and-capabilities>`_
 sections of the admin docs for more information.
 
 Assuming the root user will execute containers with the ``CAP_NET_RAW``

--- a/security_options.rst
+++ b/security_options.rst
@@ -1,265 +1,269 @@
 .. _security-options:
 
-================
-Security Options
-================
+##################
+ Security Options
+##################
 
 .. _sec:security_options:
 
-{Singularity} 3.0 introduces many new security related options to the container
-runtime.  This document will describe the new methods users have for specifying
-the security scope and context when running {Singularity} containers.
+{Singularity} 3.0 introduces many new security related options to the
+container runtime. This document will describe the new methods users
+have for specifying the security scope and context when running
+{Singularity} containers.
 
-
-------------------
-Linux Capabilities
-------------------
+********************
+ Linux Capabilities
+********************
 
 .. note::
-     It is extremely important to recognize that **granting users Linux
-     capabilities with the** ``capability`` **command group is usually identical
-     to granting those users root level access on the host system**. Most if not
-     all capabilities will allow users to "break out" of the container and
-     become root on the host. This feature is targeted toward special use cases
-     (like cloud-native architectures) where an admin/developer might want to
-     limit the attack surface within a container that normally runs as root.
-     This is not a good option in multi-tenant HPC environments where an admin
-     wants to grant a user special privileges within a container. For that and
-     similar use cases, the :ref:`fakeroot feature <fakeroot>` is a better
-     option.
 
-{Singularity} provides full support for granting and revoking Linux capabilities
-on a user or group basis.  For example, let us suppose that an admin has
-decided to grant a user (named ``pinger``) capabilities to open raw sockets so
-that they can use ``ping`` in a container where the binary is controlled via
-capabilities. For information about how to manage capabilities as an admin
-please refer to the
-`capability admin docs <\{admindocs\}/configfiles.html#capability.json>`_.
+   It is extremely important to recognize that **granting users Linux
+   capabilities with the** ``capability`` **command group is usually
+   identical to granting those users root level access on the host
+   system**. Most if not all capabilities will allow users to "break
+   out" of the container and become root on the host. This feature is
+   targeted toward special use cases (like cloud-native architectures)
+   where an admin/developer might want to limit the attack surface
+   within a container that normally runs as root. This is not a good
+   option in multi-tenant HPC environments where an admin wants to grant
+   a user special privileges within a container. For that and similar
+   use cases, the :ref:`fakeroot feature <fakeroot>` is a better option.
 
+{Singularity} provides full support for granting and revoking Linux
+capabilities on a user or group basis. For example, let us suppose that
+an admin has decided to grant a user (named ``pinger``) capabilities to
+open raw sockets so that they can use ``ping`` in a container where the
+binary is controlled via capabilities. For information about how to
+manage capabilities as an admin please refer to the `capability admin
+docs
+<\{admindocs\}/configfiles.html#capability.json>`_.
 
-To take advantage of this granted capability as a user, ``pinger`` must also
-request the capability when executing a container with the ``--add-caps`` flag
-like so:
+To take advantage of this granted capability as a user, ``pinger`` must
+also request the capability when executing a container with the
+``--add-caps`` flag like so:
 
-.. code-block::
+.. code::
 
-    $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
-    PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
-    64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=73.1 ms
+   $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+   64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=73.1 ms
 
-    --- 8.8.8.8 ping statistics ---
-    1 packets transmitted, 1 received, 0% packet loss, time 0ms
-    rtt min/avg/max/mdev = 73.178/73.178/73.178/0.000 ms
+   --- 8.8.8.8 ping statistics ---
+   1 packets transmitted, 1 received, 0% packet loss, time 0ms
+   rtt min/avg/max/mdev = 73.178/73.178/73.178/0.000 ms
 
 If the admin decides that it is no longer necessary to allow the user
-``pinger`` to open raw sockets within {Singularity} containers, they can revoke
-the appropriate Linux capability and ``pinger`` will not be able to add that
-capability to their containers anymore:
+``pinger`` to open raw sockets within {Singularity} containers, they can
+revoke the appropriate Linux capability and ``pinger`` will not be able
+to add that capability to their containers anymore:
 
-.. code-block::
+.. code::
 
-    $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
-    WARNING: not authorized to add capability: CAP_NET_RAW
-    ping: socket: Operation not permitted
+   $ singularity exec --add-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   WARNING: not authorized to add capability: CAP_NET_RAW
+   ping: socket: Operation not permitted
 
-
-Another scenario which is atypical of shared resource environments, but useful
-in cloud-native architectures is dropping capabilities when spawning containers
-as the root user to help minimize attack surfaces. With a default installation
-of {Singularity}, containers created by the root user will maintain all
-capabilities. This behavior is configurable if desired. Check out the
-`capability configuration <\{admindocs\}/configfiles.html#capability.json>`_
-and `root default capabilities <\{admindocs\}/configfiles.html#setuid-and-capabilities>`_
+Another scenario which is atypical of shared resource environments, but
+useful in cloud-native architectures is dropping capabilities when
+spawning containers as the root user to help minimize attack surfaces.
+With a default installation of {Singularity}, containers created by the
+root user will maintain all capabilities. This behavior is configurable
+if desired. Check out the `capability configuration
+<\{admindocs\}/configfiles.html#capability.json>`_
+and `root default capabilities
+<\{admindocs\}/configfiles.html#setuid-and-capabilities>`_
 sections of the admin docs for more information.
 
 Assuming the root user will execute containers with the ``CAP_NET_RAW``
-capability by default, executing the same container ``pinger`` executed above
-works without the need to grant capabilities:
+capability by default, executing the same container ``pinger`` executed
+above works without the need to grant capabilities:
 
-.. code-block::
+.. code::
 
-    # singularity exec library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
-    PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
-    64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=59.6 ms
+   # singularity exec library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+   64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=59.6 ms
 
-    --- 8.8.8.8 ping statistics ---
-    1 packets transmitted, 1 received, 0% packet loss, time 0ms
-    rtt min/avg/max/mdev = 59.673/59.673/59.673/0.000 ms
+   --- 8.8.8.8 ping statistics ---
+   1 packets transmitted, 1 received, 0% packet loss, time 0ms
+   rtt min/avg/max/mdev = 59.673/59.673/59.673/0.000 ms
 
 Now we can manually drop the ``CAP_NET_RAW`` capability like so:
 
-.. code-block::
+.. code::
 
-    # singularity exec --drop-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
-    ping: socket: Operation not permitted
+   # singularity exec --drop-caps CAP_NET_RAW library://sylabs/tests/ubuntu_ping:v1.0 ping -c 1 8.8.8.8
+   ping: socket: Operation not permitted
 
-And now the container will not have the ability to create new sockets, causing
-the ``ping`` command to fail.
+And now the container will not have the ability to create new sockets,
+causing the ``ping`` command to fail.
 
-The ``--add-caps`` and ``--drop-caps`` options will accept the ``all`` keyword.
-Of course appropriate caution should be exercised when using this keyword.
+The ``--add-caps`` and ``--drop-caps`` options will accept the ``all``
+keyword. Of course appropriate caution should be exercised when using
+this keyword.
 
------------------------------
-Building encrypted containers
------------------------------
-Beginning in {Singularity} 3.4.0 it is possible to build and run encrypted
-containers.  The containers are decrypted at runtime entirely in kernel space,
-meaning that no intermediate decrypted data is ever present on disk. See
-:ref:`encrypted containers <encryption>` for more details.
+*******************************
+ Building encrypted containers
+*******************************
 
+Beginning in {Singularity} 3.4.0 it is possible to build and run
+encrypted containers. The containers are decrypted at runtime entirely
+in kernel space, meaning that no intermediate decrypted data is ever
+present on disk. See :ref:`encrypted containers <encryption>` for more
+details.
 
--------------------------------
-Security related action options
--------------------------------
+*********************************
+ Security related action options
+*********************************
 
-{Singularity} 3.0 introduces many new flags that can be passed to the action
-commands; ``shell``, ``exec``, and ``run`` allowing fine grained control of
-security.
-
+{Singularity} 3.0 introduces many new flags that can be passed to the
+action commands; ``shell``, ``exec``, and ``run`` allowing fine grained
+control of security.
 
 ``--add-caps``
 ==============
 
-As explained above, ``--add-caps`` will "activate" Linux capabilities when a
-container is initiated, providing those capabilities have been granted to the
-user by an administrator using the ``capability add`` command. This option will
-also accept the case insensitive keyword ``all`` to add every capability
-granted by the administrator.
-
+As explained above, ``--add-caps`` will "activate" Linux capabilities
+when a container is initiated, providing those capabilities have been
+granted to the user by an administrator using the ``capability add``
+command. This option will also accept the case insensitive keyword
+``all`` to add every capability granted by the administrator.
 
 ``--allow-setuid``
 ==================
 
-The SetUID bit allows a program to be executed as the user that owns the binary.
-The most well-known SetUID binaries are owned by root and allow a user to
-execute a command with elevated privileges.  But other SetUID binaries may
-allow a user to execute a command as a service account.
+The SetUID bit allows a program to be executed as the user that owns the
+binary. The most well-known SetUID binaries are owned by root and allow
+a user to execute a command with elevated privileges. But other SetUID
+binaries may allow a user to execute a command as a service account.
 
-By default SetUID is disallowed within {Singularity} containers as a security
-precaution.  But the root user can override this precaution and allow SetUID
-binaries to behave as expected within a {Singularity} container with the
-``--allow-setuid`` option like so:
+By default SetUID is disallowed within {Singularity} containers as a
+security precaution. But the root user can override this precaution and
+allow SetUID binaries to behave as expected within a {Singularity}
+container with the ``--allow-setuid`` option like so:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity shell --allow-setuid some_container.sif
-
+   $ sudo singularity shell --allow-setuid some_container.sif
 
 ``--keep-privs``
 ================
 
-It is possible for an admin to set a different set of default capabilities or to
-reduce the default capabilities to zero for the root user by setting the ``root
-default capabilities`` parameter in the ``singularity.conf`` file to ``file`` or
-``no`` respectively.  If this change is in effect, the root user can override
-the ``singularity.conf`` file and enter the container with full capabilities
-using the ``--keep-privs`` option.
+It is possible for an admin to set a different set of default
+capabilities or to reduce the default capabilities to zero for the root
+user by setting the ``root default capabilities`` parameter in the
+``singularity.conf`` file to ``file`` or ``no`` respectively. If this
+change is in effect, the root user can override the ``singularity.conf``
+file and enter the container with full capabilities using the
+``--keep-privs`` option.
 
-.. code-block::
+.. code::
 
-    $ sudo singularity exec --keep-privs library://centos ping -c 1 8.8.8.8
-    PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
-    64 bytes from 8.8.8.8: icmp_seq=1 ttl=128 time=18.8 ms
+   $ sudo singularity exec --keep-privs library://centos ping -c 1 8.8.8.8
+   PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+   64 bytes from 8.8.8.8: icmp_seq=1 ttl=128 time=18.8 ms
 
-    --- 8.8.8.8 ping statistics ---
-    1 packets transmitted, 1 received, 0% packet loss, time 0ms
-    rtt min/avg/max/mdev = 18.838/18.838/18.838/0.000 ms
-
+   --- 8.8.8.8 ping statistics ---
+   1 packets transmitted, 1 received, 0% packet loss, time 0ms
+   rtt min/avg/max/mdev = 18.838/18.838/18.838/0.000 ms
 
 ``--drop-caps``
-================
+===============
 
-By default, the root user has a full set of capabilities when they enter the
-container. You may choose to drop specific capabilities when you initiate a
-container as root to enhance security.
+By default, the root user has a full set of capabilities when they enter
+the container. You may choose to drop specific capabilities when you
+initiate a container as root to enhance security.
 
-For instance, to drop the ability for the root user to open a raw socket inside
-the container:
+For instance, to drop the ability for the root user to open a raw socket
+inside the container:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity exec --drop-caps CAP_NET_RAW library://centos ping -c 1 8.8.8.8
-    ping: socket: Operation not permitted
+   $ sudo singularity exec --drop-caps CAP_NET_RAW library://centos ping -c 1 8.8.8.8
+   ping: socket: Operation not permitted
 
-The ``drop-caps`` option will also accept the case insensitive keyword ``all``
-as an option to drop all capabilities when entering the container.
-
+The ``drop-caps`` option will also accept the case insensitive keyword
+``all`` as an option to drop all capabilities when entering the
+container.
 
 ``--security``
 ==============
 
-The ``--security`` flag allows the root user to leverage security modules such
-as SELinux, AppArmor, and seccomp within your {Singularity} container. You can
-also change the UID and GID of the user within the container at runtime.
+The ``--security`` flag allows the root user to leverage security
+modules such as SELinux, AppArmor, and seccomp within your {Singularity}
+container. You can also change the UID and GID of the user within the
+container at runtime.
 
 For instance:
 
-.. code-block::
+.. code::
 
-    $ sudo whoami
-    root
+   $ sudo whoami
+   root
 
-    $ sudo singularity exec --security uid:1000 my_container.sif whoami
-    david
+   $ sudo singularity exec --security uid:1000 my_container.sif whoami
+   david
 
-To use seccomp to blacklist a command follow this procedure. (It is actually
-preferable from a security standpoint to whitelist commands but this will
-suffice for a simple example.)  Note that this example was run on Ubuntu and
-that {Singularity} was installed with the ``libseccomp-dev`` and ``pkg-config``
-packages as dependencies.
+To use seccomp to blacklist a command follow this procedure. (It is
+actually preferable from a security standpoint to whitelist commands but
+this will suffice for a simple example.) Note that this example was run
+on Ubuntu and that {Singularity} was installed with the
+``libseccomp-dev`` and ``pkg-config`` packages as dependencies.
 
-First write a configuration file.  An example configuration file is installed
-with {Singularity}, normally at ``/usr/local/etc/singularity/seccomp-profiles/default.json``.
-For this example, we will use a much simpler configuration file to blacklist the
+First write a configuration file. An example configuration file is
+installed with {Singularity}, normally at
+``/usr/local/etc/singularity/seccomp-profiles/default.json``. For this
+example, we will use a much simpler configuration file to blacklist the
 ``mkdir`` command.
 
-.. code-block::
+.. code::
 
-    {
-        "defaultAction": "SCMP_ACT_ALLOW",
-        "archMap": [
-            {
-                "architecture": "SCMP_ARCH_X86_64",
-                "subArchitectures": [
-                    "SCMP_ARCH_X86",
-                    "SCMP_ARCH_X32"
-                ]
-            }
-        ],
-        "syscalls": [
-            {
-                "names": [
-                    "mkdir"
-                ],
-                "action": "SCMP_ACT_KILL",
-                "args": [],
-                "comment": "",
-                "includes": {},
-                "excludes": {}
-            }
-        ]
-    }
+   {
+       "defaultAction": "SCMP_ACT_ALLOW",
+       "archMap": [
+           {
+               "architecture": "SCMP_ARCH_X86_64",
+               "subArchitectures": [
+                   "SCMP_ARCH_X86",
+                   "SCMP_ARCH_X32"
+               ]
+           }
+       ],
+       "syscalls": [
+           {
+               "names": [
+                   "mkdir"
+               ],
+               "action": "SCMP_ACT_KILL",
+               "args": [],
+               "comment": "",
+               "includes": {},
+               "excludes": {}
+           }
+       ]
+   }
 
-We'll save the file at ``/home/david/no_mkdir.json``. Then we can invoke the
-container like so:
+We'll save the file at ``/home/david/no_mkdir.json``. Then we can invoke
+the container like so:
 
-.. code-block::
+.. code::
 
-    $ sudo singularity shell --security seccomp:/home/david/no_mkdir.json my_container.sif
+   $ sudo singularity shell --security seccomp:/home/david/no_mkdir.json my_container.sif
 
-    Singularity> mkdir /tmp/foo
-    Bad system call (core dumped)
+   Singularity> mkdir /tmp/foo
+   Bad system call (core dumped)
 
-Note that attempting to use the blacklisted ``mkdir`` command resulted in a
-core dump.
+Note that attempting to use the blacklisted ``mkdir`` command resulted
+in a core dump.
 
-The full list of arguments accepted by the ``--security`` option are as follows:
+The full list of arguments accepted by the ``--security`` option are as
+follows:
 
-.. code-block::
+.. code::
 
-    --security="seccomp:/usr/local/etc/singularity/seccomp-profiles/default.json"
-    --security="apparmor:/usr/bin/man"
-    --security="selinux:context"
-    --security="uid:1000"
-    --security="gid:1000"
-    --security="gid:1000:1:0" (multiple gids, first is always the primary group)
+   --security="seccomp:/usr/local/etc/singularity/seccomp-profiles/default.json"
+   --security="apparmor:/usr/bin/man"
+   --security="selinux:context"
+   --security="uid:1000"
+   --security="gid:1000"
+   --security="gid:1000:1:0" (multiple gids, first is always the primary group)

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -1,69 +1,73 @@
-.. _signNverify:
+.. _signnverify:
 
-================================
-Signing and Verifying Containers
-================================
+##################################
+ Signing and Verifying Containers
+##################################
 
+.. _sec:signnverify:
 
-.. _sec:signNverify:
-
-{Singularity} 3.0 introduced the ability to create and manage PGP keys and use
-them to sign and verify containers. This provides a trusted method for
-{Singularity} users to share containers. It ensures a bit-for-bit reproduction
-of the original container as the author intended it.
+{Singularity} 3.0 introduced the ability to create and manage PGP keys
+and use them to sign and verify containers. This provides a trusted
+method for {Singularity} users to share containers. It ensures a
+bit-for-bit reproduction of the original container as the author
+intended it.
 
 .. note::
 
-    {Singularity} 3.6.0 uses a new signature format. Containers signed
-    by 3.6.0 cannot be verifed by older versions of {Singularity}.
+   {Singularity} 3.6.0 uses a new signature format. Containers signed by
+   3.6.0 cannot be verifed by older versions of {Singularity}.
 
-    To verify containers signed with older versions of {Singularity} using 3.6.0
-    the ``--legacy-insecure`` flag must be provided to the ``singularity verify`` command.
-
+   To verify containers signed with older versions of {Singularity}
+   using 3.6.0 the ``--legacy-insecure`` flag must be provided to the
+   ``singularity verify`` command.
 
 .. _verify_container_from_library:
 
------------------------------------------------
-Verifying containers from the Container Library
------------------------------------------------
+*************************************************
+ Verifying containers from the Container Library
+*************************************************
 
-The ``verify`` command will allow you to verify that a container has been
-signed using a PGP key. To use this feature with images that you pull from the
-container library, you must first generate an access token to the Sylabs Cloud.
-If you don't already have a valid access token, follow these steps:
+The ``verify`` command will allow you to verify that a container has
+been signed using a PGP key. To use this feature with images that you
+pull from the container library, you must first generate an access token
+to the Sylabs Cloud. If you don't already have a valid access token,
+follow these steps:
 
-  1) Go to: https://cloud.sylabs.io/
-  2) Click "Sign In" and follow the sign in steps.
-  3) Click on your login id (same and updated button as the Sign in one).
-  4) Select "Access Tokens" from the drop down menu.
-  5) Enter a name for your new access token, such as "test token"
-  6) Click the "Create a New Access Token" button.
-  7) Click "Copy token to Clipboard" from the "New API Token" page.
-  8) Run ``singularity remote login`` and paste the access token at the prompt.
+   #. Go to: https://cloud.sylabs.io/
+   #. Click "Sign In" and follow the sign in steps.
+   #. Click on your login id (same and updated button as the Sign in
+      one).
+   #. Select "Access Tokens" from the drop down menu.
+   #. Enter a name for your new access token, such as "test token"
+   #. Click the "Create a New Access Token" button.
+   #. Click "Copy token to Clipboard" from the "New API Token" page.
+   #. Run ``singularity remote login`` and paste the access token at the
+      prompt.
 
-Now you can verify containers that you pull from the library, ensuring they are
-bit-for-bit reproductions of the original image.
+Now you can verify containers that you pull from the library, ensuring
+they are bit-for-bit reproductions of the original image.
 
-.. code-block::
+.. code::
 
-    $ singularity verify alpine_latest.sif 
+   $ singularity verify alpine_latest.sif
 
-    Container is signed by 1 key(s):
+   Container is signed by 1 key(s):
 
-    Verifying partition: FS:
-    8883491F4268F173C6E5DC49EDECE4F3F38D871E
-    [REMOTE]  Sylabs Admin <support@sylabs.io>
-    [OK]      Data integrity verified
+   Verifying partition: FS:
+   8883491F4268F173C6E5DC49EDECE4F3F38D871E
+   [REMOTE]  Sylabs Admin <support@sylabs.io>
+   [OK]      Data integrity verified
 
-    INFO:    Container verified: alpine_latest.sif
+   INFO:    Container verified: alpine_latest.sif
 
-In this example you can see that **Sylabs Admin** has signed the container.
+In this example you can see that **Sylabs Admin** has signed the
+container.
 
 .. _sign_your_own_containers:
 
----------------------------
-Signing your own containers
----------------------------
+*****************************
+ Signing your own containers
+*****************************
 
 Generating and managing PGP keys
 ================================
@@ -71,274 +75,270 @@ Generating and managing PGP keys
 To sign your own containers you first need to generate one or more keys.
 
 If you attempt to sign a container before you have generated any keys,
-{Singularity} will guide you through the interactive process of creating a new
-key. Or you can use the ``newpair`` subcommand in the ``key`` command group
-like so:.
+{Singularity} will guide you through the interactive process of creating
+a new key. Or you can use the ``newpair`` subcommand in the ``key``
+command group like so:.
 
-.. code-block::
+.. code::
 
-    $ singularity key newpair
-    
-    Enter your name (e.g., John Doe) : David Trudgian
-    Enter your email address (e.g., john.doe@example.com) : david.trudgian@sylabs.io
-    Enter optional comment (e.g., development keys) : demo
-    Enter a passphrase : 
-    Retype your passphrase : 
-    Would you like to push it to the keystore? [Y,n] Y
-    Generating Entity and OpenPGP Key Pair... done
-    Key successfully pushed to: https://keys.sylabs.io
+   $ singularity key newpair
+
+   Enter your name (e.g., John Doe) : David Trudgian
+   Enter your email address (e.g., john.doe@example.com) : david.trudgian@sylabs.io
+   Enter optional comment (e.g., development keys) : demo
+   Enter a passphrase :
+   Retype your passphrase :
+   Would you like to push it to the keystore? [Y,n] Y
+   Generating Entity and OpenPGP Key Pair... done
+   Key successfully pushed to: https://keys.sylabs.io
 
 Note that I chose ``Y`` when asked if I wanted to push my key to the
 keystore. This will push my public key to whichever keystore has been
 configured by the ``singularity remote`` command, so that it can be
 retrieved by other users running ``singularity verify``. If you do not
-wish to push your public key, say ``n`` during the ``newpair``
-process.
-    
+wish to push your public key, say ``n`` during the ``newpair`` process.
 
-The ``list`` subcommand will show you all of the keys you have created or saved
-locally.`
+The ``list`` subcommand will show you all of the keys you have created
+or saved locally.`
 
-.. code-block::
+.. code::
 
-    $ singularity key list
+   $ singularity key list
 
-    Public key listing (/home/dave/.singularity/sypgp/pgp-public):
+   Public key listing (/home/dave/.singularity/sypgp/pgp-public):
 
-    0) U: David Trudgian (demo) <david.trudgian@sylabs.io>
-       C: 2019-11-15 09:54:54 -0600 CST
-       F: E5F780B2C22F59DF748524B435C3844412EE233B
-       L: 4096
-       --------
+   0) U: David Trudgian (demo) <david.trudgian@sylabs.io>
+      C: 2019-11-15 09:54:54 -0600 CST
+      F: E5F780B2C22F59DF748524B435C3844412EE233B
+      L: 4096
+      --------
 
 In the output above the index of my key is ``0`` and the letters stand
 for the following:
 
-       - U: User
-       - C: Creation date and time
-       - F: Fingerprint
-       - L: Key length
+   -  U: User
+   -  C: Creation date and time
+   -  F: Fingerprint
+   -  L: Key length
 
-If you chose not to push your key to the keystore during the ``newpair`` process, but later wish to, you can push it to a keystore configured using ``singularity remote`` like so:
+If you chose not to push your key to the keystore during the ``newpair``
+process, but later wish to, you can push it to a keystore configured
+using ``singularity remote`` like so:
 
-.. code-block::
+.. code::
 
-    $ singularity key push E5F780B2C22F59DF748524B435C3844412EE233B
-    
-    public key `E5F780B2C22F59DF748524B435C3844412EE233B` pushed to server successfully
+   $ singularity key push E5F780B2C22F59DF748524B435C3844412EE233B
 
-If you delete your local public PGP key, you can always locate and download it
-again like so.
+   public key `E5F780B2C22F59DF748524B435C3844412EE233B` pushed to server successfully
 
-.. code-block::
+If you delete your local public PGP key, you can always locate and
+download it again like so.
 
-    $ singularity key search Trudgian
+.. code::
 
-    Showing 1 results
+   $ singularity key search Trudgian
 
-    KEY ID    BITS  NAME/EMAIL
-    12EE233B  4096  David Trudgian (demo) <david.trudgian@sylabs.io>  
+   Showing 1 results
 
-    $ singularity key pull 12EE233B
-    
-    1 key(s) added to keyring of trust /home/dave/.singularity/sypgp/pgp-public
+   KEY ID    BITS  NAME/EMAIL
+   12EE233B  4096  David Trudgian (demo) <david.trudgian@sylabs.io>
 
-But note that this only restores the *public* key (used for verifying) to your
-local machine and does not restore the *private* key (used for signing).
+   $ singularity key pull 12EE233B
+
+   1 key(s) added to keyring of trust /home/dave/.singularity/sypgp/pgp-public
+
+But note that this only restores the *public* key (used for verifying)
+to your local machine and does not restore the *private* key (used for
+signing).
 
 .. _searching_for_keys:
 
 Searching for keys
 ==================
 
-{Singularity} allows you to search the keystore for public keys. You can search for names,
-emails, and fingerprints (key IDs). When searching for a fingerprint, you need to use ``0x``
-before the fingerprint, check the example:
+{Singularity} allows you to search the keystore for public keys. You can
+search for names, emails, and fingerprints (key IDs). When searching for
+a fingerprint, you need to use ``0x`` before the fingerprint, check the
+example:
 
-.. code-block::
+.. code::
 
-    # search for key ID:
-    $ singularity key search 0x8883491F4268F173C6E5DC49EDECE4F3F38D871E
+   # search for key ID:
+   $ singularity key search 0x8883491F4268F173C6E5DC49EDECE4F3F38D871E
 
-    # search for the sort ID:
-    $ singularity key search 0xF38D871E
+   # search for the sort ID:
+   $ singularity key search 0xF38D871E
 
-    # search for user:
-    $ singularity key search Godlove
+   # search for user:
+   $ singularity key search Godlove
 
-    # search for email:
-    $ singularity key search @gmail.com
+   # search for email:
+   $ singularity key search @gmail.com
 
 Signing and validating your own containers
 ==========================================
 
-Now that you have a key generated, you can use it to sign images like so:
+Now that you have a key generated, you can use it to sign images like
+so:
 
-.. code-block::
+.. code::
 
-    $ singularity sign my_container.sif 
+   $ singularity sign my_container.sif
 
-    Signing image: my_container.sif
-    Enter key passphrase : 
-    Signature created and applied to my_container.sif
+   Signing image: my_container.sif
+   Enter key passphrase :
+   Signature created and applied to my_container.sif
 
-Because your public PGP key is saved locally you can verify the image without
-needing to contact the Keystore.
+Because your public PGP key is saved locally you can verify the image
+without needing to contact the Keystore.
 
-.. code-block::
+.. code::
 
-    $ singularity verify my_container.sif
-    Verifying image: my_container.sif
-    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
-    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
-    Objects verified:
-    ID  |GROUP   |LINK    |TYPE
-    ------------------------------------------------
-    1   |1       |NONE    |Def.FILE
-    2   |1       |NONE    |JSON.Generic
-    3   |1       |NONE    |FS
-    Container verified: my_container.sif
+   $ singularity verify my_container.sif
+   Verifying image: my_container.sif
+   [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
+   Objects verified:
+   ID  |GROUP   |LINK    |TYPE
+   ------------------------------------------------
+   1   |1       |NONE    |Def.FILE
+   2   |1       |NONE    |JSON.Generic
+   3   |1       |NONE    |FS
+   Container verified: my_container.sif
 
+If you've pushed your key to the Keystore you can also verify this image
+in the absence of a local public key. To demonstrate this, first
+``remove`` your local public key, and then try to use the ``verify``
+command again.
 
-If you've pushed your key to the Keystore you can also verify this
-image in the absence of a local public key.  To demonstrate this,
-first ``remove`` your local public key, and then try to use the
-``verify`` command again.
+.. code::
 
-.. code-block::
+   $ singularity key remove E5F780B2C22F59DF748524B435C3844412EE233B
 
-    $ singularity key remove E5F780B2C22F59DF748524B435C3844412EE233B
-
-    $ singularity verify my_container.sif
-    Verifying image: my_container.sif
-    [REMOTE]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
-    [REMOTE]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
-    Objects verified:
-    ID  |GROUP   |LINK    |TYPE
-    ------------------------------------------------
-    1   |1       |NONE    |Def.FILE
-    2   |1       |NONE    |JSON.Generic
-    3   |1       |NONE    |FS
-    Container verified: my_container.sif
-
+   $ singularity verify my_container.sif
+   Verifying image: my_container.sif
+   [REMOTE]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
+   [REMOTE]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
+   Objects verified:
+   ID  |GROUP   |LINK    |TYPE
+   ------------------------------------------------
+   1   |1       |NONE    |Def.FILE
+   2   |1       |NONE    |JSON.Generic
+   3   |1       |NONE    |FS
+   Container verified: my_container.sif
 
 Note that the ``[REMOTE]`` message shows the key used for verification
 was obtained from the keystore, and is not present on your local
 computer. You can retrieve it, so that you can verify even if you are
 offline with ``singularity key pull``
 
-.. code-block::
+.. code::
 
-    $ singularity key pull E5F780B2C22F59DF748524B435C3844412EE233B
+   $ singularity key pull E5F780B2C22F59DF748524B435C3844412EE233B
 
-    1 key(s) added to keyring of trust /home/dave/.singularity/sypgp/pgp-public
-
+   1 key(s) added to keyring of trust /home/dave/.singularity/sypgp/pgp-public
 
 Advanced Signing - SIF IDs and Groups
 =====================================
 
-As well as the default behaviour, which signs all objects,
-fine-grained control of signing is possible.
+As well as the default behaviour, which signs all objects, fine-grained
+control of signing is possible.
 
-If you ``sif list`` a SIF file you will see it is comprised of a
-number of objects. Each object has an ``ID``, and belongs to a
-``GROUP``.
+If you ``sif list`` a SIF file you will see it is comprised of a number
+of objects. Each object has an ``ID``, and belongs to a ``GROUP``.
 
-.. code-block::
+.. code::
 
-    $ singularity sif list my_container.sif 
+   $ singularity sif list my_container.sif
 
-    Container id: e455d2ae-7f0b-4c79-b3ef-315a4913d76a
-    Created on:   2019-11-15 10:11:58 -0600 CST
-    Modified on:  2019-11-15 10:11:58 -0600 CST
-    ----------------------------------------------------
-    Descriptor list:
-    ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
-    ------------------------------------------------------------------------------
-    1    |1       |NONE    |32768-32800               |Def.FILE
-    2    |1       |NONE    |36864-36961               |JSON.Generic
-    3    |1       |NONE    |40960-25890816            |FS (Squashfs/*System/amd64)
+   Container id: e455d2ae-7f0b-4c79-b3ef-315a4913d76a
+   Created on:   2019-11-15 10:11:58 -0600 CST
+   Modified on:  2019-11-15 10:11:58 -0600 CST
+   ----------------------------------------------------
+   Descriptor list:
+   ID   |GROUP   |LINK    |SIF POSITION (start-end)  |TYPE
+   ------------------------------------------------------------------------------
+   1    |1       |NONE    |32768-32800               |Def.FILE
+   2    |1       |NONE    |36864-36961               |JSON.Generic
+   3    |1       |NONE    |40960-25890816            |FS (Squashfs/*System/amd64)
 
+I can choose to sign and verify a specific object with the ``--sif-id``
+option to ``sign`` and ``verify``.
 
-I can choose to sign and verify a specific object with the ``--sif-id`` option
-to ``sign`` and ``verify``.
+.. code::
 
-.. code-block::
+   $ singularity sign --sif-id 1 my_container.sif
+   Signing image: my_container.sif
+   Enter key passphrase :
+   Signature created and applied to my_container.sif
 
-    $ singularity sign --sif-id 1 my_container.sif 
-    Signing image: my_container.sif
-    Enter key passphrase : 
-    Signature created and applied to my_container.sif 
+   $ singularity verify --sif-id 1 my_container.sif
+   Verifying image: my_container.sif
+   [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
+   Objects verified:
+   ID  |GROUP   |LINK    |TYPE
+   ------------------------------------------------
+   1   |1       |NONE    |Def.FILE
+   Container verified: my_container.sif
 
-    $ singularity verify --sif-id 1 my_container.sif
-    Verifying image: my_container.sif
-    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
-    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
-    Objects verified:
-    ID  |GROUP   |LINK    |TYPE
-    ------------------------------------------------
-    1   |1       |NONE    |Def.FILE
-    Container verified: my_container.sif
+Note that running the ``verify`` command without specifying the specific
+sif-id gives a fatal error. The container is not considered verified as
+whole because other objects could have been changed without my
+knowledge.
 
+.. code::
 
-Note that running the ``verify`` command without specifying the specific sif-id
-gives a fatal error. The container is not considered verified as whole because
-other objects could have been changed without my knowledge.
+   $ singularity verify my_container.sif
+   Verifying image: my_container.sif
+   [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
 
-.. code-block::
+   Error encountered during signature verification: object 2: object not signed
+   FATAL:   Failed to verify container: integrity: object 2: object not signed
 
-    $ singularity verify my_container.sif
-    Verifying image: my_container.sif
-    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
-    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
+I can sign a group of objects with the ``--group-id`` option to
+``sign``.
 
-    Error encountered during signature verification: object 2: object not signed
-    FATAL:   Failed to verify container: integrity: object 2: object not signed
+.. code::
 
+   $ singularity sign --groupid 1 my_container.sif
+   Signing image: my_container.sif
+   Enter key passphrase :
+   Signature created and applied to my_container.sif
 
-I can sign a group of objects with the ``--group-id`` option to ``sign``.
+This creates one signature over all objects in the group. I can verify
+that nothing in the group has been modified by running ``verify`` with
+the same ``--group-id`` option.
 
-.. code-block::
+.. code::
 
-    $ singularity sign --groupid 1 my_container.sif 
-    Signing image: my_container.sif
-    Enter key passphrase : 
-    Signature created and applied to my_container.sif
+   $ singularity verify --group-id 1 my_container.sif
+   Verifying image: my_container.sif
+   [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
+   Objects verified:
+   ID  |GROUP   |LINK    |TYPE
+   ------------------------------------------------
+   1   |1       |NONE    |Def.FILE
+   2   |1       |NONE    |JSON.Generic
+   3   |1       |NONE    |FS
+   Container verified: my_container.sif
 
+Because every object in the SIF file is within the signed group 1 the
+entire container is signed, and the default ``verify`` behavior without
+specifying ``--group-id`` can also verify the container:
 
-This creates one signature over all objects in the
-group. I can verify that nothing in the group has been modified by
-running ``verify`` with the same ``--group-id`` option.
+.. code::
 
-.. code-block::
-
-    $ singularity verify --group-id 1 my_container.sif 
-    Verifying image: my_container.sif
-    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
-    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
-    Objects verified:
-    ID  |GROUP   |LINK    |TYPE
-    ------------------------------------------------
-    1   |1       |NONE    |Def.FILE
-    2   |1       |NONE    |JSON.Generic
-    3   |1       |NONE    |FS
-    Container verified: my_container.sif
-
-
-Because every object in the SIF file is within the signed group 1 the entire
-container is signed, and the default ``verify`` behavior without specifying
-``--group-id`` can also verify the container:
-
-.. code-block::
-
-    $ singularity verify my_container.sif
-    Verifying image: my_container.sif
-    [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
-    [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
-    Objects verified:
-    ID  |GROUP   |LINK    |TYPE
-    ------------------------------------------------
-    1   |1       |NONE    |Def.FILE
-    2   |1       |NONE    |JSON.Generic
-    3   |1       |NONE    |FS
-    Container verified: my_container.sif
+   $ singularity verify my_container.sif
+   Verifying image: my_container.sif
+   [LOCAL]   Signing entity: David Trudgian (Demo keys) <david.trudgian@sylabs.io>
+   [LOCAL]   Fingerprint: 65833F473098C6215E750B3BDFD69E5CEE85D448
+   Objects verified:
+   ID  |GROUP   |LINK    |TYPE
+   ------------------------------------------------
+   1   |1       |NONE    |Def.FILE
+   2   |1       |NONE    |JSON.Generic
+   3   |1       |NONE    |FS
+   Container verified: my_container.sif

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -44,7 +44,7 @@ If you don't already have a valid access token, follow these steps:
 Now you can verify containers that you pull from the library, ensuring they are
 bit-for-bit reproductions of the original image.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity verify alpine_latest.sif 
 
@@ -75,7 +75,7 @@ If you attempt to sign a container before you have generated any keys,
 key. Or you can use the ``newpair`` subcommand in the ``key`` command group
 like so:.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity key newpair
     
@@ -99,7 +99,7 @@ process.
 The ``list`` subcommand will show you all of the keys you have created or saved
 locally.`
 
-.. code-block:: none
+.. code-block::
 
     $ singularity key list
 
@@ -121,7 +121,7 @@ for the following:
 
 If you chose not to push your key to the keystore during the ``newpair`` process, but later wish to, you can push it to a keystore configured using ``singularity remote`` like so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity key push E5F780B2C22F59DF748524B435C3844412EE233B
     
@@ -130,7 +130,7 @@ If you chose not to push your key to the keystore during the ``newpair`` process
 If you delete your local public PGP key, you can always locate and download it
 again like so.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity key search Trudgian
 
@@ -155,7 +155,7 @@ Searching for keys
 emails, and fingerprints (key IDs). When searching for a fingerprint, you need to use ``0x``
 before the fingerprint, check the example:
 
-.. code-block:: none
+.. code-block::
 
     # search for key ID:
     $ singularity key search 0x8883491F4268F173C6E5DC49EDECE4F3F38D871E
@@ -174,7 +174,7 @@ Signing and validating your own containers
 
 Now that you have a key generated, you can use it to sign images like so:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity sign my_container.sif 
 
@@ -185,7 +185,7 @@ Now that you have a key generated, you can use it to sign images like so:
 Because your public PGP key is saved locally you can verify the image without
 needing to contact the Keystore.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity verify my_container.sif
     Verifying image: my_container.sif
@@ -205,7 +205,7 @@ image in the absence of a local public key.  To demonstrate this,
 first ``remove`` your local public key, and then try to use the
 ``verify`` command again.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity key remove E5F780B2C22F59DF748524B435C3844412EE233B
 
@@ -227,7 +227,7 @@ was obtained from the keystore, and is not present on your local
 computer. You can retrieve it, so that you can verify even if you are
 offline with ``singularity key pull``
 
-.. code-block:: none
+.. code-block::
 
     $ singularity key pull E5F780B2C22F59DF748524B435C3844412EE233B
 
@@ -244,7 +244,7 @@ If you ``sif list`` a SIF file you will see it is comprised of a
 number of objects. Each object has an ``ID``, and belongs to a
 ``GROUP``.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity sif list my_container.sif 
 
@@ -263,7 +263,7 @@ number of objects. Each object has an ``ID``, and belongs to a
 I can choose to sign and verify a specific object with the ``--sif-id`` option
 to ``sign`` and ``verify``.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity sign --sif-id 1 my_container.sif 
     Signing image: my_container.sif
@@ -285,7 +285,7 @@ Note that running the ``verify`` command without specifying the specific sif-id
 gives a fatal error. The container is not considered verified as whole because
 other objects could have been changed without my knowledge.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity verify my_container.sif
     Verifying image: my_container.sif
@@ -298,7 +298,7 @@ other objects could have been changed without my knowledge.
 
 I can sign a group of objects with the ``--group-id`` option to ``sign``.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity sign --groupid 1 my_container.sif 
     Signing image: my_container.sif
@@ -310,7 +310,7 @@ This creates one signature over all objects in the
 group. I can verify that nothing in the group has been modified by
 running ``verify`` with the same ``--group-id`` option.
 
-.. code-block:: none
+.. code-block::
 
     $ singularity verify --group-id 1 my_container.sif 
     Verifying image: my_container.sif
@@ -329,7 +329,7 @@ Because every object in the SIF file is within the signed group 1 the entire
 container is signed, and the default ``verify`` behavior without specifying
 ``--group-id`` can also verify the container:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity verify my_container.sif
     Verifying image: my_container.sif

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -45,7 +45,7 @@ It's easy to run a public Docker Hub container with
 repository and tag. To run the container that's called
 ``sylabsio/lolcow:latest``:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity run docker://sylabsio/lolcow:latest
     INFO:    Converting OCI blobs to SIF format
@@ -80,7 +80,7 @@ To obtain the Docker container as a SIF file in a specific location,
 which you can move, share, and keep for later, ``singularity pull``
 it:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity pull docker://sylabsio/lolcow
     INFO:    Using cached SIF image
@@ -346,7 +346,7 @@ uses the AWS CLI to request a password, which can then be used to
 authenticate to an ECR private registry in the specified region. The
 username used in conjunction with this password is always ``AWS``.
 
-.. code-block:: none
+.. code-block::
 
     $ aws ecr get-login-password --region region
 
@@ -515,7 +515,7 @@ If you have pulled or run a container on your machine under
 ``docker``, it will be cached locally by the Docker daemon. The
 ``docker images`` command will list containers that are available:
 
-.. code-block:: none
+.. code-block::
 
     $ docker images
     REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -526,7 +526,7 @@ by Docker. You can directly build it into a SIF file using a
 ``docker-daemon://`` URI specifying the ``REPOSITORY:TAG`` container
 name:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity build lolcow_from_docker_cache.sif docker-daemon://sylabsio/lolcow:latest
     INFO:    Starting build...
@@ -586,7 +586,7 @@ by extracting them as part of the build process.
 If an image is listed by the ``docker images`` command, then we can
 create a tar archive file using ``docker save`` and the image ID:
 
-.. code-block:: none
+.. code-block::
 
         $ sudo docker images
         REPOSITORY                        TAG               IMAGE ID       CREATED          SIZE
@@ -597,7 +597,7 @@ create a tar archive file using ``docker save`` and the image ID:
 If we examine the contents of the tar file we can see that it contains
 the layers and metadata that make up a Docker container:
 
-.. code-block:: none
+.. code-block::
 
     $ tar tvf lolcow.tar
     drwxr-xr-x  0 0      0           0 Aug 16 11:22 2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171/
@@ -618,7 +618,7 @@ rather than an object hosted by a service, it uses ``:<filename>``,
 not ``://<location>``. To build a tar archive directly to a SIF
 container:
 
-.. code-block:: none
+.. code-block::
 
     $ singularity build lolcow_tar.sif docker-archive:lolcow.tar
     INFO:    Starting build...
@@ -789,7 +789,7 @@ To disable automatic propagation of environment variables, the
 used, only variables on the host that are prefixed with
 ``SINGULARITYENV_`` are set in the container:
 
-.. code-block:: none
+.. code-block::
 
     # Set a host variable
     $ export HOST_VAR=123
@@ -934,7 +934,7 @@ this script mirrors Docker as closely as possible.
 If the Docker container only has an ``ENTRYPOINT`` - that
 ``ENTRYPOINT`` is run, with any arguments appended:
 
-.. code-block:: none
+.. code-block::
 
    # ENTRYPOINT="date"
 
@@ -949,7 +949,7 @@ If the Docker container only has an ``ENTRYPOINT`` - that
 If the Docker container only has a ``CMD`` - the ``CMD`` is run, or is
 *replaced* with any arguments:
 
-.. code-block:: none
+.. code-block::
 
    # CMD="date"
 
@@ -965,7 +965,7 @@ If the Docker container has a ``CMD`` *and* ``ENTRYPOINT``, then we
 run ``ENTRYPOINT`` with either ``CMD`` as default arguments, or
 replaced with any user supplied arguments:
 
-.. code-block:: none
+.. code-block::
 
    # ENTRYPOINT="date"
    # CMD="--utc"

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -1,11 +1,11 @@
 .. _singularity-and-docker:
 
-=====================================
-Support for Docker and OCI Containers
-=====================================
+#######################################
+ Support for Docker and OCI Containers
+#######################################
 
-The Open Containers Initiative (OCI) container format, which grew out
-of Docker, is the dominant standard for cloud-focused containerized
+The Open Containers Initiative (OCI) container format, which grew out of
+Docker, is the dominant standard for cloud-focused containerized
 deployments of software. Although {Singularity}'s own container format
 has many unique advantages, it's likely you will need to work with
 Docker/OCI containers at some point.
@@ -16,22 +16,20 @@ and especially in HPC environments.
 
 Using {Singularity} you can:
 
-* Pull, run, and build from most containers on Docker Hub, without
-  changes.
+-  Pull, run, and build from most containers on Docker Hub, without
+   changes.
+-  Pull, run, and build from containers hosted on other registries,
+   including private registries deployed on premise, or in the cloud.
+-  Pull and build from OCI containers in archive formats, or cached in a
+   local Docker daemon.
 
-* Pull, run, and build from containers hosted on other registries,
-  including private registries deployed on premise, or in the cloud.
+This section will highlight these workflows, and discuss the limitations
+and best practices to keep in mind when creating containers targeting
+both Docker and {Singularity}.
 
-* Pull and build from OCI containers in archive formats, or cached in
-  a local Docker daemon.
-
-This section will highlight these workflows, and discuss the
-limitations and best practices to keep in mind when creating
-containers targeting both Docker and {Singularity}.
-
---------------------------
-Containers From Docker Hub
---------------------------
+****************************
+ Containers From Docker Hub
+****************************
 
 Docker Hub is the most common place that projects publish public
 container images. At some point, it's likely that you will want to run
@@ -40,53 +38,49 @@ or build from containers that are hosted there.
 Public Containers
 =================
 
-It's easy to run a public Docker Hub container with
-{Singularity}. Just put ``docker://`` in front of the container
-repository and tag. To run the container that's called
-``sylabsio/lolcow:latest``:
+It's easy to run a public Docker Hub container with {Singularity}. Just
+put ``docker://`` in front of the container repository and tag. To run
+the container that's called ``sylabsio/lolcow:latest``:
 
-.. code-block::
+.. code::
 
-    $ singularity run docker://sylabsio/lolcow:latest
-    INFO:    Converting OCI blobs to SIF format
-    INFO:    Starting build...
-    Getting image source signatures
-    Copying blob 16ec32c2132b done
-    Copying blob 5ca731fc36c2 done
-    Copying config fd0daa4d89 done
-    Writing manifest to image destination
-    Storing signatures
-    2021/10/04 14:50:21  info unpack layer: sha256:16ec32c2132b43494832a05f2b02f7a822479f8250c173d0ab27b3de78b2f058
-    2021/10/04 14:50:23  info unpack layer: sha256:5ca731fc36c28789c5ddc3216563e8bfca2ab3ea10347e07554ebba1c953242e
-    INFO:    Creating SIF file...
-     _____________________________
-    < Mon Oct 4 14:50:30 CDT 2021 >
-     -----------------------------
-	    \   ^__^
-	     \  (oo)\_______
-		(__)\       )\/\
-		    ||----w |
-		    ||     ||
-
+   $ singularity run docker://sylabsio/lolcow:latest
+   INFO:    Converting OCI blobs to SIF format
+   INFO:    Starting build...
+   Getting image source signatures
+   Copying blob 16ec32c2132b done
+   Copying blob 5ca731fc36c2 done
+   Copying config fd0daa4d89 done
+   Writing manifest to image destination
+   Storing signatures
+   2021/10/04 14:50:21  info unpack layer: sha256:16ec32c2132b43494832a05f2b02f7a822479f8250c173d0ab27b3de78b2f058
+   2021/10/04 14:50:23  info unpack layer: sha256:5ca731fc36c28789c5ddc3216563e8bfca2ab3ea10347e07554ebba1c953242e
+   INFO:    Creating SIF file...
+    _____________________________
+   < Mon Oct 4 14:50:30 CDT 2021 >
+    -----------------------------
+           \   ^__^
+            \  (oo)\_______
+               (__)\       )\/\
+                   ||----w |
+                   ||     ||
 
 Note that {Singularity} retrieves blobs and configuration data from
 Docker Hub, extracts the layers that make up the Docker container, and
 creates a SIF file from them. This SIF file is kept in your
-{Singularity} :ref:`cache directory <sec:cache>`, so if you run the
-same Docker container again the downloads and conversion aren't
-required.
+{Singularity} :ref:`cache directory <sec:cache>`, so if you run the same
+Docker container again the downloads and conversion aren't required.
 
 To obtain the Docker container as a SIF file in a specific location,
-which you can move, share, and keep for later, ``singularity pull``
-it:
+which you can move, share, and keep for later, ``singularity pull`` it:
 
-.. code-block::
+.. code::
 
-    $ singularity pull docker://sylabsio/lolcow
-    INFO:    Using cached SIF image
+   $ singularity pull docker://sylabsio/lolcow
+   INFO:    Using cached SIF image
 
-    $ ls -l lolcow_latest.sif
-    -rwxr-xr-x 1 myuser myuser 74993664 Oct  4 14:55 lolcow_latest.sif
+   $ ls -l lolcow_latest.sif
+   -rwxr-xr-x 1 myuser myuser 74993664 Oct  4 14:55 lolcow_latest.sif
 
 If it's the first time you pull the container it'll be downloaded and
 translated. If you have pulled the container before, it will be copied
@@ -97,35 +91,34 @@ from the cache.
    ``singularity pull`` of a Docker container actually runs a
    ``singularity build`` behind the scenes, since we are translating
    from OCI to SIF. If you ``singularity pull`` a Docker container
-   twice, the output file isn't identical because metadata such as
-   dates from the conversion will vary. This differs from pulling a
-   SIF container (e.g. from a ``library://`` URI), which always give
-   you an exact copy of the image.
-
+   twice, the output file isn't identical because metadata such as dates
+   from the conversion will vary. This differs from pulling a SIF
+   container (e.g. from a ``library://`` URI), which always give you an
+   exact copy of the image.
 
 Docker Hub Limits
 =================
 
-Docker Hub introduced limits on anonymous access to its API in
-November 2020. Every time you use a ``docker://`` URI to run, pull
-etc. a container {Singularity} will make requests to Docker Hub in
-order to check whether the container has been modified there. On
-shared systems, and when running containers in parallel, this can
-quickly exhaust the Docker Hub API limits.
+Docker Hub introduced limits on anonymous access to its API in November
+2020. Every time you use a ``docker://`` URI to run, pull etc. a
+container {Singularity} will make requests to Docker Hub in order to
+check whether the container has been modified there. On shared systems,
+and when running containers in parallel, this can quickly exhaust the
+Docker Hub API limits.
 
 We recommend that you ``singularity pull`` a Docker image to a local
 SIF, and then always run from the SIF file, rather than using
 ``singularity run docker://...`` repeatedly.
 
-Alternatively, if you have signed up for a Docker Hub account, make
-sure that you authenticate before using ``docker://`` container URIs.
+Alternatively, if you have signed up for a Docker Hub account, make sure
+that you authenticate before using ``docker://`` container URIs.
 
 Authentication / Private Containers
 ===================================
 
 To make use of the API limits under a Docker Hub account, or to access
-private containers, you'll need to authenticate to Docker Hub. There
-are a number of ways to do this with {Singularity}.
+private containers, you'll need to authenticate to Docker Hub. There are
+a number of ways to do this with {Singularity}.
 
 Singularity CLI Remote Command
 ------------------------------
@@ -135,11 +128,11 @@ Hub and other OCI registries. For Docker Hub, the registry hostname is
 ``docker.io``, so you will need to login as below, specifying your
 username:
 
-.. code-block::
+.. code::
 
-    $ singularity remote login --username myuser docker://docker.io
-    Password / Token:
-    INFO:    Token stored in /home/myuser/.singularity/remote.yaml
+   $ singularity remote login --username myuser docker://docker.io
+   Password / Token:
+   INFO:    Token stored in /home/myuser/.singularity/remote.yaml
 
 The Password / Token you enter must be a Docker Hub CLI access token,
 which you should generate in the 'Security' section of your account
@@ -151,7 +144,7 @@ use ``singularity remote list``.
 To logout of a registry, so that your credentials are forgotten, use
 ``singularity remote logout``:
 
-.. code-block::
+.. code::
 
    $ singularity remote logout docker://docker.io
    INFO:    Logout succeeded
@@ -160,10 +153,10 @@ Docker CLI Authentication
 -------------------------
 
 If you have the ``docker`` CLI installed on your machine, you can
-``docker login`` to your account. This stores authentication
-information in ``~/.docker/config.json``. The process that
-{Singularity} uses to retrieve Docker / OCI containers will attempt to
-use this information to login.
+``docker login`` to your account. This stores authentication information
+in ``~/.docker/config.json``. The process that {Singularity} uses to
+retrieve Docker / OCI containers will attempt to use this information to
+login.
 
 .. note::
 
@@ -177,7 +170,7 @@ Interactive Login
 To perform a one-off interactive login, which will not store your
 credentials, use the ``--docker-login`` flag:
 
-.. code-block::
+.. code::
 
    $ singularity pull --docker-login docker://sylabsio/private
    Enter Docker Username: myuser
@@ -186,33 +179,33 @@ credentials, use the ``--docker-login`` flag:
 Environment Variables
 ---------------------
 
-When calling {Singularity} in a CI/CD workflow, or other
-non-interactive scenario, it may be useful to specify Docker Hub login
-credentials using environment variables. These are often the default
-way of passing secrets into jobs within CI pipelines.
+When calling {Singularity} in a CI/CD workflow, or other non-interactive
+scenario, it may be useful to specify Docker Hub login credentials using
+environment variables. These are often the default way of passing
+secrets into jobs within CI pipelines.
 
 Singularity accepts a username, and password / token, as
 ``SINGULARITY_DOCKER_USERNAME`` and ``SINGULARITY_DOCKER_PASSWORD``
 respectively. These environment variables will override any stored
 credentials.
 
-.. code-block::
+.. code::
 
    $ export SINGULARITY_DOCKER_USERNAME=myuser
    $ export SINGULARITY_DOCKER_PASSWORD=mytoken
    $ singularity pull docker://sylabsio/private
 
---------------------------------
-Containers From Other Registries
---------------------------------
+**********************************
+ Containers From Other Registries
+**********************************
 
 You can use ``docker://`` URIs with {Singularity} to pull and run
-containers from OCI registries other than Docker Hub. To do this,
-you'll need to include the hostname or IP address of the registry in
-your ``docker://`` URI. Authentication with other registries is
-carried out in the same basic manner, but sometimes you'll need to
-retrieve your credentials using a specific tool, especially when
-working with Cloud Service Provider environments.
+containers from OCI registries other than Docker Hub. To do this, you'll
+need to include the hostname or IP address of the registry in your
+``docker://`` URI. Authentication with other registries is carried out
+in the same basic manner, but sometimes you'll need to retrieve your
+credentials using a specific tool, especially when working with Cloud
+Service Provider environments.
 
 Below are specific examples for some common registries. Most other
 registries follow a similar pattern for pulling public images, and
@@ -222,36 +215,32 @@ Quay.io
 =======
 
 Quay is an OCI container registry used by a large number of projects,
-and hosted at ``https://quay.io``. To pull public containers from
-Quay, just include the ``quay.io`` hostname in your ``docker://`` URI:
+and hosted at ``https://quay.io``. To pull public containers from Quay,
+just include the ``quay.io`` hostname in your ``docker://`` URI:
 
-.. code-block::
+.. code::
 
-    $ singularity pull docker://quay.io/bitnami/python:3.7
-    INFO:    Converting OCI blobs to SIF format
-    INFO:    Starting build...
-    ...
+   $ singularity pull docker://quay.io/bitnami/python:3.7
+   INFO:    Converting OCI blobs to SIF format
+   INFO:    Starting build...
+   ...
 
-    $ singularity run python_3.7.sif
-    Python 3.7.12 (default, Sep 24 2021, 11:48:27)
-    [GCC 8.3.0] on linux
-    Type "help", "copyright", "credits" or "license" for more information.
-    >>>
+   $ singularity run python_3.7.sif
+   Python 3.7.12 (default, Sep 24 2021, 11:48:27)
+   [GCC 8.3.0] on linux
+   Type "help", "copyright", "credits" or "license" for more information.
+   >>>
 
-To pull containers from private repositories you will need to generate
-a CLI token in the Quay web interface, then use it to login with
+To pull containers from private repositories you will need to generate a
+CLI token in the Quay web interface, then use it to login with
 {Singularity}. Use the same methods as described for Docker Hub above:
 
-* Run ``singularity remote login --username myuser docker://quay.io``
-  to store your credentials for {Singularity}.
-
-* Use ``docker login quay.io`` if ``docker`` is on your machine.
-
-* Use the ``--docker-login`` flag for a one-time interactive login.
-
-* Set the ``SINGULARITY_DOCKER_USERNAME`` and
-  ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
-
+-  Run ``singularity remote login --username myuser docker://quay.io``
+   to store your credentials for {Singularity}.
+-  Use ``docker login quay.io`` if ``docker`` is on your machine.
+-  Use the ``--docker-login`` flag for a one-time interactive login.
+-  Set the ``SINGULARITY_DOCKER_USERNAME`` and
+   ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
 
 NVIDIA NGC
 ==========
@@ -265,109 +254,101 @@ Previously, an account and API token was required to pull NGC
 containers. However, they are now available to pull as a guest without
 login:
 
-.. code-block::
+.. code::
 
    $ singularity pull docker://nvcr.io/nvidia/pytorch:21.09-py3
    INFO:    Converting OCI blobs to SIF format
    INFO:    Starting build...
 
 If you do need to pull containers using an NVIDIA account, e.g. if you
-have access to an NGC Private Registry, you will need to generate an
-API key in the web interface in order to authenticate.
+have access to an NGC Private Registry, you will need to generate an API
+key in the web interface in order to authenticate.
 
 Use one of the following authentication methods (detailed above for
 Docker Hub), with the username ``$oauthtoken`` and the password set to
 your NGC API key.
 
-* Run ``singularity remote login --username \$oauthtoken
-  docker://nvcr.io`` to store your credentials for {Singularity}.
+-  Run ``singularity remote login --username \$oauthtoken
+   docker://nvcr.io`` to store your credentials for {Singularity}.
+-  Use ``docker login nvcr.io`` if ``docker`` is on your machine.
+-  Use the ``--docker-login`` flag for a one-time interactive login.
+-  Set the ``SINGULARITY_DOCKER_USERNAME="\$oauthtoken"`` and
+   ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
 
-* Use ``docker login nvcr.io`` if ``docker`` is on your machine.
-
-* Use the ``--docker-login`` flag for a one-time interactive login.
-
-* Set the ``SINGULARITY_DOCKER_USERNAME="\$oauthtoken"`` and
-  ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
-
-See also: https://docs.nvidia.com/ngc/ngc-private-registry-user-guide/index.html
-
+See also:
+https://docs.nvidia.com/ngc/ngc-private-registry-user-guide/index.html
 
 GitHub Container Registry
 =========================
 
 GitHub Container Registry is increasingly used to provide Docker
-containers alongside the source code of hosted projects. You can pull
-a public container from GitHub Container Registry using a ``ghcr.io``
-URI:
+containers alongside the source code of hosted projects. You can pull a
+public container from GitHub Container Registry using a ``ghcr.io`` URI:
 
-.. code-block::
+.. code::
 
    $ singularity pull docker://ghcr.io/containerd/alpine:latest
    INFO:    Converting OCI blobs to SIF format
    INFO:    Starting build...
 
-
 To pull private containers from GHCR you will need to generate a
 personal access token in the GitHub web interface in order to
-authenticate. This token must have required scopes. See
-`the GitHub documentation here. <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>`__
+authenticate. This token must have required scopes. See `the GitHub
+documentation here.
+<https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>`__
 
 Use one of the following authentication methods (detailed above for
 Docker Hub), with your username and personal access token:
 
-* Run ``singularity remote login --username myuser docker://ghcr.io`` to store your
-  credentials for {Singularity}.
-
-* Use ``docker login ghcr.io`` if ``docker`` is on your machine.
-
-* Use the ``--docker-login`` flag for a one-time interactive login.
-
-* Set the ``SINGULARITY_DOCKER_USERNAME`` and
-  ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
+-  Run ``singularity remote login --username myuser docker://ghcr.io``
+   to store your credentials for {Singularity}.
+-  Use ``docker login ghcr.io`` if ``docker`` is on your machine.
+-  Use the ``--docker-login`` flag for a one-time interactive login.
+-  Set the ``SINGULARITY_DOCKER_USERNAME`` and
+   ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
 
 AWS ECR
 =======
 
 To work with an AWS hosted Elastic Container Registry (ECR) generally
-requires authentication. There are various ways to generate
-credentials. You should follow one of the approaches in
-`the ECR guide <https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html>`__
+requires authentication. There are various ways to generate credentials.
+You should follow one of the approaches in `the ECR guide
+<https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html>`__
 in order to obtain a username and password.
 
 .. warning::
 
-    The ECR Docker credential helper cannot be used, as {Singularity}
-    does not currently support external credential helpers used with
-    Docker, only reading credentials stored directly in the
-    ``.docker/config.json`` file.
+   The ECR Docker credential helper cannot be used, as {Singularity}
+   does not currently support external credential helpers used with
+   Docker, only reading credentials stored directly in the
+   ``.docker/config.json`` file.
 
-The ``get-login-password`` approach is the most straightforward. It
-uses the AWS CLI to request a password, which can then be used to
+The ``get-login-password`` approach is the most straightforward. It uses
+the AWS CLI to request a password, which can then be used to
 authenticate to an ECR private registry in the specified region. The
 username used in conjunction with this password is always ``AWS``.
 
-.. code-block::
+.. code::
 
-    $ aws ecr get-login-password --region region
+   $ aws ecr get-login-password --region region
 
 Then login using one of the following methods:
 
-* Run ``singularity remote login --username AWS
-  docker://<accountid>.dkr.ecr.<region>.amazonaws.com`` to store your
-  credentials for {Singularity}.
+-  Run ``singularity remote login --username AWS
+   docker://<accountid>.dkr.ecr.<region>.amazonaws.com`` to store your
+   credentials for {Singularity}.
 
-* Use ``docker login --username AWS
-  <accountid>.dkr.ecr.<region>.amazonaws.com`` if ``docker`` is on
-  your machine.
+-  Use ``docker login --username AWS
+   <accountid>.dkr.ecr.<region>.amazonaws.com`` if ``docker`` is on your
+   machine.
 
-* Use the ``--docker-login`` flag for a one-time interactive login.
+-  Use the ``--docker-login`` flag for a one-time interactive login.
 
-* Set the ``SINGULARITY_DOCKER_USERNAME=AWS`` and
-  ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
+-  Set the ``SINGULARITY_DOCKER_USERNAME=AWS`` and
+   ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
 
 You should now be able to pull containers from your ECR URI at
 ``docker://<accountid>.dkr.ecr.<region>.amazonaws.com``.
-
 
 Azure ACR
 =========
@@ -375,70 +356,68 @@ Azure ACR
 An Azure hosted Azure Container Registry (ACR) will generally hold
 private images and require authentication to pull from. There are
 several ways to authenticate to ACR, depending on the account type you
-use in Azure. See the
-`ACR documentation <https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli>`__
+use in Azure. See the `ACR documentation
+<https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli>`__
 for more information on these options.
 
-Generally, for identities, using ``az acr login`` from the Azure
-CLI will add credentials to ``.docker/config.json`` which can be read
-by {Singularity}.
+Generally, for identities, using ``az acr login`` from the Azure CLI
+will add credentials to ``.docker/config.json`` which can be read by
+{Singularity}.
 
-Service Principle accounts will have an explicit username and
-password, and you should authenticate using one of the following
-methods:
+Service Principle accounts will have an explicit username and password,
+and you should authenticate using one of the following methods:
 
-* Run ``singularity remote login --username myuser
-  docker://myregistry.azurecr.io`` to store your credentials for
-  {Singularity}.
+-  Run ``singularity remote login --username myuser
+   docker://myregistry.azurecr.io`` to store your credentials for
+   {Singularity}.
 
-* Use ``docker login --username myuser myregistry.azurecr.io`` if
-  ``docker`` is on your machine.
+-  Use ``docker login --username myuser myregistry.azurecr.io`` if
+   ``docker`` is on your machine.
 
-* Use the ``--docker-login`` flag for a one-time interactive login.
+-  Use the ``--docker-login`` flag for a one-time interactive login.
 
-* Set the ``SINGULARITY_DOCKER_USERNAME`` and
-  ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
+-  Set the ``SINGULARITY_DOCKER_USERNAME`` and
+   ``SINGULARITY_DOCKER_PASSWORD`` environment variables.
 
 The recent repository-scoped access token preview may be more
-convenient. See the
-`preview documentation <https://docs.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions>`__
-which details how to use ``az acr token create`` to obtain a token
-name and password pair that can be used to authenticate with the above
+convenient. See the `preview documentation
+<https://docs.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions>`__
+which details how to use ``az acr token create`` to obtain a token name
+and password pair that can be used to authenticate with the above
 methods.
 
--------------------------------------
-Building From Docker / OCI Containers
--------------------------------------
+***************************************
+ Building From Docker / OCI Containers
+***************************************
 
-If you wish to use an existing Docker or OCI container as the basis
-for a new container, you will need to specifiy it as the *bootstrap*
-source in a {Singularity} definition file.
+If you wish to use an existing Docker or OCI container as the basis for
+a new container, you will need to specifiy it as the *bootstrap* source
+in a {Singularity} definition file.
 
-Just as you can run or pull containers from different registries using
-a ``docker://`` URI, you can use different headers in a definition file
-to instruct {Singularity} where to find the container you want to use
-as the starting point for your build.
-
+Just as you can run or pull containers from different registries using a
+``docker://`` URI, you can use different headers in a definition file to
+instruct {Singularity} where to find the container you want to use as
+the starting point for your build.
 
 Registries In Definition Files
 ==============================
 
-When you wish to build from a Docker or OCI container that's hosted in
-a registry, such as Docker Hub, your definition file should begin with
+When you wish to build from a Docker or OCI container that's hosted in a
+registry, such as Docker Hub, your definition file should begin with
 ``Bootstrap: docker``, followed with a ``From:`` line which specifies
 the location of the container you wish to pull.
 
 Docker Hub
 ----------
 
-Docker Hub is the default registry, so when building from Docker Hub
-the ``From:`` header only needs to specify the container respository
-and tag:
+Docker Hub is the default registry, so when building from Docker Hub the
+``From:`` header only needs to specify the container respository and
+tag:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: docker
-    From: ubuntu:20.04
+   Bootstrap: docker
+   From: ubuntu:20.04
 
 If you ``singularity build`` a definition file with these lines,
 {Singularity} will fetch the ``ubuntu:20.04`` container image from
@@ -451,25 +430,23 @@ To pull from a different Docker registry, you can either specify the
 hostname in the ``From:`` header, or use the separate ``Registry:``
 header. The following two examples are equivalent:
 
+.. code:: singularity
 
-.. code-block:: singularity
+   Bootstrap: docker
+   From: quay.io/bitnami/python:3.7
 
-    Bootstrap: docker
-    From: quay.io/bitnami/python:3.7
-
-.. code-block:: singularity
+.. code:: singularity
 
    Bootstrap: docker
    Registry: quay.io
    From: bitnami/python:3.7
 
-
 Authentication During a Build
 -----------------------------
 
-If you are building from an image in a private registry you will need
-to ensure that the credentials needed to access the image are
-available to {Singularity}.
+If you are building from an image in a private registry you will need to
+ensure that the credentials needed to access the image are available to
+{Singularity}.
 
 A build might be run as the ``root`` user, e.g. via ``sudo``, or under
 your own account with ``--fakeroot``.
@@ -478,257 +455,245 @@ If you are running the build as ``root``, using ``sudo``, then any
 stored credentials or environment variables must be available to the
 ``root`` user:
 
-* Use the ``--docker-login`` flag for a one-time interactive
-  login. I.E. run ``sudo singularity build --docker-login myimage.sif
-  Singularity``.
+-  Use the ``--docker-login`` flag for a one-time interactive login.
+   I.E. run ``sudo singularity build --docker-login myimage.sif
+   Singularity``.
 
-* Set the ``SINGULARITY_DOCKER_USERNAME`` and
-  ``SINGULARITY_DOCKER_PASSWORD`` environment variables. Pass the
-  environment variables through sudo to the ``root`` build process by
-  running ``sudo -E singularity build ...``.
+-  Set the ``SINGULARITY_DOCKER_USERNAME`` and
+   ``SINGULARITY_DOCKER_PASSWORD`` environment variables. Pass the
+   environment variables through sudo to the ``root`` build process by
+   running ``sudo -E singularity build ...``.
 
-* Run ``sudo singularity remote login ...`` to store your credentials
-  for the ``root`` user on your system. This is separate from storing
-  the credentials under your own account.
+-  Run ``sudo singularity remote login ...`` to store your credentials
+   for the ``root`` user on your system. This is separate from storing
+   the credentials under your own account.
 
-* Use ``sudo docker login`` if ``docker`` is on your
-  machine. This is separate from storing the credentials under your
-  own account.
+-  Use ``sudo docker login`` if ``docker`` is on your machine. This is
+   separate from storing the credentials under your own account.
 
 If you are running the build under your account via the ``--fakeroot``
-feature you do not need to specially set credentials for the root
-user.
-
+feature you do not need to specially set credentials for the root user.
 
 Archives & Docker Daemon
 ========================
 
-As well as being hosted in a registry, Docker / OCI containers might
-be found inside a running Docker daemon, or saved as an
-archive. {Singularity} can build from these locations by using
-specialised bootstrap agents.
+As well as being hosted in a registry, Docker / OCI containers might be
+found inside a running Docker daemon, or saved as an archive.
+{Singularity} can build from these locations by using specialised
+bootstrap agents.
 
 Containers Cached by the Docker Daemon
 --------------------------------------
 
-If you have pulled or run a container on your machine under
-``docker``, it will be cached locally by the Docker daemon. The
-``docker images`` command will list containers that are available:
+If you have pulled or run a container on your machine under ``docker``,
+it will be cached locally by the Docker daemon. The ``docker images``
+command will list containers that are available:
 
-.. code-block::
+.. code::
 
-    $ docker images
-    REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
-    sylabsio/lolcow     latest              5a15b484bc65        2 hours ago         188MB
+   $ docker images
+   REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
+   sylabsio/lolcow     latest              5a15b484bc65        2 hours ago         188MB
 
 This indicates that ``sylabsio/lolcow:latest`` has been cached locally
 by Docker. You can directly build it into a SIF file using a
 ``docker-daemon://`` URI specifying the ``REPOSITORY:TAG`` container
 name:
 
-.. code-block::
+.. code::
 
-    $ singularity build lolcow_from_docker_cache.sif docker-daemon://sylabsio/lolcow:latest
-    INFO:    Starting build...
-    Getting image source signatures
-    Copying blob sha256:a2022691bf950a72f9d2d84d557183cb9eee07c065a76485f1695784855c5193
-     119.83 MiB / 119.83 MiB [==================================================] 6s
-    Copying blob sha256:ae620432889d2553535199dbdd8ba5a264ce85fcdcd5a430974d81fc27c02b45
-     15.50 KiB / 15.50 KiB [====================================================] 0s
-    Copying blob sha256:c561538251751e3685c7c6e7479d488745455ad7f84e842019dcb452c7b6fecc
-     14.50 KiB / 14.50 KiB [====================================================] 0s
-    Copying blob sha256:f96e6b25195f1b36ad02598b5d4381e41997c93ce6170cab1b81d9c68c514db0
-     5.50 KiB / 5.50 KiB [======================================================] 0s
-    Copying blob sha256:7f7a065d245a6501a782bf674f4d7e9d0a62fa6bd212edbf1f17bad0d5cd0bfc
-     3.00 KiB / 3.00 KiB [======================================================] 0s
-    Copying blob sha256:70ca7d49f8e9c44705431e3dade0636a2156300ae646ff4f09c904c138728839
-     116.56 MiB / 116.56 MiB [==================================================] 6s
-    Copying config sha256:73d5b1025fbfa138f2cacf45bbf3f61f7de891559fa25b28ab365c7d9c3cbd82
-     3.33 KiB / 3.33 KiB [======================================================] 0s
-    Writing manifest to image destination
-    Storing signatures
-    INFO:    Creating SIF file...
-    INFO:    Build complete: lolcow_from_docker_cache.sif
+   $ singularity build lolcow_from_docker_cache.sif docker-daemon://sylabsio/lolcow:latest
+   INFO:    Starting build...
+   Getting image source signatures
+   Copying blob sha256:a2022691bf950a72f9d2d84d557183cb9eee07c065a76485f1695784855c5193
+    119.83 MiB / 119.83 MiB [==================================================] 6s
+   Copying blob sha256:ae620432889d2553535199dbdd8ba5a264ce85fcdcd5a430974d81fc27c02b45
+    15.50 KiB / 15.50 KiB [====================================================] 0s
+   Copying blob sha256:c561538251751e3685c7c6e7479d488745455ad7f84e842019dcb452c7b6fecc
+    14.50 KiB / 14.50 KiB [====================================================] 0s
+   Copying blob sha256:f96e6b25195f1b36ad02598b5d4381e41997c93ce6170cab1b81d9c68c514db0
+    5.50 KiB / 5.50 KiB [======================================================] 0s
+   Copying blob sha256:7f7a065d245a6501a782bf674f4d7e9d0a62fa6bd212edbf1f17bad0d5cd0bfc
+    3.00 KiB / 3.00 KiB [======================================================] 0s
+   Copying blob sha256:70ca7d49f8e9c44705431e3dade0636a2156300ae646ff4f09c904c138728839
+    116.56 MiB / 116.56 MiB [==================================================] 6s
+   Copying config sha256:73d5b1025fbfa138f2cacf45bbf3f61f7de891559fa25b28ab365c7d9c3cbd82
+    3.33 KiB / 3.33 KiB [======================================================] 0s
+   Writing manifest to image destination
+   Storing signatures
+   INFO:    Creating SIF file...
+   INFO:    Build complete: lolcow_from_docker_cache.sif
 
 The tag name must be included in the URI. Unlike when pulling from a
 registry, the ``docker-daemon`` bootstrap agent will not try to pull a
 ``latest`` tag automatically.
 
-
 .. note::
 
-   In the example above, the build was performed without
-   ``sudo``. This is possible only when the user is part of the
-   ``docker`` group on the host, since {Singularity} must contact the
-   Docker daemon through its socket. If you are not part of the
-   ``docker`` group you will need to use ``sudo`` for the build to
-   complete successfully.
+   In the example above, the build was performed without ``sudo``. This
+   is possible only when the user is part of the ``docker`` group on the
+   host, since {Singularity} must contact the Docker daemon through its
+   socket. If you are not part of the ``docker`` group you will need to
+   use ``sudo`` for the build to complete successfully.
 
-To build from an image cached by the Docker daemon in a definition
-file use ``Bootstrap: docker-daemon``, and a ``From:
-<REPOSITORY>:TAG`` line:
+To build from an image cached by the Docker daemon in a definition file
+use ``Bootstrap: docker-daemon``, and a ``From: <REPOSITORY>:TAG`` line:
 
-.. code-block:: singularity
+.. code:: singularity
 
-    Bootstrap: docker-daemon
-    From: sylabsio/lolcow:latest
-
+   Bootstrap: docker-daemon
+   From: sylabsio/lolcow:latest
 
 Containers in Docker Archive Files
 ----------------------------------
 
-Docker allows containers to be exported into single file tar
-archives. These cannot be run directly, but are intended to be
-imported into Docker to run at a later date, or another
-location. {Singularity} can build from (or run) these archive files,
-by extracting them as part of the build process.
+Docker allows containers to be exported into single file tar archives.
+These cannot be run directly, but are intended to be imported into
+Docker to run at a later date, or another location. {Singularity} can
+build from (or run) these archive files, by extracting them as part of
+the build process.
 
 If an image is listed by the ``docker images`` command, then we can
 create a tar archive file using ``docker save`` and the image ID:
 
-.. code-block::
+.. code::
 
-        $ sudo docker images
-        REPOSITORY                        TAG               IMAGE ID       CREATED          SIZE
-        sylabsio/lolcow                   latest            5a15b484bc65   2 hours ago      188MB
+   $ sudo docker images
+   REPOSITORY                        TAG               IMAGE ID       CREATED          SIZE
+   sylabsio/lolcow                   latest            5a15b484bc65   2 hours ago      188MB
 
-	$ docker save 5a15b484bc65 -o lolcow.tar
+   $ docker save 5a15b484bc65 -o lolcow.tar
 
 If we examine the contents of the tar file we can see that it contains
 the layers and metadata that make up a Docker container:
 
-.. code-block::
+.. code::
 
-    $ tar tvf lolcow.tar
-    drwxr-xr-x  0 0      0           0 Aug 16 11:22 2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171/
-    -rw-r--r--  0 0      0           3 Aug 16 11:22 2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171/VERSION
-    -rw-r--r--  0 0      0         401 Aug 16 11:22 2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171/json
-    -rw-r--r--  0 0      0    75156480 Aug 16 11:22 2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171/layer.tar
-    -rw-r--r--  0 0      0        1499 Aug 16 11:22 5a15b484bc657d2b418f2c20628c29945ec19f1a0c019d004eaf0ca1db9f952b.json
-    drwxr-xr-x  0 0      0           0 Aug 16 11:22 af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab/
-    -rw-r--r--  0 0      0           3 Aug 16 11:22 af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab/VERSION
-    -rw-r--r--  0 0      0         946 Aug 16 11:22 af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab/json
-    -rw-r--r--  0 0      0   118356480 Aug 16 11:22 af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab/layer.tar
-    -rw-r--r--  0 0      0         266 Dec 31  1969 manifest.json
-
+   $ tar tvf lolcow.tar
+   drwxr-xr-x  0 0      0           0 Aug 16 11:22 2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171/
+   -rw-r--r--  0 0      0           3 Aug 16 11:22 2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171/VERSION
+   -rw-r--r--  0 0      0         401 Aug 16 11:22 2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171/json
+   -rw-r--r--  0 0      0    75156480 Aug 16 11:22 2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171/layer.tar
+   -rw-r--r--  0 0      0        1499 Aug 16 11:22 5a15b484bc657d2b418f2c20628c29945ec19f1a0c019d004eaf0ca1db9f952b.json
+   drwxr-xr-x  0 0      0           0 Aug 16 11:22 af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab/
+   -rw-r--r--  0 0      0           3 Aug 16 11:22 af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab/VERSION
+   -rw-r--r--  0 0      0         946 Aug 16 11:22 af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab/json
+   -rw-r--r--  0 0      0   118356480 Aug 16 11:22 af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab/layer.tar
+   -rw-r--r--  0 0      0         266 Dec 31  1969 manifest.json
 
 We can convert this tar file into a singularity container using the
 ``docker-archive`` bootstrap agent. Because the agent accesses a file,
-rather than an object hosted by a service, it uses ``:<filename>``,
-not ``://<location>``. To build a tar archive directly to a SIF
-container:
+rather than an object hosted by a service, it uses ``:<filename>``, not
+``://<location>``. To build a tar archive directly to a SIF container:
 
-.. code-block::
+.. code::
 
-    $ singularity build lolcow_tar.sif docker-archive:lolcow.tar
-    INFO:    Starting build...
-    Getting image source signatures
-    Copying blob sha256:2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171
-     119.83 MiB / 119.83 MiB [==================================================] 6s
-    Copying blob sha256:af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab
-     15.50 KiB / 15.50 KiB [====================================================] 0s
-    Copying config sha256:5a15b484bc657d2b418f2c20628c29945ec19f1a0c019d004eaf0ca1db9f952b
-     3.33 KiB / 3.33 KiB [======================================================] 0s
-    Writing manifest to image destination
-    Storing signatures
-    INFO:    Creating SIF file...
-    INFO:    Build complete: lolcow_tar.sif
-
+   $ singularity build lolcow_tar.sif docker-archive:lolcow.tar
+   INFO:    Starting build...
+   Getting image source signatures
+   Copying blob sha256:2f0514a4c044af1ff4f47a46e14b6d46143044522fcd7a9901124209d16d6171
+    119.83 MiB / 119.83 MiB [==================================================] 6s
+   Copying blob sha256:af7e389ea6636873dbc5adc17826e8401d96d3d384135b2f9fe990865af202ab
+    15.50 KiB / 15.50 KiB [====================================================] 0s
+   Copying config sha256:5a15b484bc657d2b418f2c20628c29945ec19f1a0c019d004eaf0ca1db9f952b
+    3.33 KiB / 3.33 KiB [======================================================] 0s
+   Writing manifest to image destination
+   Storing signatures
+   INFO:    Creating SIF file...
+   INFO:    Build complete: lolcow_tar.sif
 
 .. note::
 
-    The ``docker-archive`` bootstrap agent can also handle gzipped Docker
-    archives (``.tar.gz`` or ``.tgz`` files).
+   The ``docker-archive`` bootstrap agent can also handle gzipped Docker
+   archives (``.tar.gz`` or ``.tgz`` files).
 
+To build an image using a definition file, which starts from a container
+in a Docker archive, use ``Bootstrap: docker-archive`` and specify the
+filename in the ``From:`` line:
 
-To build an image using a definition file, which starts from a
-container in a Docker archive, use ``Bootstrap: docker-archive`` and
-specify the filename in the ``From:`` line:
+.. code:: singularity
 
-.. code-block:: singularity
-
-    Bootstrap: docker-archive
-    From: lolcow.tar
+   Bootstrap: docker-archive
+   From: lolcow.tar
 
 .. _sec:optional_headers_def_files:
 
--------------------------------------
-Differences and Limitations vs Docker
--------------------------------------
+***************************************
+ Differences and Limitations vs Docker
+***************************************
 
-Though Docker / OCI container compatibility is a goal of
-{Singularity}, there are some differences and limitations due to the
-way {Singularity} was designed to work well on shared systems and HPC
-clusters. If you are having difficulty running a specific Docker
-container, check through the list of differences below. There are
-workarounds for many of the issues that you are most likely to face.
+Though Docker / OCI container compatibility is a goal of {Singularity},
+there are some differences and limitations due to the way {Singularity}
+was designed to work well on shared systems and HPC clusters. If you are
+having difficulty running a specific Docker container, check through the
+list of differences below. There are workarounds for many of the issues
+that you are most likely to face.
 
 Read-only by Default
 ====================
 
-{Singularity}'s container image format (SIF) is generally
-read-only. This permits containers to be run in parallel from a shared
-location on a network filesystem, support in-built signing and
-verification, and offer encryption. A container's filesystem is
-mounted directly from the SIF, as SquashFS, so cannot be written to by
-default.
+{Singularity}'s container image format (SIF) is generally read-only.
+This permits containers to be run in parallel from a shared location on
+a network filesystem, support in-built signing and verification, and
+offer encryption. A container's filesystem is mounted directly from the
+SIF, as SquashFS, so cannot be written to by default.
 
 When a container is run using Docker its layers are extracted, and the
 resulting container filesystem can be written to and modified by
-default. If a Docker container expects to write files, you will need
-to follow one of the following methods to allow it to run under
+default. If a Docker container expects to write files, you will need to
+follow one of the following methods to allow it to run under
 {Singularity}.
 
-* A directory from the host can be passed into the container with the
-  ``--bind`` or ``--mount`` flags. It needs to be mounted inside the
-  container at the location where files will be written.
+-  A directory from the host can be passed into the container with the
+   ``--bind`` or ``--mount`` flags. It needs to be mounted inside the
+   container at the location where files will be written.
 
-* The ``--writable-tmpfs`` flag can be used to allow files to be
-  created in a special temporary overlay. Any changes are lost when
-  the container exits. The SIF file is never modified.
+-  The ``--writable-tmpfs`` flag can be used to allow files to be
+   created in a special temporary overlay. Any changes are lost when the
+   container exits. The SIF file is never modified.
 
-* The container can be converted to a sandbox directory, and executed
-  with the ``--writable`` flag, which allows modification of the
-  sandbox content.
+-  The container can be converted to a sandbox directory, and executed
+   with the ``--writable`` flag, which allows modification of the
+   sandbox content.
 
-* A writable overlay partition can be added to the SIF file, and the container
-  executed with the ``--writable`` flag. Any changes made are kept
-  permanently in the overlay partition.
+-  A writable overlay partition can be added to the SIF file, and the
+   container executed with the ``--writable`` flag. Any changes made are
+   kept permanently in the overlay partition.
 
 Of these methods, only ``--writable-tmpfs`` is always safe to run in
 parallel. Each time the container is executed, a separate temporary
 overlay is used and then discarded.
 
-Binding a directory into a container, or running a writable sandbox
-may or may not be safe, depending on the program executed. The program
-must use, and the filesystem support, some type of locking in order
-that the parallel runs do not interfere.
+Binding a directory into a container, or running a writable sandbox may
+or may not be safe, depending on the program executed. The program must
+use, and the filesystem support, some type of locking in order that the
+parallel runs do not interfere.
 
-A writable overlay file in a SIF partition cannot be used in
-parallel. {Singularity} will refuse to run concurrently using the same
-SIF writable overlay partition.
+A writable overlay file in a SIF partition cannot be used in parallel.
+{Singularity} will refuse to run concurrently using the same SIF
+writable overlay partition.
 
 Dockerfile ``USER``
 ===================
 
 The ``Dockerfile`` used to build a Docker container may contain a
-``USER`` statement. This tells the container runtime that it should
-run the container under the specified user account.
+``USER`` statement. This tells the container runtime that it should run
+the container under the specified user account.
 
 Because {Singularity} is designed to provide easy and safe access to
-data on the host system, work under batch schedulers, etc., it does
-not permit changing the user account the container is run as.
+data on the host system, work under batch schedulers, etc., it does not
+permit changing the user account the container is run as.
 
 Any ``USER`` statement in a ``Dockerfile`` will be ignored by
 {Singularity} when the container is run. In practice, this often does
-not affect the execution of the software in the container. Software
-that is written in a way that requires execution under a specific user
+not affect the execution of the software in the container. Software that
+is written in a way that requires execution under a specific user
 account will generally require modification for use with {Singularity}.
 
 {Singularity}'s ``--fakeroot`` mode will start a container as a fake
 ``root`` user, mapped to the user's real account outside of the
-container. Inside the container it is possible to change to another
-user account, which is mapped to a configured range of sub-uids / gids
+container. Inside the container it is possible to change to another user
+account, which is mapped to a configured range of sub-uids / gids
 belonging to the original user. It may be possible to execute software
 expecting a fixed user account manually inside a ``--fakeroot`` shell,
 if your adminstrator has configured the system for ``--fakeroot``.
@@ -744,17 +709,17 @@ host directories into the container by default.
 
 The home directory mount is the most likely to cause problems when
 running Docker containers. Various software will look for packages,
-plugins, and configuration files in ``$HOME``. If you have, for
-example, installed packages for Python into your home directory (``pip
-install --user``) then a Python container may find and attempt to use
-them. This can cause conflicts and unexpected behaviour.
+plugins, and configuration files in ``$HOME``. If you have, for example,
+installed packages for Python into your home directory (``pip install
+--user``) then a Python container may find and attempt to use them. This
+can cause conflicts and unexpected behaviour.
 
 If you experience issues, use the ``--contain`` option to stop
-{Singularity} automatically binding directories into the
-container. You may need to use ``--bind`` or ``--mount`` to then add
-back e.g. an HPC project directory that you need access to.
+{Singularity} automatically binding directories into the container. You
+may need to use ``--bind`` or ``--mount`` to then add back e.g. an HPC
+project directory that you need access to.
 
-.. code-block::
+.. code::
 
    # Without --contain, python in the container finds packages
    # in your $HOME directory.
@@ -775,154 +740,143 @@ back e.g. an HPC project directory that you need access to.
    setuptools 57.5.0
    wheel      0.37.0
 
-
 Environment Propagation
 =======================
 
-{Singularity} propagates most environment variables set on the host
-into the container, by default. Docker does not propagate any host
+{Singularity} propagates most environment variables set on the host into
+the container, by default. Docker does not propagate any host
 environment variables into the container. Environment variables may
 change the behaviour of software.
 
 To disable automatic propagation of environment variables, the
-``--cleanenv / -e`` flag can be specified. When ``--cleanenv`` is
-used, only variables on the host that are prefixed with
-``SINGULARITYENV_`` are set in the container:
+``--cleanenv / -e`` flag can be specified. When ``--cleanenv`` is used,
+only variables on the host that are prefixed with ``SINGULARITYENV_``
+are set in the container:
 
-.. code-block::
+.. code::
 
-    # Set a host variable
-    $ export HOST_VAR=123
-    # Set a singularity container environment variable
-    $ export "SINGULARITYENV_FORCE_VAR="123"
+   # Set a host variable
+   $ export HOST_VAR=123
+   # Set a singularity container environment variable
+   $ export "SINGULARITYENV_FORCE_VAR="123"
 
-    $ singularity run library://alpine env | grep VAR
-    FORCE_VAR=123
-    HOST_VAR=ABC
+   $ singularity run library://alpine env | grep VAR
+   FORCE_VAR=123
+   HOST_VAR=ABC
 
-    $ singularity run --cleanenv library://alpine env | grep VAR
-    FORCE_VAR=123
+   $ singularity run --cleanenv library://alpine env | grep VAR
+   FORCE_VAR=123
 
 Any environment variables set via an ``ENV`` line in a ``Dockerfile``
 will be available when the container is run with {Singularity}.
-
 
 Namespace & Device Isolation
 ============================
 
 Because {Singularity} favors an integration over isolation approach it
-does not, by default, use all the methods through which a container
-can be isolated from the host system. This makes it much easier to run
-a {Singularity} container like any other program, while the unique
+does not, by default, use all the methods through which a container can
+be isolated from the host system. This makes it much easier to run a
+{Singularity} container like any other program, while the unique
 security model ensures safety. You can access the host's network, GPUs,
-and other devices directly. Processes in the container are not
-numbered separately from host processes. Hostnames are not changed,
-etc.
+and other devices directly. Processes in the container are not numbered
+separately from host processes. Hostnames are not changed, etc.
 
-Most containers are not impacted by the differences in isolation. If
-you require more isolation, than {Singularity} provides by default, you
-can enable some of the extra namespaces that Docker uses, with flags:
+Most containers are not impacted by the differences in isolation. If you
+require more isolation, than {Singularity} provides by default, you can
+enable some of the extra namespaces that Docker uses, with flags:
 
-* ``--ipc / -i`` creates a separate IPC (inter process communication)
-  namespace, for SystemV IPC objects and POSIX message queues.
+-  ``--ipc / -i`` creates a separate IPC (inter process communication)
+   namespace, for SystemV IPC objects and POSIX message queues.
 
-* ``--net / -n`` creates a new network namespace, abstracting the container
-  networking from the host.
+-  ``--net / -n`` creates a new network namespace, abstracting the
+   container networking from the host.
 
-* ``--userns / -u`` runs the container unprivileged, inside a user
-  namespace and avoiding setuid setup code. This prevents executing
-  SIF images directly. They will be extracted to a directory sandbox.
+-  ``--userns / -u`` runs the container unprivileged, inside a user
+   namespace and avoiding setuid setup code. This prevents executing SIF
+   images directly. They will be extracted to a directory sandbox.
 
-* ``--uts`` creates a new UTS namespace, which allows a different
-  hostname and/or NIS domain for the container.
+-  ``--uts`` creates a new UTS namespace, which allows a different
+   hostname and/or NIS domain for the container.
 
 To limit presentation of devices from the host into the container, use
 the ``--contain`` flag. As well as preventing automatic binds of host
-directories into the container, ``--contain`` sets up a minimal
-``/dev`` directory, rather than binding in the entire host ``/dev``
-tree.
+directories into the container, ``--contain`` sets up a minimal ``/dev``
+directory, rather than binding in the entire host ``/dev`` tree.
 
 .. note::
 
-   When using the ``--nv`` or ``--rocm`` flags, GPU devices are
-   present in the container even when ``--contain`` is used.
+   When using the ``--nv`` or ``--rocm`` flags, GPU devices are present
+   in the container even when ``--contain`` is used.
 
 Init Shim Process
 =================
 
-When a {Singularity} container is run using the ``--pid / p`` option,
-or started as an instance (which implies ``--pid``), a shim init
-process is executed that will run the container payload itself.
+When a {Singularity} container is run using the ``--pid / p`` option, or
+started as an instance (which implies ``--pid``), a shim init process is
+executed that will run the container payload itself.
 
 The shim process helps to ensure signals are propagated correctly from
-the terminal, or batch schedulers etc. when containers are not
-designed for interactive use. Because Docker does not provide an init
-process by default, some containers have been designed to run their
-own init process, which cannot operate under the control of
-{Singularity}'s shim.
+the terminal, or batch schedulers etc. when containers are not designed
+for interactive use. Because Docker does not provide an init process by
+default, some containers have been designed to run their own init
+process, which cannot operate under the control of {Singularity}'s shim.
 
 For example, a container using the ``tini`` init process will produce
-warnings when started as an instance, or if run with ``--pid``. To
-work around this, use the ``--no-init`` flag to disable the shim:
+warnings when started as an instance, or if run with ``--pid``. To work
+around this, use the ``--no-init`` flag to disable the shim:
 
-.. code-block::
+.. code::
 
-    $ singularity run --pid tini_example.sif
-    [WARN  tini (2690)] Tini is not running as PID 1 .
-    Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
-    To fix the problem, run Tini as PID 1.
+   $ singularity run --pid tini_example.sif
+   [WARN  tini (2690)] Tini is not running as PID 1 .
+   Zombie processes will not be re-parented to Tini, so zombie reaping won't work.
+   To fix the problem, run Tini as PID 1.
 
-    $ singularity run --pid --no-init tini_example.sif
-    ...
-    # NO WARNINGS
+   $ singularity run --pid --no-init tini_example.sif
+   ...
+   # NO WARNINGS
 
------------------------------
-Docker-like ``--compat`` Flag
------------------------------
+*******************************
+ Docker-like ``--compat`` Flag
+*******************************
 
-If Docker-like behavior is important, {Singularity} can be started
-with the ``--compat`` flag. This flag is a convenient short-hand
-alternative to using all of:
+If Docker-like behavior is important, {Singularity} can be started with
+the ``--compat`` flag. This flag is a convenient short-hand alternative
+to using all of:
 
-* ``--containall``
-* ``--no-init``
-* ``--no-umask``
-* ``--writable-tmpfs``
+-  ``--containall``
+-  ``--no-init``
+-  ``--no-umask``
+-  ``--writable-tmpfs``
 
 A container run with ``--compat`` has:
 
-* A writable root filesystem, using a temporary overlay where changes
-  are discarded at container exit.
-
-* No automatic bind mounts of ``$HOME`` or other directories from the
-  host into the container.
-
-* Empty temporary ``$HOME`` and ``/tmp`` directories, the contents of
-  which will be discarded at container exit.
-
-* A minimal ``/dev`` tree, that does not expose host devices inside
-  the container (except GPUs when used with ``--nv`` or ``--rocm``).
-
-* An clean environment, not including environment variables set on the
-  host.
-
-* Its own PID and IPC namespaces.
-
-* No shim init process.
+-  A writable root filesystem, using a temporary overlay where changes
+   are discarded at container exit.
+-  No automatic bind mounts of ``$HOME`` or other directories from the
+   host into the container.
+-  Empty temporary ``$HOME`` and ``/tmp`` directories, the contents of
+   which will be discarded at container exit.
+-  A minimal ``/dev`` tree, that does not expose host devices inside the
+   container (except GPUs when used with ``--nv`` or ``--rocm``).
+-  An clean environment, not including environment variables set on the
+   host.
+-  Its own PID and IPC namespaces.
+-  No shim init process.
 
 These options will allow most, but not all, Docker / OCI containers to
 execute correctly under {Singularity}. The user namespace and network
 namespace are not used, as these negate benefits of SIF and direct
 access to high performance cluster networks.
 
---------------------------
-CMD / ENTRYPOINT Behaviour
---------------------------
+****************************
+ CMD / ENTRYPOINT Behaviour
+****************************
 
 When a container is run using ``docker``, its default behavior depends
-on the ``CMD`` and/or ``ENTRYPOINT`` set in the ``Dockerfile`` that
-was used to build it, along with any arguments on the command
-line. The ``CMD`` and ``ENTRYPOINT`` can also be overridden by flags.
+on the ``CMD`` and/or ``ENTRYPOINT`` set in the ``Dockerfile`` that was
+used to build it, along with any arguments on the command line. The
+``CMD`` and ``ENTRYPOINT`` can also be overridden by flags.
 
 A {Singularity} container has the concept of a *runscript*, which is a
 single shell script defining what happens when you ``singularity run``
@@ -931,10 +885,10 @@ the container. Because there is no internal concept of ``CMD`` and
 and ``ENTRYPOINT`` when converting a Docker container. The behavior of
 this script mirrors Docker as closely as possible.
 
-If the Docker container only has an ``ENTRYPOINT`` - that
-``ENTRYPOINT`` is run, with any arguments appended:
+If the Docker container only has an ``ENTRYPOINT`` - that ``ENTRYPOINT``
+is run, with any arguments appended:
 
-.. code-block::
+.. code::
 
    # ENTRYPOINT="date"
 
@@ -949,7 +903,7 @@ If the Docker container only has an ``ENTRYPOINT`` - that
 If the Docker container only has a ``CMD`` - the ``CMD`` is run, or is
 *replaced* with any arguments:
 
-.. code-block::
+.. code::
 
    # CMD="date"
 
@@ -961,11 +915,11 @@ If the Docker container only has a ``CMD`` - the ``CMD`` is run, or is
    $ singularity run mycontainer.sif echo hello
    hello
 
-If the Docker container has a ``CMD`` *and* ``ENTRYPOINT``, then we
-run ``ENTRYPOINT`` with either ``CMD`` as default arguments, or
-replaced with any user supplied arguments:
+If the Docker container has a ``CMD`` *and* ``ENTRYPOINT``, then we run
+``ENTRYPOINT`` with either ``CMD`` as default arguments, or replaced
+with any user supplied arguments:
 
-.. code-block::
+.. code::
 
    # ENTRYPOINT="date"
    # CMD="--utc"
@@ -979,15 +933,14 @@ replaced with any user supplied arguments:
    Wed, 06 Oct 2021 14:49:07 -0500
 
 There is no flag to override an ``ENTRYPOINT`` set for a Docker
-container. Instead, use ``singularity exec`` to run an arbitrary
-program inside a container.
-
+container. Instead, use ``singularity exec`` to run an arbitrary program
+inside a container.
 
 .. _sec:best_practices:
 
--------------------------------------------------------
-Best Practices for Docker & {Singularity} Compatibility
--------------------------------------------------------
+*********************************************************
+ Best Practices for Docker & {Singularity} Compatibility
+*********************************************************
 
 As detailed previously, {Singularity} can make use of most Docker and
 OCI images without issues, or via simple workarounds. In general,
@@ -995,84 +948,81 @@ however, there are some best practices that should be applied when
 creating Docker / OCI containers that will also be run using
 {Singularity}.
 
+   #. **Don't require execution by a specific user**
 
-    1. **Don't require execution by a specific user**
+   Avoid using the ``USER`` instruction in your Docker file, as it is
+   ignored by Singularity. Install and configure software inside the
+   container so that it can be run by any user.
 
-    Avoid using the ``USER`` instruction in your Docker file, as it is
-    ignored by Singularity. Install and configure software inside the
-    container so that it can be run by any user.
+   2. **Don't install software under /root or in another user's home
+      directory**
 
-    2. **Don't install software under /root or in another user's home
-       directory**
+   Because a Docker container builds and runs as the ``root`` user by
+   default, it's tempting to install software into root's home directory
+   (``/root``). Permissions on ``/root`` are usually set so that it is
+   inaccessible to non-root users. When the container is run as another
+   user the software may be inaccessible.
 
-    Because a Docker container builds and runs as the ``root`` user by
-    default, it's tempting to install software into root's home
-    directory (``/root``). Permissions on ``/root`` are usually set so
-    that it is inaccessible to non-root users. When the container is
-    run as another user the software may be inaccessible.
+   Software inside another user's home directory, e.g. ``/home/myapp``,
+   may be obscured by {Singularity}'s automatic mounts onto ``/home``.
 
-    Software inside another user's home directory,
-    e.g. ``/home/myapp``, may be obscured by {Singularity}'s automatic
-    mounts onto ``/home``.
+   Install software into system-wide locations in the container, such as
+   under ``/usr`` or ``/opt`` to avoid these issues.
 
-    Install software into system-wide locations in the container,
-    such as under ``/usr`` or ``/opt`` to avoid these issues.
+   3. **Support a read-only filesystem**
 
-    3. **Support a read-only filesystem**
+   Because of the immutable nature of the SIF format, a container run
+   with {Singularity} is read-only by default.
 
-    Because of the immutable nature of the SIF format, a container run
-    with {Singularity} is read-only by default.
+   Try to ensure your container will run with a read-only filesystem. If
+   this is not possible, document exactly where the container needs to
+   write, so that a user can bind in a writable location, or use
+   ``--writable-tmpfs`` as appropriate.
 
-    Try to ensure your container will run with a read-only
-    filesystem. If this is not possible, document exactly where the
-    container needs to write, so that a user can bind in a writable
-    location, or use ``--writable-tmpfs`` as appropriate.
+   You can test read-only execution with Docker using ``docker run
+   --read-only --tmpfs /run --tmpfs /tmp sylabsio/lolcow``.
 
-    You can test read-only execution with Docker using ``docker
-    run --read-only --tmpfs /run --tmpfs /tmp sylabsio/lolcow``.
+   4. **Be careful writing to /tmp**
 
-    4. **Be careful writing to /tmp**
+   {Singularity} mounts the *host* ``/tmp`` into the container, by
+   default. This means you must be be careful when writing sensitive
+   information to ``/tmp``, and should ensure your container cleans up
+   files it writes there.
 
-    {Singularity} mounts the *host* ``/tmp`` into the container, by
-    default. This means you must be be careful when writing sensitive
-    information to ``/tmp``, and should ensure your container cleans
-    up files it writes there.
+   5. **Consider library caches / ldconfig**
 
-    5. **Consider library caches / ldconfig**
+   If your ``Dockerfile`` adds libraries and / or manipulates the ld
+   search path in the container (``ld.so.conf`` / ``ld.so.conf.d``), you
+   should ensure the library cache is updated during the build.
 
-    If your ``Dockerfile`` adds libraries and / or manipulates the ld
-    search path in the container (``ld.so.conf`` / ``ld.so.conf.d``),
-    you should ensure the library cache is updated during the build.
+   Because Singularity runs containers read-only by default, the cache
+   and any missing library symlinks may not be able to be updated /
+   created at execution time.
 
-    Because Singularity runs containers read-only by default, the
-    cache and any missing library symlinks may not be able to be
-    updated / created at execution time.
-
-    Run ``ldconfig`` toward the *end* of your ``Dockerfile`` to ensure
-    symbolic links and the the ``ld.so.cache`` are up-to-date.
-
+   Run ``ldconfig`` toward the *end* of your ``Dockerfile`` to ensure
+   symbolic links and the the ``ld.so.cache`` are up-to-date.
 
 .. _sec:troubleshooting:
 
----------------
-Troubleshooting
----------------
+*****************
+ Troubleshooting
+*****************
 
 Registry Authentication Issues
 ==============================
 
 If you experience problems pulling containers from a private registry,
-check your credentials carefully. You can ``singularity pull`` with
-the ``--docker-login`` flag to perform an interactive login. This may
-be useful if you are unsure whether you have stored credentials
-properly via ``singularity remote login`` or ``docker login``.
+check your credentials carefully. You can ``singularity pull`` with the
+``--docker-login`` flag to perform an interactive login. This may be
+useful if you are unsure whether you have stored credentials properly
+via ``singularity remote login`` or ``docker login``.
 
-OCI registries expect different values for username and password
-fields. Some require a token to be generated and used instead of your
-account password. Some take a generic username, and rely only on the
-token to identify you. Consult the documentation for your registry
-carefully. Look for instructions that detail how to login via ``docker
-login`` without external helper programs, if possible.
+OCI registries expect different values for username and password fields.
+Some require a token to be generated and used instead of your account
+password. Some take a generic username, and rely only on the token to
+identify you. Consult the documentation for your registry carefully.
+Look for instructions that detail how to login via ``docker login``
+without external helper programs, if possible.
 
 Container Doesn't Start
 =======================
@@ -1097,33 +1047,34 @@ likely cause is the different level of isolation that Singularity
 provides vs Docker.
 
 Try running the container with the ``--contain`` option, or the
-``--compat`` option (which is more strict). This disables the
-automatic mount of your home directory, which is a common source of
-issues where software in the container loads configuration or packages
-that may be present there.
+``--compat`` option (which is more strict). This disables the automatic
+mount of your home directory, which is a common source of issues where
+software in the container loads configuration or packages that may be
+present there.
 
 Getting Help
 ============
 
 The community Slack channels and mailing list are excellent places to
 ask for help with running a specific Docker container. Other users may
-have already had success running the same container or
-software. Please don't report issues with specific Docker containers
-on GitHub, unless you believe they are due to a bug in {Singularity}.
-
+have already had success running the same container or software. Please
+don't report issues with specific Docker containers on GitHub, unless
+you believe they are due to a bug in {Singularity}.
 
 .. _sec:deffile-vs-dockerfile:
 
---------------------------------------------
-{Singularity} Definition file vs. Dockerfile
---------------------------------------------
+**********************************************
+ {Singularity} Definition file vs. Dockerfile
+**********************************************
 
 An alternative to running Docker containers with {Singularity} is to
-re-write the ``Dockerfile`` as a definition file, and build a native
-SIF image.
+re-write the ``Dockerfile`` as a definition file, and build a native SIF
+image.
 
 The table below gives a quick reference comparing Dockerfile and
-{Singularity} definition files. For more detail please see :ref:`definition-files`.
+{Singularity} definition files. For more detail please see
+:ref:`definition-files`.
+
 
 ================ =========================== ================ =============================
 {Singularity} Definition file                Dockerfile


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-userdocs#50

The original PR description was:

> RST markup is very flexible, and our documentation files have made use of this over time, to the point that they are very inconsistent:
> 
> * Different markup for the header levels in different files
> * Incorrect specification of a 'none' pygments lexer for code without highlighting
> * Varying indentation of code / note blocks etc. 
> 
> This PR fixes a couple of problems that prevented running `rstfmt` successfully, then runs `rstfmt` over all of the `.rst` files.
> 
> Brings us consistent line wrapping, indentation, and markup for header levels - making it easier to keep things tidy as we go forward.
> 
> Edit - Noting that rstfmt marks itself as an experimental / unstable project, so it's not really appropriate to use it in CI, or require manual use of it in our contribution guidelines. It was suitable here to get us to consistency at a point in time.... in order to encourage maintaining that consistency in future contributions.