### PR TITLE
Ubuntu 18.04 EOL, from sylabs 166

### DIFF
--- a/encryption.rst
+++ b/encryption.rst
@@ -22,10 +22,9 @@ at runtime in memory.
 
 .. note::
 
-   This feature utilizes the Linux ``dm-crypt`` library and
-   ``cryptsetup`` utility and requires cryptsetup version of >= 2.0.0.
-   This version should be standard with recent Linux versions such as
-   Ubuntu 18.04, Debian 10 and CentOS/RHEL 7, but users of older Linux
+   This feature utilizes the Linux ``dm-crypt`` library and ``cryptsetup``
+   utility and requires cryptsetup version of >= 2.0.0. This version should be
+   standard with recent Linux versions, but users of older Linux
    versions may have to update.
 
 .. note:: 

--- a/gpu.rst
+++ b/gpu.rst
@@ -437,10 +437,6 @@ you must ensure that:
 These requirements can be satisfied by following the requirements on the
 `ROCm web site <https://rocm.github.io/ROCmInstall.html>`__
 
-At time of release, {Project} was tested successfully on Debian 10
-with ROCm 2.8/2.9 and the upstream kernel driver, and Ubuntu 18.04 with
-ROCm 2.9 and the DKMS driver.
-
 Example - tensorflow-rocm
 =========================
 

--- a/library_api.rst
+++ b/library_api.rst
@@ -249,7 +249,7 @@ This is our definition file. Let's call it ``ubuntu.def``:
 .. code:: {command}
 
    bootstrap: library
-   from: ubuntu:18.04
+   from: ubuntu:22.04
 
    %runscript
        echo "hello world from ubuntu container!"

--- a/mpi.rst
+++ b/mpi.rst
@@ -144,14 +144,14 @@ example can be used:
 .. code::
 
    Bootstrap: docker
-   From: ubuntu:18.04
+   From: ubuntu:22.04
 
    %files
        mpitest.c /opt
 
    %environment
        # Point to MPICH binaries, libraries man pages
-       export MPICH_DIR=/opt/mpich-3.3.2
+       export MPICH_DIR=/opt/mpich-4.1.1
        export PATH="$MPICH_DIR/bin:$PATH"
        export LD_LIBRARY_PATH="$MPICH_DIR/lib:$LD_LIBRARY_PATH"
        export MANPATH=$MPICH_DIR/share/man:$MANPATH
@@ -162,7 +162,7 @@ example can be used:
        apt-get update && apt-get install -y wget git bash gcc gfortran g++ make
 
        # Information about the version of MPICH to use
-       export MPICH_VERSION=3.3.2
+       export MPICH_VERSION=4.1.1
        export MPICH_URL="http://www.mpich.org/static/downloads/$MPICH_VERSION/mpich-$MPICH_VERSION.tar.gz"
        export MPICH_DIR=/opt/mpich
 
@@ -200,7 +200,7 @@ If the host MPI is Open MPI, the definition file looks like:
 .. code::
 
    Bootstrap: docker
-   From: ubuntu:18.04
+   From: ubuntu:22.04
 
    %files
        mpitest.c /opt
@@ -217,11 +217,11 @@ If the host MPI is Open MPI, the definition file looks like:
 
    %post
        echo "Installing required packages..."
-       apt-get update && apt-get install -y wget git bash gcc gfortran g++ make file
+       apt-get update && apt-get install -y wget git bash gcc gfortran g++ make file bzip2
 
        echo "Installing Open MPI"
        export OMPI_DIR=/opt/ompi
-       export OMPI_VERSION=4.0.5
+       export OMPI_VERSION=4.1.5
        export OMPI_URL="https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-$OMPI_VERSION.tar.bz2"
        mkdir -p /tmp/ompi
        mkdir -p /opt
@@ -345,7 +345,7 @@ program, which in this case has been compiled on the host to
 .. code::
 
    Bootstrap: docker
-   From: ubuntu:18.04
+   From: ubuntu:22.04
 
    %files
          /tmp/mpitest /opt/mpitest

--- a/mpi.rst
+++ b/mpi.rst
@@ -151,7 +151,7 @@ example can be used:
 
    %environment
        # Point to MPICH binaries, libraries man pages
-       export MPICH_DIR=/opt/mpich-4.1.1
+       export MPICH_DIR=/opt/mpich
        export PATH="$MPICH_DIR/bin:$PATH"
        export LD_LIBRARY_PATH="$MPICH_DIR/lib:$LD_LIBRARY_PATH"
        export MANPATH=$MPICH_DIR/share/man:$MANPATH
@@ -159,7 +159,7 @@ example can be used:
    %post
        echo "Installing required packages..."
        export DEBIAN_FRONTEND=noninteractive
-       apt-get update && apt-get install -y wget git bash gcc gfortran g++ make
+       apt-get update && apt-get install -y wget git bash gcc gfortran g++ make python3-dev
 
        # Information about the version of MPICH to use
        export MPICH_VERSION=4.1.1
@@ -172,7 +172,7 @@ example can be used:
        # Download
        cd /tmp/mpich && wget -O mpich-$MPICH_VERSION.tar.gz $MPICH_URL && tar xzf mpich-$MPICH_VERSION.tar.gz
        # Compile and install
-       cd /tmp/mpich/mpich-$MPICH_VERSION && ./configure --prefix=$MPICH_DIR && make install
+       cd /tmp/mpich/mpich-$MPICH_VERSION && ./configure --prefix=$MPICH_DIR && make -j$(nproc) install
 
        # Set env variables so we can compile our application
        export PATH=$MPICH_DIR/bin:$PATH
@@ -222,13 +222,13 @@ If the host MPI is Open MPI, the definition file looks like:
        echo "Installing Open MPI"
        export OMPI_DIR=/opt/ompi
        export OMPI_VERSION=4.1.5
-       export OMPI_URL="https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-$OMPI_VERSION.tar.bz2"
+       export OMPI_URL="https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-$OMPI_VERSION.tar.bz2"
        mkdir -p /tmp/ompi
        mkdir -p /opt
        # Download
        cd /tmp/ompi && wget -O openmpi-$OMPI_VERSION.tar.bz2 $OMPI_URL && tar -xjf openmpi-$OMPI_VERSION.tar.bz2
        # Compile and install
-       cd /tmp/ompi/openmpi-$OMPI_VERSION && ./configure --prefix=$OMPI_DIR && make -j8 install
+       cd /tmp/ompi/openmpi-$OMPI_VERSION && ./configure --prefix=$OMPI_DIR && make -j$(nproc) install
 
        # Set env variables so we can compile our application
        export PATH=$OMPI_DIR/bin:$PATH

--- a/networking.rst
+++ b/networking.rst
@@ -53,7 +53,7 @@ hostname within the container.
 .. code::
 
    $ hostname
-   ubuntu-bionic
+   ubuntu
 
    $ sudo {command} exec --hostname hal-9000 my_container.sif hostname
    hal-9000


### PR DESCRIPTION
This pulls in sylabs PR
- sylabs/singularity-userdocs# 166

The original PR description was:
> Remove references to Ubuntu 18.04, which goes EOL on 2024-04-30.
> 
> Make edits to MPI def file examples, bumping to newer versions that compile without issue on Ubuntu 22.04 (gfortran 10).