### PR TITLE
Clarify Docker ENV / host env var override (corrected), from sylabs 77

### DIFF
--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -87,8 +87,9 @@ If I build a singularity container from the image
 This happens because the ``Dockerfile`` used to build that container has
 ``ENV PYTHON_VERSION 3.7.7`` set inside it.
 
-You can always override the value of these base image environment
-variables, if needed. See below.
+You can override the inherited environment with ``APPTAINERENV_`` vars, or the
+``--env / --env-file`` flags (see below), but ``Dockerfile`` ``ENV`` vars will
+not be overridden by host environment variables of the same name.
 
 ************************************
  Environment from a definition file
@@ -127,23 +128,6 @@ The ``%runscript`` is set to echo the value.
    initialization tasks because this would impact users running the
    image and the execution could abort due to timeout.
 
-
-Default values
-==============
-
-To set a default value for a variable in the ``%environment`` section,
-but adopt the value of a host environment variable if it is set, use
-the following syntax:
-
-.. code:: singularity
-
-    %environment
-        FOO=${FOO:-'default'}
-
-The value of ``FOO`` in the container will take the value of ``FOO``
-on the host, or ``default`` if ``FOO`` is not set on the host or
-``--cleanenv`` / ``--containall`` have been specified.
-
 Build time variables in ``%post``
 =================================
 
@@ -159,7 +143,6 @@ Variables set in the ``%post`` section through
 ``$APPTAINER_ENVIRONMENT`` take precedence over those added via
 ``%environment``.
 
-
 ***************************
  Environment from the host
 ***************************
@@ -168,10 +151,10 @@ If you have environment variables set outside of your container, on the
 host, then by default they will be available inside the container.
 Except that:
 
-   -  An environment variable set on the host will be overridden by a
-      variable of the same name that has been set inside the container
-      image, via ``APPTAINERENV_`` environment variables, or the
-      ``--env`` and ``--env-file`` flags.
+   -  An environment variable set on the host will be overridden by a variable
+      of the same name that has been set either inside the container image, or
+      via ``APPTAINERENV_`` environment variables, or the ``--env`` and
+      ``--env-file`` flags.
 
    -  The ``PS1`` shell prompt is reset for a container specific prompt.
 
@@ -181,6 +164,19 @@ Except that:
    -  The ``LD_LIBRARY_PATH`` is modified to a default
       ``/.singularity.d/libs``, that will include NVIDIA / ROCm
       libraries if applicable.
+
+To override an environment variable that is already set in the container with
+the value from the host, use ``APPTAINERENV_`` or the ``--env`` flag. For
+example, to force ``MYVAR`` in the container to take the value of ``MYVAR`` on
+the host:
+
+.. code::
+
+   $ export APPTAINERENV_MYVAR="$MYVAR"
+   $ singularity run mycontainer.sif
+
+   # or
+   $ singularity run --env "MYVAR=$MYVAR"
 
 If you *do not want* the host environment variables to pass into the
 container you can use the ``-e`` or ``--cleanenv`` option. This gives a
@@ -462,8 +458,7 @@ environment is constructed in the following order:
       {Project} defaults
    -  Set environment variables defined explicitly in the
       ``%environment`` section of the definition file. These can
-      override any previously set values, and may reference host
-      variables.
+      override any previously set values.
    -  Set environment variables that were defined in the ``%post``
       section of the build, by addition to the
       ``$APPTAINER_ENVIRONMENT`` file.

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -767,8 +767,27 @@ are set in the container:
    $ singularity run --cleanenv library://alpine env | grep VAR
    FORCE_VAR=123
 
-Any environment variables set via an ``ENV`` line in a ``Dockerfile``
-will be available when the container is run with {Project}.
+Any environment variables set via an ``ENV`` line in a ``Dockerfile`` will be
+available when the container is run with {Project}. You can override them
+with ``APPTAINERENV_`` vars, or the ``--env / --env-file`` flags, but they
+will not be overridden by host environment variables.
+
+For example, the ``docker://openjdk:latest`` container sets ``JAVA_HOME``:
+
+.. code::
+
+   # Set a host JAVA_HOME
+   export JAVA_HOME=/test
+
+   # Check JAVA_HOME in the docker container.
+   # This value comes from ENV in the Dockerfile.
+   $ singularity run docker://openjdk:latest echo \$JAVA_HOME
+   /usr/java/openjdk-17
+
+   # Override JAVA_HOME in the container
+   export APPTAINERENV_JAVA_HOME=/test
+   $ singularity run docker://openjdk:latest echo \$JAVA_HOME
+   /test
 
 Namespace & Device Isolation
 ============================


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-userdocs#77
 which fixed
- sylabs/singularity-userdocs#69

The original PR description was:
> Corrected after the revert of incorrectly documented behaviour that included a regression.
> 
> The default value method previously added was also taking advantage of the regression, and has been removed.