### PR TITLE
Add software licenses to appendix, from sylabs75

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Sphinx
         run: |
-          pip install --user --upgrade --upgrade-strategy eager sphinx sphinx-rtd-theme restructuredtext_lint pygments
+          pip install --user --upgrade --upgrade-strategy eager sphinx sphinx-rtd-theme restructuredtext_lint pygments m2r2
 
       - name: Build web documentation
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Sphinx
         run: |
-          pip install --user --upgrade --upgrade-strategy eager sphinx sphinx-rtd-theme restructuredtext_lint rstcheck pygments
+          pip install --user --upgrade --upgrade-strategy eager sphinx sphinx-rtd-theme restructuredtext_lint rstcheck pygments m2r2
 
       - name: Lint rst
         run: |

--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -1,0 +1,3 @@
+[rstcheck]
+ignore_directives=mdinclude
+

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Sphinx is written in Python. To get setup to contribute:
 
 - Install Python 3.5 or newer, from your OS package manager or the [Python download
   site](https://www.python.org/downloads/)
-- Use `pip3`to install Sphinx and the RTD theme package into your home directory:
+- Use `pip3`to install Sphinx, RTD theme package, and extensions / linters into
+  your home directory:
 
 ```sh
-pip3 install --user Sphinx sphinx-rtd-theme
+pip3 install --user sphinx sphinx-rtd-theme rstcheck pygments m2r2
 ```
 
 If your version of python 3 does not come with `pip` / `pip3`, you may need to

--- a/conf.py
+++ b/conf.py
@@ -28,13 +28,13 @@ import os
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ['m2r2']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ['.rst']
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
@@ -73,7 +73,7 @@ release = version
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', 'apptainer_source', '.github', 'README.md']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/index.rst
+++ b/index.rst
@@ -131,4 +131,4 @@ other users, or simply testing new releases.
    :maxdepth: 1
 
    Command Line Reference <cli>
-   License <license>
+   Licenses <license>

--- a/license.rst
+++ b/license.rst
@@ -1,8 +1,22 @@
-#########
- License
-#########
+##########
+ Licenses
+##########
+
+***************
+ Documentation
+***************
 
 This documentation is subject to the following 3-clause BSD license:
 
 .. include:: LICENSE
    :literal:
+
+********************
+ {Project} Software
+********************
+
+.. mdinclude:: apptainer_source/LICENSE.md
+
+.. mdinclude:: apptainer_source/LICENSE_THIRD_PARTY.md
+
+.. mdinclude:: apptainer_source/LICENSE_DEPENDENCIES.md


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-userdocs#75

The original PR description was:
> Bump singularity_source and add the SingularityCE project software licenses to the appendix, so that they are distributed with the documentation and easy to find / review.