### PR TITLE
fix oras bootstrap agent example, from sylabs 126

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -600,7 +600,7 @@ module to use.
 
 .. code:: {command}
 
-   From: oras://registry/namespace/image:tag
+   From: registry/namespace/image:tag
 
 The ``From`` keyword is mandatory. It specifies the container to use as
 a base. Also,``tag`` is mandatory that refers to the version of image


### PR DESCRIPTION
This pulls in sylabs PR
- sylabs/singularity-userdocs# 126

The original PR description was:
> removed `oras://` from the `From:` line in the oras bootstrap agent example