### PR TITLE
Document --no-mount bind-paths, from sylabs 152

### DIFF
--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -41,9 +41,9 @@ container.
 Disabling System Binds
 ======================
 
-The ``--no-mount`` flag allows specific
-system mounts to be disabled, even if they are set in the
-``{command}.conf`` configuration file by the administrator.
+The ``--no-mount`` flag allows specific system mounts to be disabled, even if
+they are set in the ``{command}.conf`` configuration file by the
+administrator.
 
 For example, if {Project} has been configured with ``mount hostfs =
 yes`` then every filesystem on the host will be bind mounted to the
@@ -55,11 +55,30 @@ running, you can disable the ``hostfs`` binds:
 
    $ {command} run --no-mount hostfs mycontainer.sif
 
-Multiple mounts can be disabled by specifying them separated by commas:
+Multiple system mounts can be disabled by specifying them separated by commas:
 
 .. code:: console
 
    $ {command} run --no-mount tmp,sys,dev mycontainer.sif
+
+When the administrator has configured custom ``bind path`` entries in
+``{command}.conf``, to mount specific paths into the container by default, you
+can disable them individually. To do this, specify the path(s) to disable with
+the ``--no-mount`` flag. For example, if the adminstrator has configured
+``{command}.conf`` to always mount ``/data2``. you can disable this with
+``--no-mount /data2``:
+
+.. code:: console
+
+   $ {command} run --no-mount /data2 mycontainer.sif
+
+To disable all ``bind path`` entries set in ``{command}.conf``, use
+``--no-mount bind-paths``:
+
+.. code:: console
+
+   $ {command} run --no-mount bind-paths mycontainer.sif
+
 
 .. _user-defined-bind-paths:
 


### PR DESCRIPTION
This pulls in sylabs PR
- sylabs/singularity-userdocs# 152
which fixed
- sylabs/singularity-userdocs# 139