### PR TITLE
Document --no-eval added, from sylabs 89

### DIFF
--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -789,6 +789,39 @@ For example, the ``docker://openjdk:latest`` container sets ``JAVA_HOME``:
    $ {command} run docker://openjdk:latest echo \$JAVA_HOME
    /test
 
+
+Environment Variable Escaping / Evaluation
+==========================================
+
+The default behavior of {Project} differs from Docker/OCI handling of
+environment variables as {Project} uses a shell interpreter to process
+environment on container startup, in a manner that evaluates environment
+variables. To avoid the extra evaluation of variables that {Project}
+performs you can:
+
+* Follow the instructions in the :ref:`escaping-environment` section to
+  explictly escape environment variables.
+* Use the ``--no-eval`` flag.
+
+``--no-eval`` prevents {Project} from evaluating environment variables on
+container startup, so that they will take the same value as with a Docker/OCI
+runtime:
+
+.. code::
+
+   # Set an environment variable that would run `date` if evaluated
+   $ export {ENVPREFIX}_MYVAR='$(date)'
+
+   # Default behavior
+   # MYVAR was evaluated in the container, and is set to the output of `date`
+   $ {command} run ~/ubuntu_latest.sif env | grep MYVAR
+   MYVAR=Tue Apr 26 14:37:07 CDT 2022
+
+   # --no-eval / --compat behavior
+   # MYVAR was not evaluated and is a literal `$(date)`
+   $ {command} run --no-eval ~/ubuntu_latest.sif env | grep MYVAR
+   MYVAR=$(date)
+
 Namespace & Device Isolation
 ============================
 
@@ -869,6 +902,7 @@ to using all of:
 -  ``--no-init``
 -  ``--no-umask``
 -  ``--writable-tmpfs``
+-  ``--no-eval``
 
 A container run with ``--compat`` has:
 
@@ -880,10 +914,12 @@ A container run with ``--compat`` has:
    which will be discarded at container exit.
 -  A minimal ``/dev`` tree, that does not expose host devices inside the
    container (except GPUs when used with ``--nv`` or ``--rocm``).
--  An clean environment, not including environment variables set on the
+-  A clean environment, not including environment variables set on the
    host.
 -  Its own PID and IPC namespaces.
 -  No shim init process.
+-  Argument and environment variable handling matching Docker / OCI runtimes,
+   with respect to evaluation and escaping.
 
 These options will allow most, but not all, Docker / OCI containers to
 execute correctly under {Project}. The user namespace and network
@@ -960,11 +996,40 @@ inside a container.
 Argument Handling
 =================
 
-Because {Project} runscripts are evaluated shell scripts
-arguments can behave slightly differently than in Docker/OCI
-runtimes, if they contain shell code that may be evaluated. To
-replicate Docker/OCI behavior you may need additional escaping or
-quoting of arguments.
+Because {Project} runscripts are evaluated shell scripts, arguments can
+behave slightly differently than in Docker/OCI runtimes if they contain shell
+code that may be evaluated. 
+
+If you are using a container that was directly built or run from a Docker/OCI
+source, with {Project} 1.1.0 or later, the ``--no-eval`` flag will prevent
+this extra evaluation so that arguments are handled in a compatible manner:
+
+.. code:: 
+
+   # docker/OCI behavior
+   $ docker run -it --rm alpine echo "\$HOSTNAME"
+   $HOSTNAME
+
+   # {Project} default
+   $ {command} run docker://alpine echo "\$HOSTNAME"
+   p700
+
+   # {Project} with --no-eval
+   $ {command} run --no-eval docker://alpine echo "\$HOSTNAME"
+   $HOSTNAME
+
+.. note:: 
+
+   ``--no-eval`` will not change argument behavior for containers built with
+   {Project} 1.1.0 or earlier, as the handling is implemented in the runscript
+   that is built into the container.
+
+   You can check the version of {Project} used to build  a container with
+   ``{command} inspect mycontainer.sif``.
+
+To avoid evaluation without ``--no-eval``, and when using containers built with
+{Project} 1.1.0 or earlier, you will need to add an extra level of shell
+escaping to arguments on the command line:
 
 .. code::
 
@@ -978,7 +1043,7 @@ quoting of arguments.
    $HOSTNAME
 
 If you are running a binary inside a ``docker://`` container directly,
-using the ``exec`` command the argument handling mirrors Docker/OCI
+using the ``exec`` command, the argument handling mirrors Docker/OCI
 runtimes as there is no evaluated runscript.
 
 .. _sec:best_practices:
@@ -993,7 +1058,7 @@ however, there are some best practices that should be applied when
 creating Docker / OCI containers that will also be run using
 {Project}.
 
-   #. **Don't require execution by a specific user**
+   1. **Don't require execution by a specific user**
 
    Avoid using the ``USER`` instruction in your Docker file, as it is
    ignored by {Project}. Install and configure software inside the

--- a/docker_and_oci.rst
+++ b/docker_and_oci.rst
@@ -855,6 +855,8 @@ around this, use the ``--no-init`` flag to disable the shim:
    ...
    # NO WARNINGS
 
+.. _compat-flag:
+
 *******************************
  Docker-like ``--compat`` Flag
 *******************************

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -62,7 +62,7 @@ container, rather than when running a container, see :ref:`build
 environment section <build-environment>`.
 
 *******************************
- Environment from a base image
+ Environment From a Base Image
 *******************************
 
 When you build a container with {Project} you might *bootstrap* from
@@ -92,7 +92,7 @@ You can override the inherited environment with ``{ENVPREFIX}ENV_`` vars, or the
 not be overridden by host environment variables of the same name.
 
 ************************************
- Environment from a definition file
+ Environment From a Definition File
 ************************************
 
 Environment variables can be included in your container by adding them
@@ -128,7 +128,7 @@ The ``%runscript`` is set to echo the value.
    initialization tasks because this would impact users running the
    image and the execution could abort due to timeout.
 
-Build time variables in ``%post``
+Build Time Cariables in ``%post``
 =================================
 
 In some circumstances the value that needs to be assigned to an
@@ -144,7 +144,7 @@ Variables set in the ``%post`` section through
 ``%environment``.
 
 ***************************
- Environment from the host
+ Environment From the Host
 ***************************
 
 If you have environment variables set outside of your container, on the
@@ -214,9 +214,9 @@ environment variables for correct operation of most software.
    such as ``PYTHONPATH`` that can change the way code runs, and
    consider using ``--cleanenv``.
 
-********************************************
- Environment from the {Project} runtime
-********************************************
+****************************************
+ Environment From the {Project} Runtime
+****************************************
 
 It can be useful for a program to know when it is running in a
 {Project} container, and some basic information about the container
@@ -245,7 +245,7 @@ program running in the container.
    variable support :ref:`here <singularity_environment_variable_compatibility>`.
 
 **********************************
- Overriding environment variables
+ Overriding Environment Variables
 **********************************
 
 You can override variables that have been set in the container image, or
@@ -365,24 +365,53 @@ to the start) of the ``PATH`` variable in the container.
 Alternatively you could use the ``--env`` option to set a
 ``PREPEND_PATH`` variable, e.g. ``--env PREPEND_PATH=/startpath``.
 
-Escaping and evaluation of environment variables
-================================================
+************************************************
+Escaping and Evaluation of Environment Variables
+************************************************
 
-{Project} uses an embedded shell interpreter to process the
-container startup scripts and environment. When this processing is
-performed, a single step of shell evaluation happens in the container
-context. The shell from which you are running {Project} may also
-evaluate variables on your command line before passing them to
-{Project}.
+{Project} uses an embedded shell interpreter to process the container
+startup scripts and environment. When this processing is performed, by default a
+single step of shell evaluation happens in the container context. The shell from
+which you are running {Project} may also evaluate variables on your command
+line before passing them to {Project}.
 
-.. warning::
+Docker / OCI Compatibility
+==========================
 
-   This behavior differs from Docker/OCI handling of environment
-   variables / ``ENV`` directives. You may need additional quoting and
-   escaping to replicate behavior. See below.
+This default behavior of {Project} differs from Docker/OCI handling of
+environment variables / ``ENV`` directives. To avoid the extra evaluation of
+variables that {Project} performs you can:
 
-Using host variables
---------------------
+* Follow the instructions about escaping in the sections below, to add
+  additional escape characters and/or quoting.
+* Use the ``--no-eval`` or ``--compat`` flags.
+
+
+``--no-eval`` prevents {Project} from evaluating environment variables on
+container startup, so that they will take the same value as with a Docker/OCI
+runtime:
+
+.. code::
+
+   # Set an environment variable that would run `date` if evaluated
+   $ export {ENVPREFIX}_MYVAR='$(date)'
+
+   # Default behavior
+   # MYVAR was evaluated in the container, and is set to the output of `date`
+   $ {command} run ~/ubuntu_latest.sif env | grep MYVAR
+   MYVAR=Tue Apr 26 14:37:07 CDT 2022
+
+   # --no-eval / --compat behavior
+   # MYVAR was not evaluated and is a literal `$(date)`
+   $ {command} run --no-eval ~/ubuntu_latest.sif env | grep MYVAR
+   MYVAR=$(date)
+
+
+The ``--compat`` flag is a short-hand flag to activate ``--no-eval`` along with
+other Docker/OCI compatibility flags. See :ref:`compat-flag` for more details.
+
+Using Host Variables
+====================
 
 To set a container environment variable to the value of a variable on
 the host, use double quotes around the variable, so that it is
@@ -404,7 +433,7 @@ substituted before the host shell runs ``{command}``.
    correctly.
 
 Using Container Variables
--------------------------
+=========================
 
 To set an environment variable to a value that references another
 variable inside the container, you should escape the ``$`` sign to
@@ -425,7 +454,7 @@ APPEND_PATH="/endpath"``, which uses the special ``APPEND/PREPEND``
 handling for ``PATH`` discussed above.
 
 Quoting / Avoiding Evaluation
------------------------------
+=============================
 
 If you need to pass an environment variable into the container
 verbatim, it must be quoted and escaped appropriately. For example, if
@@ -450,9 +479,9 @@ level of escaping:
 
    {command} run --env='LD_PRELOAD=/foo/bar/\$LIB/baz.so' mycontainer.sif
 
-
+*******************************
 Environment Variable Precedence
-===============================
+*******************************
 
 When a container is run with {Project}, the container
 environment is constructed in the following order:

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -365,6 +365,8 @@ to the start) of the ``PATH`` variable in the container.
 Alternatively you could use the ``--env`` option to set a
 ``PREPEND_PATH`` variable, e.g. ``--env PREPEND_PATH=/startpath``.
 
+.. _escaping-environment:
+
 ************************************************
 Escaping and Evaluation of Environment Variables
 ************************************************

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -910,15 +910,14 @@ SIF file metadata descriptor.
    dynamically written at runtime, *and should not be modified* in the
    container.
 
--  **env**: All ``*.sh`` files in this directory are sourced in
-   alphanumeric order when the container is started. For legacy purposes
-   there is a symbolic link called ``/environment`` that points to
-   ``/.singularity.d/env/90-environment.sh``. Whenever possible, avoid
-   modifying or creating environment files manually to prevent potential
-   issues building & running containers with future versions of
-   {Project}. Additional
-   facilities such as ``--env`` and ``--env-file`` are available to
-   allow manipulation of the container environment at runtime.
+-  **env**: All ``*.sh`` files in this directory are sourced in alphanumeric
+   order when the container is started. For legacy purposes there is a symbolic
+   link called ``/environment`` that points to
+   ``/.singularity.d/env/90-environment.sh``. Whenever possible, avoid modifying
+   or creating environment files manually to prevent potential issues building &
+   running containers with future versions of {Project}. Additional
+   facilities such as ``--env`` and ``--env-file`` are available to allow
+   manipulation of the container environment at runtime.
 
 -  **labels.json**: The json file that stores a containers labels
    described above.

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -128,7 +128,7 @@ The ``%runscript`` is set to echo the value.
    initialization tasks because this would impact users running the
    image and the execution could abort due to timeout.
 
-Build Time Cariables in ``%post``
+Build Time Variables in ``%post``
 =================================
 
 In some circumstances the value that needs to be assigned to an


### PR DESCRIPTION
This pulls in sylabs PR

- sylabs/singularity-userdocs#89

The original PR description was:
> Drop 'Changes in 3.6'... we are now 4 minor versions and 2 years ahead of this. Add `--no-eval` notes to environment section Tidy header nesting, capitalization.
> 
> Add `--no-eval` notes to Docker compat section